### PR TITLE
Make EnvKey optional for listener

### DIFF
--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -1,5 +1,9 @@
 require('dotenv').config()
-require('envkey')
+try {
+  require('envkey')
+} catch (error) {
+  console.log('EnvKey not configured')
+}
 
 const fs = require('fs')
 const http = require('http')


### PR DESCRIPTION
Small tweak to make EnvKey optional for event-listener. We want the listener to remain configurable via CLI so I just added a try/catch so that it can carry on if the ENVKEY environment variable is not set.