### PR TITLE
[DApp] Set INSTRUCTIONS_URL to point to Mainnet blog post

### DIFF
--- a/deployment/dockerfiles/dev/origin-dapp
+++ b/deployment/dockerfiles/dev/origin-dapp
@@ -37,7 +37,8 @@ ENV BRIDGE_SERVER_DOMAIN=bridge.dev.originprotocol.com \
     PROVIDER_URL=https://rinkeby.infura.io/emIXjs9eDuy57IlTYsIP \
     MESSAGING_NAMESPACE=origin:dev \
     DEPLOY_TAG=$DEPLOY_TAG \
-    BLOCK_EPOCH=0
+    BLOCK_EPOCH=0 \
+    INSTRUCTIONS_URL=https://medium.com/originprotocol/draft-origin-launches-beta-on-mainnet-draft-e3b70161ae86
 
 WORKDIR /app/
 RUN npm install --quiet --no-progress

--- a/deployment/dockerfiles/prod/origin-dapp
+++ b/deployment/dockerfiles/prod/origin-dapp
@@ -21,7 +21,8 @@ ENV BRIDGE_SERVER_DOMAIN=bridge.originprotocol.com \
     PROVIDER_URL=https://mainnet.infura.io/emIXjs9eDuy57IlTYsIP \
     MESSAGING_NAMESPACE=origin \
     DEPLOY_TAG=$DEPLOY_TAG \
-    BLOCK_EPOCH=6400000
+    BLOCK_EPOCH=6400000 \
+    INSTRUCTIONS_URL=https://medium.com/originprotocol/draft-origin-launches-beta-on-mainnet-draft-e3b70161ae86
 
 WORKDIR /app/origin-dapp
 RUN npm install --quiet --no-progress

--- a/deployment/dockerfiles/staging/origin-dapp
+++ b/deployment/dockerfiles/staging/origin-dapp
@@ -37,7 +37,8 @@ ENV BRIDGE_SERVER_DOMAIN=bridge.staging.originprotocol.com \
     PROVIDER_URL=https://rinkeby.infura.io/emIXjs9eDuy57IlTYsIP \
     MESSAGING_NAMESPACE=origin:staging \
     DEPLOY_TAG=$DEPLOY_TAG \
-    BLOCK_EPOCH=3050000
+    BLOCK_EPOCH=3050000 \
+    INSTRUCTIONS_URL=https://medium.com/originprotocol/draft-origin-launches-beta-on-mainnet-draft-e3b70161ae86
 
 WORKDIR /app
 RUN npm install --quiet --no-progress


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [X] Ensure all new and existing tests pass
- [X] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [X] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
Set INSTRUCTIONS_URL to point to Mainnet blog post.
