### PR TITLE
Dotenv & IPFS References

### DIFF
--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const fs = require('fs')
 const http = require('http')
 const https = require('https')
@@ -119,7 +121,7 @@ function setupOriginJS(config){
   console.log(`Web3 URL: ${config.web3Url}`)
 
   const ipfsUrl = urllib.parse(config.ipfsUrl)
-  console.log(`IPFS URL: ${ipfsUrl}`)
+  console.log(`IPFS URL: ${config.ipfsUrl}`)
 
   // Error out if any mandatory env var is not set.
   if (!process.env.ARBITRATOR_ACCOUNT) {
@@ -309,7 +311,6 @@ async function handleLog(log, rule, contractVersion, context) {
   log.eventName = rule.eventName
   log.contractVersionKey = contractVersion.versionKey
   log.networkId = context.networkId
-
   const logDetails = `blockNumber=${log.blockNumber} \
     transactionIndex=${log.transactionIndex} \
     eventName=${log.eventName} \
@@ -648,7 +649,7 @@ const config = {
   // web3 provider url
   web3Url: args['--web3-url'] || 'http://localhost:8545',
   // ipfs url
-  ipfsUrl: args['--ipfs-url'] || 'http://origin-js:8080',
+  ipfsUrl: args['--ipfs-url'] || 'http://localhost:8080',
 }
 
 // Start the listener running

--- a/origin-discovery/package-lock.json
+++ b/origin-discovery/package-lock.json
@@ -1736,6 +1736,11 @@
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         },
+        "dotenv": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
+          "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk="
+        },
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -1974,9 +1979,9 @@
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -4935,6 +4940,11 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4954,11 +4964,6 @@
         "es-abstract": "1.12.0",
         "function-bind": "1.1.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/origin-discovery/package.json
+++ b/origin-discovery/package.json
@@ -6,6 +6,7 @@
     "apollo-server": "^2.1.0",
     "db-migrate": "^0.11.1",
     "db-migrate-pg": "^0.4.0",
+    "dotenv": "^6.1.0",
     "elasticsearch": "^15.1.1",
     "graphql": "^0.13.2",
     "http": "0.0.0",


### PR DESCRIPTION
This adds [dotenv](https://www.npmjs.com/package/dotenv) to support running the listener in a local environment. It also fixes a log message for the IPFS URL, for which the default is also changed.

Note ⚠️ The `--ipfs-url` will now need to be passed in for any containers expecting to use `http://origin-js:8080`. I am assuming that there are no consequences to the other discover code as a result of these changes.