### PR TITLE
Add website redirect

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/website-redirect.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/website-redirect.ingress.yaml
@@ -1,0 +1,31 @@
+{{ if eq .Release.Namespace "prod" }}
+# Permanent redirect for originprotocol.com
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: originprotocol-com-redirect
+  labels:
+    app: website
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
+    # Disable SSL redirect to prevent double redirect
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://www.originprotocol.com"
+spec:
+  tls:
+    - secretName: originprotocol.com
+      hosts:
+        - originprotocol.com
+  rules:
+  - host: originprotocol.com
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "dapp.fullname" . }}
+          servicePort: 80
+{{- end }}


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~

### Description:

- Configures a redirect for originprotocol.com -> www.originprotocol.com so we aren't dependent on wwwizer.com and it also works with SSL.

@franckc this needs to be in your local repo before we do any more deploys or it'll disappear. :space_invader: 