### PR TITLE
Fix promise chaining in migration script

### DIFF
--- a/origin-notifications/migrations/20181029174407-create-push-subscription.js
+++ b/origin-notifications/migrations/20181029174407-create-push-subscription.js
@@ -2,39 +2,45 @@
 
 const TableName = 'push_subscription'
 
-
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS hstore;')
-      .then(queryInterface.createTable(TableName, {
-        id: {
-          autoIncrement: true,
-          primaryKey: true,
-          type: Sequelize.INTEGER
-        },
-        // not unique!
-        endpoint: {
-          type: Sequelize.STRING
-        },
-        keys: {
-          type: Sequelize.HSTORE
-        },
-        expirationTime: {
-          type: Sequelize.DATE
-        },
-        // not unique!
-        account: {
-          type: Sequelize.STRING
-        },
-        createdAt: {
-          allowNull: false,
-          type: Sequelize.DATE
-        },
-        updatedAt: {
-          allowNull: false,
-          type: Sequelize.DATE
-        }})
-        .then(() => queryInterface.addIndex(TableName, ['account', 'endpoint'])))
+    queryInterface.sequelize
+      .query('CREATE EXTENSION IF NOT EXISTS hstore;')
+      .then(() => {
+        return queryInterface
+          .createTable(TableName, {
+            id: {
+              autoIncrement: true,
+              primaryKey: true,
+              type: Sequelize.INTEGER
+            },
+            // not unique!
+            endpoint: {
+              type: Sequelize.STRING
+            },
+            keys: {
+              type: Sequelize.HSTORE
+            },
+            expirationTime: {
+              type: Sequelize.DATE
+            },
+            // not unique!
+            account: {
+              type: Sequelize.STRING
+            },
+            createdAt: {
+              allowNull: false,
+              type: Sequelize.DATE
+            },
+            updatedAt: {
+              allowNull: false,
+              type: Sequelize.DATE
+            }
+          })
+          .then(() => {
+            return queryInterface.addIndex(TableName, ['account', 'endpoint'])
+          })
+      })
   },
   down: (queryInterface, Sequelize) => {
     // Note: we don't remove the hstore extension since it could be used


### PR DESCRIPTION
Fix the ordering of things in the notifications migrate script. Also formatted it with `npx prettier-eslint-cli 20181029174407-create-push-subscription.js --write --single-quote --no-semi` which made a mess of the diff. 😞 