### PR TITLE
Temporary hack to fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 # FIXME: remove dependency between origin-faucet and origin-js/contracts/test-alt
 script:
   - cd origin-dapp && npm install && npm test
-  - cd origin-faucet && npm install && cd ../origin-js && npm install && npm test
+  - cd ../origin-faucet && npm install && cd ../origin-js && npm install && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "lts/*"
-env:
-  - TEST_DIR=origin-dapp
-  - TEST_DIR=origin-js
-script: cd $TEST_DIR && npm install && npm test
+# FIXME: remove dependency between origin-faucet and origin-js/contracts/test-alt
+script:
+  - cd origin-dapp && npm install && npm test
+  - cd origin-faucet && npm install && cd ../origin-js && npm install && npm test

--- a/origin-js/contracts/test-alt/MarketplaceLib.js
+++ b/origin-js/contracts/test-alt/MarketplaceLib.js
@@ -3,7 +3,7 @@ import assert from 'assert'
 
 import helper, { contractPath } from './_helper'
 import MarketplaceJson from '../build/contracts/V00_Marketplace'
-import Marketplace from '../../token/lib/marketplace'
+import Marketplace from '../../../origin-faucet/lib/marketplace'
 
 // These tests are for the token library that the token CLI uses. We don't
 // validate the effects of various operations. That is left to the contract

--- a/origin-js/contracts/test-alt/TokenLib.js
+++ b/origin-js/contracts/test-alt/TokenLib.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import helper, { contractPath } from './_helper'
-import Token from '../../token/lib/token'
+import Token from '../../../origin-faucet/lib/token'
 
 // These tests are for the token library that the token CLI uses. We don't
 // validate the effects of various operations. That is left to the contract

--- a/origin-js/package-lock.json
+++ b/origin-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "origin",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is a short-term hack to fix the Travis build. Better (but will take a bit longer) fix is to refactor origin-faucet and origin-js/contracts/test-alt to remove their dependency. Probably by creating a separate token-lib or equivalent package.