### PR TITLE
Make Travis use Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
   - name: "DApp unit tests"
     language: node_js
-    node_js: lts/*
+    node_js: 8
     before_script:
     - cd origin-dapp
     - npm install
@@ -12,7 +12,7 @@ matrix:
   # FIXME: remove dependency between origin-faucet and origin-js/contracts/test-alt
   - name: "Origin-js unit tests"
     language: node_js
-    node_js: lts/*
+    node_js: 8
     before_script:
     - cd origin-faucet
     - npm install


### PR DESCRIPTION
We still have build problems with Node 10.x, which Travis automatically
started using today, because 10.x started being LTS today.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs]### Description:

