### PR TITLE
🐨 Add top level readme page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 [![origin_license](https://img.shields.io/badge/license-MIT-6e3bea.svg?style=flat-square&colorA=111d28)](https://github.com/OriginProtocol/origin-js/blob/master/LICENSE)
 [![origin_travis_banner](https://img.shields.io/travis/OriginProtocol/origin-js/master.svg?style=flat-square&colorA=111d28)](https://travis-ci.org/OriginProtocol/origin-js)
 
-**Origin is empowering developers to build decentralized marketplaces on the blockchain!**
+Origin is empowering developers to build decentralized marketplaces on the blockchain!
 
 Visit our [Developer's page](https://www.originprotocol.com/developers) to learn more about what we're building and how to get involved.
 

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,23 @@
+![origin_github_banner](https://user-images.githubusercontent.com/673455/37314301-f8db9a90-2618-11e8-8fee-b44f38febf38.png)
+
+![origin_npm_version](https://img.shields.io/npm/v/origin.svg?style=flat-square&colorA=111d28&colorB=1a82ff)
+[![origin_license](https://img.shields.io/badge/license-MIT-6e3bea.svg?style=flat-square&colorA=111d28)](https://github.com/OriginProtocol/origin-js/blob/master/LICENSE)
+[![origin_travis_banner](https://img.shields.io/travis/OriginProtocol/origin-js/master.svg?style=flat-square&colorA=111d28)](https://travis-ci.org/OriginProtocol/origin-js)
+
+**Origin is empowering developers to build decentralized marketplaces on the blockchain!** Head out our [Developer's page](https://www.originprotocol.com/developers) to learn more about what we're building and how to get involved.
+
+You can see the Origin ecosystem in action at https://dapp.originprotocol.com!
+
+
+## Our projects:
+
+* [origin-js](https://github.com/OriginProtocol/origin/tree/master/origin-js) is a library of javascript code and Ethereum smart contracts which allow anyone to create decentralized marketplaces.
+* Our [dapp](https://github.com/OriginProtocol/origin/tree/master/origin-dapp) is a the first marketplace powered by the Origin Protocol. Make the code your own!
+* The [discovery server](https://github.com/OriginProtocol/origin/tree/master/origin-discovery) provides a graphql service for quickly searching origin blockchain data.
+* Our [bridge server](https://github.com/OriginProtocol/origin/tree/master/origin-bridge) provides identity attestations. 
+* Run every part of our infastructure localy for developement and testing with [origin-box](https://github.com/OriginProtocol/origin/tree/master/development) - a set of docker containers.
+* Finaly, we have a [testnet faucet](https://github.com/OriginProtocol/origin/tree/master/origin-faucet) and a distributed [messaging hub](https://github.com/OriginProtocol/origin/tree/master/origin-messaging).
+
+
+## Documentation
+[origin-js documentation](http://docs.originprotocol.com/)

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,14 @@
 [![origin_license](https://img.shields.io/badge/license-MIT-6e3bea.svg?style=flat-square&colorA=111d28)](https://github.com/OriginProtocol/origin-js/blob/master/LICENSE)
 [![origin_travis_banner](https://img.shields.io/travis/OriginProtocol/origin-js/master.svg?style=flat-square&colorA=111d28)](https://travis-ci.org/OriginProtocol/origin-js)
 
-**Origin is empowering developers to build decentralized marketplaces on the blockchain!** Head out our [Developer's page](https://www.originprotocol.com/developers) to learn more about what we're building and how to get involved.
+**Origin is empowering developers to build decentralized marketplaces on the blockchain!**
 
-You can see the Origin ecosystem in action at https://dapp.originprotocol.com!
+Visit our [Developer's page](https://www.originprotocol.com/developers) to learn more about what we're building and how to get involved.
+
+You can see the Origin ecosystem in action at https://dapp.originprotocol.com.
 
 
-## Our projects:
+## Our Projects:
 
 * [origin-js](https://github.com/OriginProtocol/origin/tree/master/origin-js) is a library of javascript code and Ethereum smart contracts which allow anyone to create decentralized marketplaces.
 * Our [dapp](https://github.com/OriginProtocol/origin/tree/master/origin-dapp) is a the first marketplace powered by the Origin Protocol. Make the code your own!


### PR DESCRIPTION
We didn't have a top level readme for the new monorepo. Here's a start.