### PR TITLE
[EventListener] Fix call to Origin constructor

### DIFF
--- a/deployment/dockerfiles/dev/event-listener
+++ b/deployment/dockerfiles/dev/event-listener
@@ -29,4 +29,8 @@ RUN npm install --quiet --no-progress
 COPY --from=origin-js-build /app/origin-js/ /usr/local/lib/node_modules/origin
 RUN npm link origin
 
+ENV ARBITRATOR_ACCOUNT=0xc9c1a92ba54c61045ebf566b154dfd6afedea992 \
+    AFFILIATE_ACCOUNT=0xc1a33cda27c68e47e370ff31cdad7d6522ea93d5 \
+    BLOCK_EPOCH=0
+
 CMD ["node", "listener/listener.js", "--elasticsearch", "--db"]

--- a/deployment/dockerfiles/prod/event-listener
+++ b/deployment/dockerfiles/prod/event-listener
@@ -12,4 +12,8 @@ WORKDIR /app/origin-discovery
 
 RUN npm install --quiet --no-progress
 
+ENV AFFILIATE_ACCOUNT=0x7aD0fa0E2380a5e0208B25AC69216Bd7Ff206bF8 \
+    ARBITRATOR_ACCOUNT=0x64967e8cb62b0cd1bbed27bee4f0a6a2e454f06a \
+    BLOCK_EPOCH=6400000
+
 CMD ["node", "listener/listener.js", "--elasticsearch", "--db"]

--- a/deployment/dockerfiles/staging/event-listener
+++ b/deployment/dockerfiles/staging/event-listener
@@ -28,4 +28,8 @@ RUN npm install --quiet --no-progress
 COPY --from=origin-js-build /app/origin-js/ /usr/local/lib/node_modules/origin
 RUN npm link origin
 
+ENV ARBITRATOR_ACCOUNT=0xc9c1a92ba54c61045ebf566b154dfd6afedea992 \
+    AFFILIATE_ACCOUNT=0xc1a33cda27c68e47e370ff31cdad7d6522ea93d5 \
+    BLOCK_EPOCH=3050000
+
 CMD ["node", "listener/listener.js", "--elasticsearch", "--db"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       - DATABASE_NAME=origin
       - ELASTICSEARCH_HOST=elasticsearch:9200
       - DATABASE_URL=postgres://origin:origin@postgres/origin
-      # TODO: Add support for .env files to the event-listener and moves those envs in there.
+      # TODO: Add support for .env files to the event-listener and move these env vars in there.
       - AFFILIATE_ACCOUNT=0x821aea9a577a9b44299b9c15c88cf3087f3b5544
       - ARBITRATOR_ACCOUNT=0x0d1d4e623d10f9fba5db95830f7d3839406c6af2
       - BLOCK_EPOCH=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,10 @@ services:
       - DATABASE_NAME=origin
       - ELASTICSEARCH_HOST=elasticsearch:9200
       - DATABASE_URL=postgres://origin:origin@postgres/origin
+      # TODO: Add support for .env files to the event-listener and moves those envs in there.
+      - AFFILIATE_ACCOUNT=0x821aea9a577a9b44299b9c15c88cf3087f3b5544
+      - ARBITRATOR_ACCOUNT=0x0d1d4e623d10f9fba5db95830f7d3839406c6af2
+      - BLOCK_EPOCH=0
     command: >
       /bin/bash -c "wait-for.sh -t 0 -q origin-js:8081 --
       npm link origin &&

--- a/origin-discovery/listener/README.md
+++ b/origin-discovery/listener/README.md
@@ -14,6 +14,8 @@ First you'll need a blockchain network to listen to. To get a local network work
 
 A simple way to see the listener in action:
 
+    cd origin-discovery
+    npm run install:dev
     node daemon/indexing/listener/listener.js
 
 ## Command line options
@@ -31,6 +33,18 @@ Output:
 Events:
 
 `--continue-file=path` Will start following events at the block number defined in the file, and will keep this file updated as it listens to events. The continue file is JSON, in the format `{"lastLogBlock":222, "version":1}`.
+
+## Env variables
+
+The listener calls out origin.js to load and validate data from the blockchain. In order to properly configure an origin.js object, the listener uses the following environment variables:
+  - ARBITRATOR_ACCOUNT: Ethereum address of the Origin marketplace arbitrator account.
+  - AFFILIATE_ACCOUNT:  Ethereum address of the Origin marketplace affilicate account.
+  - BLOCK_EPOCH: Start block to use when scanning the blockchain for Origin events.
+
+Those values can be found via the DApp info page:
+  - Mainnet: https://dapp.originprotocol.com/#/dapp-info
+  - Rinkeby: https://dapp.staging.originprotocol.com/#/dapp-info
+  - Local blockchain: http://localhost:3000/#/dapp-info
 
 
 # How the listener works

--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -119,14 +119,31 @@ function setupOriginJS(config){
   console.log(`Web3 URL: ${config.web3Url}`)
 
   const ipfsUrl = urllib.parse(config.ipfsUrl)
+  console.log(`IPFS URL: ${ipfsUrl}`)
+
+  // Error out if any mandatory env var is not set.
+  if (!process.env.ARBITRATOR_ACCOUNT) {
+    throw new Error('ARBITRATOR_ACCOUNT not set')
+  }
+  if (!process.env.AFFILIATE_ACCOUNT) {
+    throw new Error('AFFILIATE_ACCOUNT not set')
+  }
+
+  // Issue a warning for any recommended env var that is not set.
+  if (!process.env.BLOCK_EPOCH) {
+    console.log('WARNING: For performance reason it is recommended to set BLOCK_EPOCH')
+  }
+
   // global
   o = new Origin({
     ipfsDomain: ipfsUrl.hostname,
     ipfsGatewayProtocol: ipfsUrl.protocol.replace(':',''),
     ipfsGatewayPort: ipfsUrl.port,
+    arbitrator: process.env.ARBITRATOR_ACCOUNT,
+    affiliate: process.env.AFFILIATE_ACCOUNT,
+    blockEpoch: process.env.BLOCK_EPOCH || 0,
     web3
   })
-  console.log(`IPFS URL: ${config.ipfsUrl}`)
 }
 
 /**


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [X] Ensure all new and existing tests pass
- [X] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [X] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
The event-listener had a couple of issues:
  - errors when validating offers due to a couple of addresses (arbitrator and affiliate) not being passed to the Origin constructor.
 - indexing slowness on Mainnet caused by calls to scan events since inception as opposed to Origin block epoch.

This PR fixes the call to the Origin constructor in event-listener and sets env variables in the various environments.