### PR TITLE
Add redirects to nginx ingress and configuration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ node_modules/
 # Python
 /origin-bridge/*.pyc
 /origin-bridge/ve
+/origin-bridge/**/__pycache__
 
 # pytest
 /origin-bridge/.pytest_cache
@@ -102,6 +103,10 @@ node_modules/
 /origin-js/libpeerconnection.log
 /origin-js/testem.log
 /origin-js/typings
+#
+# origin-js #
+#############
+/origin-website
 
 # Recommended rules per https://gist.github.com/octocat/9257657 #
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv #

--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"

--- a/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
@@ -10,10 +10,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
-    nginx.ingress.kubernetes.io/permanent-redirect: dapp.originprotocol.com
+    # Disable SSL redirect to prevent double redirect
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://dapp.originprotocol.com"
 spec:
   tls:
     - secretName: demo.originprotocol.com

--- a/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
@@ -1,7 +1,9 @@
+{{- if eq .Release.Namespace "staging" }}
+# Permanent redirect for demo.originprotocol.com
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "dapp.fullname" . }}
+  name: demo-originprotocol-redirect
   labels:
     app: {{ template "dapp.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -11,17 +13,17 @@ metadata:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: {{ template "dapp.host" . }}
 spec:
   tls:
-    - secretName: {{ template "dapp.host" . }}
+    - secretName: demo.originprotocol.com
       hosts:
-        - {{ template "dapp.host" . }}
+        - demo.originprotocol.com
   rules:
-  - host: {{ template "dapp.host" . }}
+  - host: demo.originprotocol.com
     http:
       paths:
-        - path: /
-          backend:
-            serviceName: {{ template "dapp.fullname" . }}
-            servicePort: 80
+      - backend:
+          serviceName: {{ template "dapp.fullname" . }}
+          servicePort: 80
+{{- end }}

--- a/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     # Disable SSL redirect to prevent double redirect

--- a/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp-redirect.ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
-    nginx.ingress.kubernetes.io/permanent-redirect: {{ template "dapp.host" . }}
+    nginx.ingress.kubernetes.io/permanent-redirect: dapp.originprotocol.com
 spec:
   tls:
     - secretName: demo.originprotocol.com

--- a/deployment/kubernetes/charts/origin/templates/dapp.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp.ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"

--- a/deployment/kubernetes/charts/origin/templates/dapp.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp.ingress.yaml
@@ -17,21 +17,40 @@ spec:
     - secretName: {{ template "dapp.host" . }}
       hosts:
         - {{ template "dapp.host" . }}
-    # Additional URL for staging environment
-    {{- if eq .Release.Namespace "staging" }}
-    - secretName: demo.originprotocol.com
-      hosts:
-        - demo.originprotocol.com
-    {{- end }}
   rules:
   - host: {{ template "dapp.host" . }}
-    http: &http_rules
+    http:
       paths:
         - path: /
           backend:
             serviceName: {{ template "dapp.fullname" . }}
             servicePort: 80
-  {{- if eq .Release.Namespace "staging" }}
+{{- if eq .Release.Namespace "prod" }}
+# Permanent redirect for demo.originprotocol.com
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: demo-originprotocol-redirect
+  labels:
+    app: {{ template "dapp.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
+    nginx.ingress.kubernetes.io/permanent-redirect: {{ template "dapp.host" . }}
+spec:
+  tls:
+    - secretName: demo.originprotocol.com
+      hosts:
+        - demo.originprotocol.com
+  rules:
   - host: demo.originprotocol.com
-    http: *http_rules
-  {{- end  }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "dapp.fullname" . }}
+          servicePort: 80
+{{- end }}

--- a/deployment/kubernetes/charts/origin/templates/discovery.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/discovery.ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"

--- a/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"

--- a/deployment/kubernetes/charts/origin/templates/ipfs.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/ipfs.ingress.yaml
@@ -21,9 +21,15 @@ spec:
     - secretName: {{ template "ipfs.host" . }}
       hosts:
         - {{ template "ipfs.host" . }}
+    {{- if eq .Release.Namespace "prod" }}
+    # Additional domain that was originally used for the IPFS gateway
+    - secretName: gateway.originprotocol.com
+      hosts:
+        - gateway.originprotocol.com
+    {{- end }}
   rules:
     - host: {{ template "ipfs.host" . }}
-      http:
+      http: &http_rules
         paths:
           # Only allow the add API call through to the IPFS API
           - path: /api/v0/add
@@ -35,3 +41,7 @@ spec:
             backend:
               serviceName: {{ template "ipfs.fullname" . }}
               servicePort: 8080
+    {{- if eq .Release.Namespace "prod" }}
+    - host: gateway.originprotocol.com
+      http: *http_rules
+    {{- end }}

--- a/deployment/kubernetes/charts/origin/templates/messaging.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/messaging.ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"

--- a/deployment/kubernetes/configure-cluster.sh
+++ b/deployment/kubernetes/configure-cluster.sh
@@ -41,21 +41,37 @@ helm install stable/nginx-ingress --name dev-ingress \
 	--namespace dev \
 	--set rbac.create=true \
 	--set controller.service.loadBalancerIP="35.233.140.121" \
-	--set-string controller.extraArgs.enable-ssl-chain-completion=false
+	--set controller.ingressClass=dev-ingress \
+	--set controller.stats.enabled=true \
+	--set controller.metrics.enabled=true \
+	--set-string controller.extraArgs.enable-ssl-chain-completion=false \
+	--set-string controller.extraArgs.enable-dynamic-configuration=true \
+	--set-string controller.extraArgs.watch-namespace=dev \
+	--set-string controller.extraArgs.force-namespace-isolation=true
 
 # Install nginx ingress for staging
 helm install stable/nginx-ingress --name staging-ingress \
 	--namespace staging \
 	--set rbac.create=true \
 	--set controller.service.loadBalancerIP="35.197.88.39" \
+	--set controller.ingressClass=staging-ingress \
+	--set controller.stats.enabled=true \
+	--set controller.metrics.enabled=true \
 	--set-string controller.extraArgs.enable-ssl-chain-completion=false
+	--set-string controller.extraArgs.watch-namespace=staging \
+	--set-string controller.extraArgs.force-namespace-isolation=true
 
 # Install nginx ingress for production
 helm install stable/nginx-ingress --name prod-ingress \
 	--namespace prod \
 	--set rbac.create=true \
 	--set controller.service.loadBalancerIP="35.203.166.86" \
+	--set controller.ingressClass=prod-ingress \
+	--set controller.stats.enabled=true \
+	--set controller.metrics.enabled=true \
 	--set-string controller.extraArgs.enable-ssl-chain-completion=false
+	--set-string controller.extraArgs.watch-namespace=prod \
+	--set-string controller.extraArgs.force-namespace-isolation=true
 
 kubectl create -f misc/letsencrypt-staging.yaml
 kubectl create -f misc/letsencrypt-prod.yaml

--- a/deployment/kubernetes/values/values-dev.yaml
+++ b/deployment/kubernetes/values/values-dev.yaml
@@ -20,10 +20,10 @@ ipfsImageTag: ipfs/go-ipfs
 ipfsImageTag: master
 
 faucetImage: origin-faucet
-faucetImageTag: '3066fa3'
+faucetImageTag: '389fd1f'
 
 eventlistenerImage: event-listener
-eventlistenerImageTag: 'db88884'
+eventlistenerImageTag: '389fd1f'
 eventlistenerWeb3Url: https://eth.dev.originprotocol.com/rpc
 
 discoveryImage: origin-discovery


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:

- Adds permanent redirect for `demo.originprotocol.com` to `dapp.originprotocol.com`
- Adds `gateway.originprotocol.com` as a valid host for IPFS servers
- Snuck in a few fixes for `.gitignore`
- Added better isolation for the nginx ingress by using separate classes for `dev`, `staging` and `prod`
- Added flags to solve to solve #743 
- Added flags to enable Prometheus metrics on ingress
- Updated some containers for dev

@franckc the deployment is currently running this so please merge before doing any new deploys or it'll be undone. Merci!
