### PR TITLE
Abort deploying if contracts migrated failure

### DIFF
--- a/origin-js/scripts/helpers/deploy-contracts.js
+++ b/origin-js/scripts/helpers/deploy-contracts.js
@@ -15,9 +15,11 @@ const deployContracts = () => {
     truffleMigrate.on('exit', code => {
       if (code === 0) {
         console.log('Truffle migrate finished OK.')
+        minifyContracts()
+        resolve()
+      } else {
+        reject('Truffle migrate failed.')
       }
-      minifyContracts()
-      resolve()
     })
   })
 }


### PR DESCRIPTION
Recommend to reject() the process if truffle compile-all got failure,
just little change of code logic.

Signed-off-by: Zhilong Liu <zhilong.liu1028@gmail.com>
