### PR TITLE
URL Parsing Fix

### DIFF
--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -406,7 +406,7 @@ async function handleLog(log, rule, contractVersion, context) {
 async function postToWebhook(urlString, json) {
   const url = urllib.parse(urlString)
   const postOptions = {
-    host: url.host,
+    host: url.hostname,
     port: url.port,
     path: url.path,
     method: 'POST',


### PR DESCRIPTION
The parsed `url.host` includes the port, which will then be redundant when constructing a new `request` if also included from `url.port` causing an `ENOTFOUND`. This prevents such a case.