### PR TITLE
Stan/surplus l10n

### DIFF
--- a/origin-dapp/src/components/form-widgets/price-field.js
+++ b/origin-dapp/src/components/form-widgets/price-field.js
@@ -93,6 +93,7 @@ class PriceField extends Component {
                 )
               }}
             />
+            &nbsp;
             <span className="text-bold">
               <FormattedMessage
                 id={'price-field.price-usd-disclaimer'}

--- a/origin-dapp/src/components/listing-card-prices.js
+++ b/origin-dapp/src/components/listing-card-prices.js
@@ -56,11 +56,8 @@ class ListingCardPrices extends Component {
                     {`${Number(this.state.price).toLocaleString(undefined, {
                       minimumFractionDigits: 5,
                       maximumFractionDigits: 5
-                    })}`}&nbsp;
-                    <FormattedMessage
-                      id={'listing-card-prices.ethereumCurrencyAbbrev'}
-                      defaultMessage={'ETH'}
-                    />
+                    })}`}
+                      &nbsp;ETH
                   </div>
                   <div className="fiat">
                     {fiatPrice === null && 'Loading'}

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -474,11 +474,7 @@ class ListingsDetail extends Component {
                       maximumFractionDigits: 5,
                       minimumFractionDigits: 5
                     })}
-                      &nbsp;
-                    <FormattedMessage
-                      id={'listing-detail.ethereumCurrencyAbbrev'}
-                      defaultMessage={'ETH'}
-                    />
+                      &nbsp;ETH
                   </div>
                   {/* Via Matt 4/5/2018: Hold off on allowing buyers to select quantity > 1 */}
                   {/*

--- a/origin-dapp/src/components/my-listing-card.js
+++ b/origin-dapp/src/components/my-listing-card.js
@@ -20,10 +20,6 @@ class MyListingCard extends Component {
         id: 'my-listing-card.confirmCloseListing',
         defaultMessage:
           'Are you sure that you want to permanently close this listing? This cannot be undone.'
-      },
-      ETH: {
-        id: 'my-listing-card.ethereumCurrencyAbbrev',
-        defaultMessage: 'ETH'
       }
     })
 

--- a/origin-dapp/src/components/my-listings.js
+++ b/origin-dapp/src/components/my-listings.js
@@ -143,10 +143,7 @@ class MyListings extends Component {
                   <div className="col-12 col-sm-4 col-lg-2 offset-lg-3 text-center">
                     <div className="numberCircle">
                       <h1 className="circle-text">
-                        <FormattedMessage
-                          id={'my-listings.number-one'}
-                          defaultMessage={'1'}
-                        />
+                        1
                       </h1>
                     </div>
                     <p>
@@ -161,10 +158,7 @@ class MyListings extends Component {
                   <div className="col-12 col-sm-4 col-lg-2 text-center">
                     <div className="numberCircle">
                       <h1 className="circle-text">
-                        <FormattedMessage
-                          id={'my-listings.number-two'}
-                          defaultMessage={'2'}
-                        />
+                        2
                       </h1>
                     </div>
                     <p>
@@ -179,10 +173,7 @@ class MyListings extends Component {
                   <div className="col-12 col-sm-4 col-lg-2 text-center">
                     <div className="numberCircle">
                       <h1 className="circle-text">
-                        <FormattedMessage
-                          id={'my-listings.number-three'}
-                          defaultMessage={'3'}
-                        />
+                        3
                       </h1>
                     </div>
                     <p>

--- a/origin-dapp/src/components/my-purchase-card.js
+++ b/origin-dapp/src/components/my-purchase-card.js
@@ -71,9 +71,7 @@ class MyPurchaseCard extends Component {
                     <p className="price">{`${Number(price).toLocaleString(
                       undefined,
                       { minimumFractionDigits: 5, maximumFractionDigits: 5 }
-                    )} ${this.props.intl.formatMessage(
-                      this.intlMessages.ETH
-                    )}`}</p>
+                    )} ETH`}</p>
                     {/* Not Yet Relevant */}
                     {/* <p className="quantity">Quantity: {quantity.toLocaleString()}</p> */}
                   </div>

--- a/origin-dapp/src/components/my-sale-card.js
+++ b/origin-dapp/src/components/my-sale-card.js
@@ -22,12 +22,6 @@ class MySaleCard extends Component {
 
     this.setSoldAtTime = this.setSoldAtTime.bind(this)
 
-    this.intlMessages = defineMessages({
-      ETH: {
-        id: 'my-sale-card.ethereumCurrencyAbbrev',
-        defaultMessage: 'ETH'
-      }
-    })
   }
 
   componentWillMount() {


### PR DESCRIPTION
Remove `ETH` from being translated. It's always just ETH. 
Remove numbers '1', '2', '3' from being translated. 

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Ensure all new and existing tests pass _(`npm test` not working)_
- [ ] Format code to be consistent with the project _(`npm run format` not working)_

