### PR TITLE
Tyleryasaka/metamask privacy

### DIFF
--- a/origin-dapp/package-lock.json
+++ b/origin-dapp/package-lock.json
@@ -4813,6 +4813,11 @@
         "pull-stream": "3.6.8"
       }
     },
+    "date-arithmetic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-3.1.0.tgz",
+      "integrity": "sha1-H80D29UEudvuK5B4yFpfHH08wtM="
+    },
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
@@ -5333,6 +5338,11 @@
           "dev": true
         }
       }
+    },
+    "dom-helpers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -16122,6 +16132,25 @@
         "reflect.ownkeys": "0.2.0"
       }
     },
+    "prop-types-extra": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
+      "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
+      "requires": {
+        "react-is": "16.6.0",
+        "warning": "3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "1.4.0"
+          }
+        }
+      }
+    },
     "protocol-buffers-schema": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
@@ -16682,6 +16711,33 @@
         "prop-types": "15.6.2"
       }
     },
+    "react-big-calendar": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-0.19.2.tgz",
+      "integrity": "sha512-cuGfM211IGM54qaOUod0IaqGQh7iBYvjeNoP2DlfLQy+oLTBtZ8y+AFwBKqGsZT2gEyBOlrgNfIBLGltlrEicA==",
+      "requires": {
+        "classnames": "2.2.6",
+        "date-arithmetic": "3.1.0",
+        "dom-helpers": "3.3.1",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10",
+        "prop-types": "15.6.2",
+        "react-overlays": "0.7.4",
+        "react-prop-types": "0.4.0",
+        "uncontrollable": "4.1.0",
+        "warning": "2.1.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
+          "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
+          "requires": {
+            "loose-envify": "1.4.0"
+          }
+        }
+      }
+    },
     "react-dates": {
       "version": "17.2.0",
       "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
@@ -16730,6 +16786,11 @@
         "intl-relativeformat": "2.1.0",
         "invariant": "2.2.4"
       }
+    },
+    "react-is": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
+      "integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
     },
     "react-js-pagination": {
       "version": "3.0.2",
@@ -16795,12 +16856,52 @@
         "prop-types": "15.6.2"
       }
     },
+    "react-overlays": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.7.4.tgz",
+      "integrity": "sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==",
+      "requires": {
+        "classnames": "2.2.6",
+        "dom-helpers": "3.3.1",
+        "prop-types": "15.6.2",
+        "prop-types-extra": "1.1.0",
+        "warning": "3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "1.4.0"
+          }
+        }
+      }
+    },
     "react-portal": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.5.tgz",
       "integrity": "sha512-jJMy9DoVr4HRWPdO8IP/mDHP1Q972/aKkulVQeIrttOIyRNmCkR2IH7gK3HVjhzxy6M+k9TopSWN5q41wO/o6A==",
       "requires": {
         "prop-types": "15.6.2"
+      }
+    },
+    "react-prop-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
+      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
+      "requires": {
+        "warning": "3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "1.4.0"
+          }
+        }
       }
     },
     "react-redux": {
@@ -19698,6 +19799,14 @@
             "isarray": "1.0.0"
           }
         }
+      }
+    },
+    "uncontrollable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
+      "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
+      "requires": {
+        "invariant": "2.2.4"
       }
     },
     "underscore": {

--- a/origin-dapp/src/services/origin.js
+++ b/origin-dapp/src/services/origin.js
@@ -18,16 +18,19 @@ const hasCustomBridge = bridgeProtocol && bridgeDomain
 const bridgeUrl = hasCustomBridge ? customBridgeUrl : defaultBridgeUrl
 const attestationServerUrl = `${bridgeUrl}/api/attestations`
 const ipfsSwarm = process.env.IPFS_SWARM
-const web3 = new Web3(
-  // Detect MetaMask using global window object
-  window.web3
-    ? // Use MetaMask provider
-    window.web3.currentProvider
-    : // Use wallet-enabled browser provider
-    Web3.givenProvider ||
-      // Create a provider with Infura node
-      new Web3.providers.HttpProvider(defaultProviderUrl, 20000)
-)
+
+// See: https://gist.github.com/bitpshr/076b164843f0414077164fe7fe3278d9#file-provider-enable-js
+const getWeb3 = () => {
+  if (window.ethereum) {
+    return new Web3(window.ethereum)
+  } else if (window.web3) {
+    return new Web3(window.web3.currentProvider)
+  } else {
+    return new Web3(Web3.givenProvider || new Web3.providers.HttpProvider(defaultProviderUrl, 20000))
+  }
+}
+
+const web3 = getWeb3()
 
 const ipfsCreator = repo_key => {
   const ipfsOptions = {

--- a/origin-dapp/src/services/origin.js
+++ b/origin-dapp/src/services/origin.js
@@ -31,6 +31,7 @@ const getWeb3 = () => {
 }
 
 const web3 = getWeb3()
+const ethereum = window.ethereum
 
 const ipfsCreator = repo_key => {
   const ipfsOptions = {
@@ -80,7 +81,8 @@ const config = {
   ipfsCreator,
   OrbitDB,
   ecies,
-  web3
+  web3,
+  ethereum
 }
 
 try {

--- a/origin-js/src/index.js
+++ b/origin-js/src/index.js
@@ -35,11 +35,12 @@ class Origin {
     ecies,
     messagingNamespace,
     blockEpoch,
-    blockAttestattionV1
+    blockAttestattionV1,
+    ethereum
   } = {}) {
     this.version = VERSION
 
-    this.contractService = new ContractService({ contractAddresses, web3 })
+    this.contractService = new ContractService({ contractAddresses, web3, ethereum })
     this.ipfsService = new IpfsService({
       ipfsDomain,
       ipfsApiPort,

--- a/origin-js/src/services/contract-service.js
+++ b/origin-js/src/services/contract-service.js
@@ -130,9 +130,33 @@ class ContractService {
     return hashStr
   }
 
+  async enableEthereum() {
+    try {
+      // Request account access if needed
+      await window.ethereum.enable()
+      this.ethereumIsEnabled = true
+      this.onEthereumEnabled = null
+    } catch (error) {
+      // User denied account access...
+      console.error(`Error enabling ethereum: ${error}`)
+    }
+  }
+
+  async ensureEthereumIsEnabled() {
+    if (window.ethereum && !this.ethereumIsEnabled) {
+      // This flow allows currentAccount to be called multiple times before the user has dealt with the first popup.
+      // Otherwise, if you call this function multiple times before the first one is handled, mutltiple popups will appear.
+      if (!this.onEthereumEnabled) {
+        this.onEthereumEnabled = this.enableEthereum()
+      }
+      await this.onEthereumEnabled
+    }
+  }
+
   // Returns the first account listed, unless a default account has been set
   // explicitly
   async currentAccount() {
+    await this.ensureEthereumIsEnabled()
     const defaultAccount = this.web3.eth.defaultAccount
     if (defaultAccount) {
       return defaultAccount

--- a/origin-js/src/services/contract-service.js
+++ b/origin-js/src/services/contract-service.js
@@ -21,7 +21,7 @@ const SUPPORTED_ERC20 = [
 ]
 
 class ContractService {
-  constructor({ web3, contractAddresses } = {}) {
+  constructor({ web3, contractAddresses, ethereum } = {}) {
     const externalWeb3 = web3 || window.web3
     if (!externalWeb3) {
       throw new Error(
@@ -29,6 +29,7 @@ class ContractService {
       )
     }
     this.web3 = new Web3(externalWeb3.currentProvider)
+    this.ethereum = ethereum
 
     this.marketplaceContracts = { V00_Marketplace }
 
@@ -133,7 +134,7 @@ class ContractService {
   async enableEthereum() {
     try {
       // Request account access if needed
-      await window.ethereum.enable()
+      await this.ethereum.enable()
       this.ethereumIsEnabled = true
       this.onEthereumEnabled = null
     } catch (error) {
@@ -143,7 +144,7 @@ class ContractService {
   }
 
   async ensureEthereumIsEnabled() {
-    if (window.ethereum && !this.ethereumIsEnabled) {
+    if (this.ethereum && !this.ethereumIsEnabled) {
       // This flow allows currentAccount to be called multiple times before the user has dealt with the first popup.
       // Otherwise, if you call this function multiple times before the first one is handled, mutltiple popups will appear.
       if (!this.onEthereumEnabled) {


### PR DESCRIPTION
### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:

Makes Origin compatible with Metamask's breaking change regarding account privacy. Really glad that Metamask is doing this. And glad Origin will be able to support it right away!

Please double check me in the following paths:
1. User should be able to create listing using current Metamask (there will be no privacy popup; nothing should have changed).
2. User should be able to create a listing using a build that includes the breaking change. You'll have to manually download and install a build. Follow the instructions [here](https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8). Once you've installed the build, **make sure you go into Metamask settings and turn on privacy mode**. If all is well, when you visit the Dapp now, you should be presented with a Metamask popup requesting approval to access your accounts.
3. Same as above, but decline the request from Metamask. Nothing should crash, but an error should be logged to the console, and the old popup saying that you need to install Metamask should appear when you try to do something that requires it.

Resolves #835