### PR TITLE
Show optional review content

### DIFF
--- a/src/components/review.js
+++ b/src/components/review.js
@@ -14,7 +14,7 @@ class Review extends Component {
 
   render() {
     const { review, user } = this.props
-    const { content, rating, timestamp } = review
+    const { rating, reviewText, timestamp } = review
     const { address, profile } = user
     const claims = profile && profile.claims
     const fullName = (claims && claims.name) || 'Unnamed User'
@@ -43,7 +43,7 @@ class Review extends Component {
             <div className="age text-muted"><Timelapse reactive={false} reference={new Date(createdAt)} /></div>
           </div>
         </div>
-        <p className="content">{content}</p>
+        <p className="content">{reviewText}</p>
       </div>
     )
   }


### PR DESCRIPTION
This should have been included in [the prior reviews PR](https://github.com/OriginProtocol/demo-dapp/pull/177) but I had misunderstood something before and thought that we were neglecting the `reviewText` for the time being. It is now shown below the user summary and score.