### PR TITLE
[EventListener] Wait 1 block confirmation before processing events

### DIFF
--- a/deployment/kubernetes/charts/origin/scripts/start-event-listener.sh
+++ b/deployment/kubernetes/charts/origin/scripts/start-event-listener.sh
@@ -12,4 +12,4 @@ echo "Starting event listener"
 echo "{ \"lastLogBlock\": ${CONTINUE_BLOCK} }" > ./continue.json
 
 # Start event listener
-node listener/listener.js --elasticsearch --db --web3-url=${WEB3_URL} --ipfs-url=${IPFS_URL} --continue-file=./continue.json
+node listener/listener.js --elasticsearch --db --web3-url=${WEB3_URL} --ipfs-url=${IPFS_URL} --continue-file=./continue.json --trail-behind-blocks=1


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [X] Ensure all new and existing tests pass
- [ ] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
Wait 1 block confirmation before processing events. This should help with the out-of-sync node Infura issue we've seen (though currently it is mitigated by retries).
