### PR TITLE
Fix box install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,15 +75,6 @@ function run_step() {
 function install_origin_environment() {
 	print_origin_start
 
-	run_step "Cloning origin-js" \
-		git clone git@github.com:OriginProtocol/origin-js.git --branch stable || true
-
-	run_step "Cloning origin-bridge" \
-		git clone git@github.com:OriginProtocol/origin-bridge.git --branch stable || true
-
-	run_step "Cloning origin-dapp" \
-		git clone git@github.com:OriginProtocol/origin-dapp.git --branch stable || true
-
 	run_step "Building containers" \
 		docker-compose build
 


### PR DESCRIPTION
We no longer need to clone the repos.

I'll update the README in a separate PR to mention that to get a stable version of origin-box, it is best to run install.sh from the stable branch of the origin repo.