### PR TITLE
[EventListener] Do not exit on errors fetching data

### DIFF
--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -243,12 +243,12 @@ async function withRetrys(fn, exitOnError=true) {
     }
     if (tryCount >= MAX_RETRYS) {
       if (exitOnError) {
-        console.log(`EXITING: Maximum number of retrys reached for ${fn.name}.`)
+        console.log('EXITING: Maximum number of retrys reached')
         // Now it's up to our environment to restart us.
         // Hopefully with a clean start, things will work better
         process.exit(1)
       } else {
-        throw new Error(`Maximum number of retrys reached for ${fn.name}`)
+        throw new Error('Maximum number of retrys reached')
       }
     }
   }
@@ -270,7 +270,7 @@ async function handleLog(log, rule, contractVersion, context) {
     transactionIndex=${log.transactionIndex} \
     eventName=${log.eventName} \
     contractName=${log.contractName}`
-  console.log(`Processing log: $[logDetails}`)
+  console.log(`Processing log: ${logDetails}`)
 
   // Note: we run the rule with a retry since we've seen in production cases where we fail loading
   // from smart contracts the data pointed to by the event. This may occur due to load balancing
@@ -282,7 +282,7 @@ async function handleLog(log, rule, contractVersion, context) {
       ruleResults = await rule.ruleFn(log)
     }, exitOnError = false)
   } catch(e) {
-    console.log(`Skipping indexing for ${logDetails}`)
+    console.log(`Skipping indexing for ${logDetails} - ${e}`)
     return
   }
 

--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -223,8 +223,8 @@ async function runBatch(opts, context) {
   return lastLogBlock
 }
 
-// Retrys up to 10 times, with exponential backoff, then exits the process
-async function withRetrys(fn) {
+// Retrys up to 10 times, with exponential backoff
+async function withRetrys(fn, exitOnError=true) {
   let tryCount = 0
   while (true) {
     try {
@@ -242,10 +242,14 @@ async function withRetrys(fn) {
       await new Promise(resolve => setTimeout(resolve, waitTime))
     }
     if (tryCount >= MAX_RETRYS) {
-      console.log('Exiting. Maximum number of retrys reached.')
-      // Now it's up to our environment to restart us.
-      // Hopefully with a clean start, things will work better
-      process.exit(1)
+      if (exitOnError) {
+        console.log(`EXITING: Maximum number of retrys reached for ${fn.name}.`)
+        // Now it's up to our environment to restart us.
+        // Hopefully with a clean start, things will work better
+        process.exit(1)
+      } else {
+        throw new Error(`Maximum number of retrys reached for ${fn.name}`)
+      }
     }
   }
 }
@@ -262,22 +266,26 @@ async function handleLog(log, rule, contractVersion, context) {
   log.contractVersionKey = contractVersion.versionKey
   log.networkId = context.networkId
 
-  console.log(
-    `Processing log \
+  const logDetails = `Processing log \
     blockNumber=${log.blockNumber} \
     transactionIndex=${log.transactionIndex} \
     eventName=${log.eventName} \
     contractName=${log.contractName}`
-  )
+  console.log(logDetails)
 
   // Note: we run the rule with a retry since we've seen in production cases where we fail loading
   // from smart contracts the data pointed to by the event. This may occur due to load balancing
   // across ethereum nodes and if some nodes are lagging. For example the ethereum node we
   // end up connecting to for reading the data may lag compared to the node received the event from.
   let ruleResults = undefined
-  await withRetrys(async () => {
-    ruleResults = await rule.ruleFn(log)
-  })
+  try {
+    await withRetrys(async () => {
+      ruleResults = await rule.ruleFn(log)
+    }, exitOnError = false)
+  } catch(e) {
+    console.log(`Skipping indexing for ${logDetails}`)
+    return
+  }
 
   const output = {
     log: log,


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [X] Ensure all new and existing tests pass
- [X] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
There are a few early listings that have malformed offer data with missing arbitrator.
Currently the indexer will get stuck on those and not make progress (it will fail, exit, restart over and over).
With this change, after max number of retries is reached, the indexer will log then skip the malformed entry.
