### PR TITLE
[Attestation] Update staging attestation signing key

### DIFF
--- a/deployment/kubernetes/values/secrets-staging.enc.yaml
+++ b/deployment/kubernetes/values/secrets-staging.enc.yaml
@@ -1,21 +1,22 @@
-bridgeEnvKey: ENC[AES256_GCM,data:3+2ERRxx/cbc+NE26fbh+44UoD6y5MBZ0bVnQrhlozIzIxtTRQ==,iv:YJzOeIyBpjnObCraQhPqVUFS/VUHbxN58RX2dfTwSOw=,tag:xpEo4QYXexmGb00v+BWCvQ==,type:str]
-#ENC[AES256_GCM,data:/isi/JWSPDmqb4ZE6EmwsxXo1P6h/sf3eFNigYKYmugpvfyQMBMjM6ois8kTQqNd1mcjZjUYfQrj,iv:3QDPpgG3PywmW7blZX4ztVI9D4CDeOfrnAFBN/tzcuo=,tag:LJ/aqQMPKpxyZKm+Gujgzw==,type:comment]
-ethstatsWebsocketSecret: ENC[AES256_GCM,data:hX0n9epVnN+ts9qx6CaJsA==,iv:vl1ph6LEbr98KEgJw737UpJIvxqa6twCmszC+E69paE=,tag:DyEV1OMSVc/F645SnK4t9w==,type:str]
-#ENC[AES256_GCM,data:/WZvrKD3OK7eifPTmhQ83JKVYfpunQoicEmdCA==,iv:8gIedxLC8BuqMu+c8OWPvxctXYGtkpxrdKkemjzNIf8=,tag:d//D722mM8eOpgvHwPCP0w==,type:comment]
-faucetMnemonic: ENC[AES256_GCM,data:X4aDLPLUNGHG+zKuxms3rvET4ySVzD8wkfWsRbPC8fsx5cS06MtRHV6iXJSIV9luNH54fFdrmkSQZFoA4i7Oy4lSXL3Rq2ULllnk9Q==,iv:zhnVcmvcdHt2mRwF6Xv4mqXN5NqgnB1dwubf+jFEH2E=,tag:FQEQ0yTnujBhaNpTRGHz5w==,type:str]
-#ENC[AES256_GCM,data:fLAlcGJpkrLmeumALacf4lekgJESL95GRC1hiWODtuME,iv:60YaVHC0YGe1f7oryyE3+ySatpDE83potZuUtHKwLIg=,tag:DFR37u2R+EK6KlynlvFb6A==,type:comment]
-databaseUsername: ENC[AES256_GCM,data:j09ehw23,iv:/zsi8Nlrc4dEOvOnqbwKVetRex/HQoIt0RYhT74TwJk=,tag:2/vzJJ+CyEaEsef7Ygrsjw==,type:str]
-databasePassword: ENC[AES256_GCM,data:x2y5GHFUeqJfCRfs4Gdcew==,iv:mhrQporXX+E3k3QjKm1DnJJtlPDsA4KaqCkT4IW0XiY=,tag:e+AYGw6lE+7mbu/Yf4EVGQ==,type:str]
-#ENC[AES256_GCM,data:mO3uMF8iLHTIEgKEc2sIXLT3ltjLbaBbGl6/8f/tug==,iv:rSNMY0CyCwwNg/YxqKh84dtuAAi9AbGdoDe58Qy8I9A=,tag:GUSOL/FRyvDsYXX8DYaV/g==,type:comment]
-infuraAccessToken: ENC[AES256_GCM,data:ulWq+Xd+VtAgiM8DbtDHPMiQLso=,iv:DwDr1NF4MQE3fsHJZpqXQfPaWz3Y/vMQoMuXxXVv2XU=,tag:7v0243z+Y6I6uTkOhq4DNw==,type:str]
+bridgeEnvKey: ENC[AES256_GCM,data:GCGBzZKbAYo6Hzm3+n53z0gsL+scqTEw5nFbj/8cK/SplefjMg==,iv:c0fWu2ch5nKpPz3i0oCXNEzN0h4CueUuourSJ6Z1e7k=,tag:W6nxD6frROc4kOsEJEyfCw==,type:str]
+#ENC[AES256_GCM,data:yDtgDiCcJRzu+qV3f0qnV8/wjOMceVf2hfFakPqEbT5G+mR1eZAUqdtn59hk+FAhFSr2sh4c1Y9q,iv:VYTcLDAMreo4JPjgRhNeNyZ6jVTJQVa/5JDXX0+LL6Y=,tag:MchzDW36uftLh8/HwseBfg==,type:comment]
+ethstatsWebsocketSecret: ENC[AES256_GCM,data:uhXMX44PVoe3ASntXFsN7w==,iv:q+UGV/YepgqRcH7csIhbPNgIahaZtBZl4cbGl3/S/Zw=,tag:zppLDtNE1jMo3Ki3g8CS2g==,type:str]
+#ENC[AES256_GCM,data:Y6KnqQipQPp1ObhYwrNHzUnRVsdUljxVVlQ5Lg==,iv:4zfgvGwvdxhUxlWrp+qonwy2J3/JATk49V2Al6An3O4=,tag:4Rpw2mS1u23BGVID8Dp50w==,type:comment]
+faucetMnemonic: ENC[AES256_GCM,data:p+qsH0jgAKYS+d1xJZlcAmjS+E6Mufgy7ElFVac4C6c6k5ukWXES9KRyiyE4tW7SZFV6wrsvYYx3dyePtNeBdtvaeUVSbDV397qIlA==,iv:ayvoanPIwi0XCE3cD3sOmzeyTnfiCOWhZJXUtJvJEpE=,tag:m/eubN81R4+gDZt047TDUA==,type:str]
+#ENC[AES256_GCM,data:xdgI8BE/UIV18Hy9L0y7gVvxu0R9IBa3wjZkX4ufnpn4,iv:iJ63ScvXMCgvWCFvdbgLEQ/KWD8wTvyJfE5qbAl7wqk=,tag:YxFjrQp3qpwh81oFrIHinw==,type:comment]
+databaseUsername: ENC[AES256_GCM,data:JvJbAHwS,iv:XjQNHRxKADxM0gzpHKiH5bwcdwxFGZ9e7TQqM712rzY=,tag:f+7zy7CP/anThHc7mq+96g==,type:str]
+databasePassword: ENC[AES256_GCM,data:FrjulFmgKIzXNvdvFY6N9w==,iv:wd/A2CLv0OD0Ff3J8mH+eUXm1svB2MpvMLS77kurlig=,tag:IJuCTIpomgsTng1K3PQZpQ==,type:str]
+#ENC[AES256_GCM,data:gR2dgKGS7qPtOLUMlkrP9g5Cp4GAQIq7g4aLmMwHRg==,iv:f+GcRzK3x/i1I4yFeuNZUmlde7KLh9U9qn5SiFVUHas=,tag:/3vDQF4m5aTKyYHN1meUpA==,type:comment]
+infuraAccessToken: ENC[AES256_GCM,data:4UlrgV5HZcCryafGeBJYmbOytPg=,iv:0dEfonb98hBA0RHxDBlF9W9fgWBCTi6xUJ6L07g+UdU=,tag:abQm8hf8JihpW/9HEycp/Q==,type:str]
 sops:
     kms: []
     gcp_kms:
     -   resource_id: projects/origin-214503/locations/global/keyRings/sops/cryptoKeys/sops-key
-        created_at: '2018-09-28T23:47:26Z'
-        enc: CiQAJ0Lg+5VJM+B8ZryGjPyu4Sl4rxYyNO+SqOiyzrZ57lROs0cSSAA4BiSnN3ELD/kxTg8FDzvWX1x7wFdwBZETJ1NCnSSLL45F6nRGzE1CwrUMmzf0clJoC4IKS11U3x9m5UCOb648o5AX80Nq8A==
-    lastmodified: '2018-09-28T23:47:28Z'
-    mac: ENC[AES256_GCM,data:nRAnnqn/l3XB2PvPjc/fFal1v8x0BcFK9kCD9CV+cNFlf0hlFbg7A++v4VjAzrqtEMfiDJu7r1Hpd17inVhOCEyU97XYeWqyaZXnyFl/ua4h+0/zdhZl4a8Ei/l1E6M8Bg1MovsX7Wf3J94l0M+y5jlwjpqXW3384p3l6/RgFyg=,iv:01WEyDBa0W5Z9V0YORlskEkAwcKujkY0uSyDeUMtsb0=,tag:KHAQf9Zd5jJmQ7LoNHt6Fg==,type:str]
+        created_at: '2018-10-16T19:11:57Z'
+        enc: CiQAJ0Lg+5Ds9TPuv0m6kzVWb1s+9FExegHOlcw5n9bSyw6RjXASSAA4BiSnPqx35sZFEJKqvxSXC1u8SDgPeEZohphhSFfLb8YIUMuNrLcml5GDXI4i8Uspr80KvjhG4wKJr4kdGtfiV6B9kRFrtA==
+    azure_kv: []
+    lastmodified: '2018-10-16T19:11:58Z'
+    mac: ENC[AES256_GCM,data:+4U51rpX/IyIQ4f7aRI5sxaR9d2kJnEEpNXIRGf/KF3FvpE0kJ+8KP5vHexdXPlRAfpz5jBX9GyEqXhseS0GmxGt4I23D52SZgzw5tl7QelGZjLCUtMP0zszvTuzS0L8sQIO5tYa5s2M/a9FTxEmdNYVCSBVEw6pDfh58vgo8f4=,iv:0Mr00yuOscTwvGANzGouZ3QjzzH1zVL0AwF7/pdHnfI=,tag:JdBeShqnvqfmLbzTX5IHKg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.0.5
+    version: 3.1.0

--- a/origin-js/contracts/migrations/12_add_staging_issuer.js
+++ b/origin-js/contracts/migrations/12_add_staging_issuer.js
@@ -1,0 +1,37 @@
+// Migration to add an attestation key specific to staging
+// (vs using same signing key as prod which was the behavior prior to this change).
+var OriginIdentity = artifacts.require("./OriginIdentity.sol");
+var Web3 = require("web3")
+
+const ISSUER_STAGING = "0x5be37555816d258f5e316e0f84D59335DB2400B2"
+const keyPurpose = 3
+const keyType = 1
+
+module.exports = function(deployer, network) {
+  return deployer.then(() => {
+    return add_sample_issuer(network)
+  })
+}
+
+async function add_sample_issuer(network) {
+  let accounts = await new Promise((resolve, reject) => {
+    web3.eth.getAccounts((error, result) => {
+      if (error) {
+        reject(err)
+      }
+      resolve(result)
+    })
+  })
+
+  let defaultAccount = accounts[0]
+  let originIdentity = await OriginIdentity.deployed()
+
+  if (network === "rinkeby") {
+    await originIdentity.addKey(
+      Web3.utils.soliditySha3(ISSUER_STAGING),
+      keyPurpose,
+      keyType,
+      { from: defaultAccount, gas: 4000000 }
+    )
+  }
+}

--- a/origin-js/contracts/migrations/12_add_staging_issuer.js
+++ b/origin-js/contracts/migrations/12_add_staging_issuer.js
@@ -1,9 +1,9 @@
-// Migration to add an attestation key specific to staging
+// Migration to add an attestation key specific to staging on Rinkeby
 // (vs using same signing key as prod which was the behavior prior to this change).
-var OriginIdentity = artifacts.require("./OriginIdentity.sol");
-var Web3 = require("web3")
+var OriginIdentity = artifacts.require('./OriginIdentity.sol');
+var Web3 = require('web3')
 
-const ISSUER_STAGING = "0x5be37555816d258f5e316e0f84D59335DB2400B2"
+const ISSUER_STAGING = '0x5be37555816d258f5e316e0f84D59335DB2400B2'
 const keyPurpose = 3
 const keyType = 1
 
@@ -26,7 +26,7 @@ async function add_sample_issuer(network) {
   let defaultAccount = accounts[0]
   let originIdentity = await OriginIdentity.deployed()
 
-  if (network === "rinkeby") {
+  if (network === 'rinkeby') {
     await originIdentity.addKey(
       Web3.utils.soliditySha3(ISSUER_STAGING),
       keyPurpose,


### PR DESCRIPTION

First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [X] Ensure all new and existing tests pass
- [ ] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
Currently, the origin bridge server is using the same attestation signing key as prod because it is using the same ENVKEY variables.

For more context, see discussion in [this issue](https://github.com/OriginProtocol/origin-js/issues/591).

I generated a new signing private key for staging and set it as value in the ENVKEY for bridge server on staging.
This PR makes the necessary changes to start using it:
 - Adds a migration script to run on Rinkeby for adding the new key
 - Update the bridge server staging configuration to use the proper ENVKEY (so far it was using prod )
 



