### PR TITLE
fix bug that crashed ipfs proxy when 404 status should be reported

### DIFF
--- a/ipfs-proxy/src/index.js
+++ b/ipfs-proxy/src/index.js
@@ -121,7 +121,7 @@ const server = http.createServer((req, res) => {
   } else if (req.url.startsWith('/ipfs')) {
     handleFileDownload(req, res)
   } else {
-    req.writeHead(404, { 'Connection': 'close' })
+    res.writeHead(404, { 'Connection': 'close' })
     res.end()
   }
 }).listen(config.IPFS_PROXY_PORT, config.IPFS_PROXY_ADDRESS)


### PR DESCRIPTION
### Description:

Prevents a crash of `ipfs-proxy` container when 404 response should be returned 
