### PR TITLE
Repair Method Call

### DIFF
--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -198,7 +198,7 @@ class ListingsDetail extends Component {
       })
     } catch (error) {
       this.props.showAlert(
-        this.props.formatMessage(this.intlMessages.loadingError)
+        this.props.intl.formatMessage(this.intlMessages.loadingError)
       )
       console.error(
         `Error fetching contract or IPFS info for listing: ${


### PR DESCRIPTION
This should resolve the issue of getting `this.props.formatMessage is not a function` intermittently on some listing detail pages. However, the issue resolved here only addresses the symptom. There is an underlying error occurring that causes the localized message to appear; probably [this one](https://github.com/OriginProtocol/origin/issues/799).