### PR TITLE
Search Results Pagination

### DIFF
--- a/origin-dapp/src/components/listings-grid.js
+++ b/origin-dapp/src/components/listings-grid.js
@@ -30,7 +30,7 @@ class ListingsGrid extends Component {
 
   render() {
     const { contractFound, listingIds, search, featuredListingIds, hiddenListingIds } = this.props
-    let activePage, currentPageListingIds, includedFeaturedListingIds, listingIdsNotHidden
+    let activePage, currentPageListingIds, includedFeaturedListingIds, listingIdsNotHidden, resultsCount
 
     if (this.props.renderMode === 'home-page') {
       listingIdsNotHidden = listingIds.filter(id => !hiddenListingIds.includes(id))
@@ -54,6 +54,7 @@ class ListingsGrid extends Component {
         Math.max(0, startSlicePosition + LISTINGS_PER_PAGE - includedFeaturedListingIds.length)
       )
       currentPageListingIds = [...includedFeaturedListingIds, ...currentPageListingIds]
+      resultsCount = listingIdsNotHidden.length
     } else if (this.props.renderMode === 'search') {
       listingIdsNotHidden = search.listingIds.filter(id => !hiddenListingIds.includes(id))
       currentPageListingIds = listingIdsNotHidden.sort((a, b) => {
@@ -71,9 +72,8 @@ class ListingsGrid extends Component {
         }
       })
       activePage = this.props.searchPage
+      resultsCount = search.listingsLength - hiddenListingIds.length
     }
-
-    const resultsCount = listingIdsNotHidden.length
 
     return (
       <div className="listings-wrapper">


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [ ] ~Format code to be consistent with the project~
- [ ] ~Wrap any new text/strings for translation~
- [ ] ~Map any new environment variables with a default value in the Webpack config~
- [ ] ~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~

### Description:

I misunderstood how the search-related pagination was working, so this branch now allows it to find the additional pages.

With efd0f95, there are still blank spots on the pages prior to the final one. I suspect this is because the discovery server is unaware of the hidelist. I also get a count (58) higher than the non-search results count (56), and an even lower number of actual search results (58, I think). @sparrowDom I'll defer to you on this until I get a chance to dig deeper.

Resolves #742 😐 