### PR TITLE
🎧 Listener - wait N confirmations before processing events.

### DIFF
--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -152,7 +152,12 @@ async function liveTracking(config) {
         return scheduleNextCheck()
       }
       console.log('New block: ' + currentBlockNumber)
-      const toBlock = Math.min(lastLogBlock+MAX_BATCH_BLOCKS, currentBlockNumber)
+      const toBlock = Math.min( // Pick the smallest of either
+        // the last log we processed, plus the max batch size
+        lastLogBlock + MAX_BATCH_BLOCKS, 
+         // or the current block number, minus any trailing blocks we waiting on
+        Math.max(currentBlockNumber - config.trailBlocks, 0),
+      )
       const opts = { fromBlock: lastLogBlock + 1, toBlock: toBlock }
       await runBatch(opts, context)
       lastLogBlock = toBlock
@@ -542,6 +547,8 @@ const config = {
   verbose: args['--verbose'],
   // File to use for picking which block number to restart from
   continueFile: args['--continue-file'],
+  // Trail X number of blocks behind
+  trailBlocks: args['--trail-behind-blocks'] || 0,
   // web3 provider url
   web3Url: args['--web3-url'] || 'http://localhost:8545',
   // ipfs url


### PR DESCRIPTION
Adds a `—trail-behind-blocks=N` parameter that forces the listener to stay N blocks behind the current block. Allows you to wait for more confirmations before processing.

Closes https://github.com/OriginProtocol/origin-js/issues/407

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
