### PR TITLE
Update deployment eth node hostnames

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/_helpers.tpl
+++ b/deployment/kubernetes/charts/origin/templates/_helpers.tpl
@@ -45,6 +45,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{- printf "%s-%s" .Release.Name "ethereum" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "ethereum.host" -}}
+{{- if ne .Release.Namespace "prod" -}}
+{{- printf "eth.%s.originprotocol.com" .Release.Namespace -}}
+{{- else -}}
+{{- printf "eth.originprotocol.com" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "faucet.fullname" -}}
 {{- printf "%s-%s" .Release.Name "faucet" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deployment/kubernetes/charts/origin/templates/eth.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/eth.ingress.yaml
@@ -14,11 +14,11 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   tls:
-    - secretName: eth.{{ .Release.Namespace }}.originprotocol.com
+    - secretName: {{ template "ethereum.host" . }}
       hosts:
-        - eth.{{ .Release.Namespace }}.originprotocol.com
+        - {{ template "ethereum.host" . }}
   rules:
-  - host: eth.{{ .Release.Namespace }}.originprotocol.com
+  - host: {{ template "ethereum.host" . }}
     http:
       paths:
       - path: /


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
- ~~[ ] Wrap any new text/strings for translation~~
- ~~[ ] Map any new environment variables with a default value in the Webpack config~~
- ~~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~

### Description:

- Moves the host for our mainnet Ethereum node from `eth.prod.originprotocol.com` to `eth.originprotocol.com`.