### PR TITLE
Add NAMESPACE env var to event-listener container

### DIFF
--- a/deployment/kubernetes/charts/origin/scripts/start-event-listener.sh
+++ b/deployment/kubernetes/charts/origin/scripts/start-event-listener.sh
@@ -12,4 +12,4 @@ echo "Starting event listener"
 echo "{ \"lastLogBlock\": ${CONTINUE_BLOCK} }" > ./continue.json
 
 # Start event listener
-node listener/listener.js --elasticsearch --db --web3-url=${WEB3_URL} --ipfs-url=${IPFS_URL} --continue-file=./continue.json --trail-behind-blocks=1 --webhook=http://notifications.${NAMESPACE}.svc.cluster.local:3456/events
+node listener/listener.js --elasticsearch --db --web3-url=${WEB3_URL} --ipfs-url=${IPFS_URL} --continue-file=./continue.json --trail-behind-blocks=1 --webhook=http://${NAMESPACE}-notifications.${NAMESPACE}.svc.cluster.local:3456/events

--- a/deployment/kubernetes/charts/origin/templates/eventlistener.deployment.yaml
+++ b/deployment/kubernetes/charts/origin/templates/eventlistener.deployment.yaml
@@ -47,6 +47,8 @@ spec:
           value: https://{{ template "ipfs.host" . }}
         - name: CONTINUE_BLOCK
           value: {{ default "0" .Values.eventlistenerContinueBlock | quote }}
+        - name: NAMESPACE
+          value: {{ .Release.Namespace | quote }}
         command: ["/bin/sh"]
         args:
         - "-c"


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Ensure all new and existing tests pass
- [ ] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:

NAMESPACE needs to be defined since it is used by start-event-listener.sh

Now, after that is fixed, there is still something broken I think with the event-listener webhook to the notification server. From a shell within the event-listener container, I could not connect to the notification server:
```# curl http://notifications.staging.svc.cluster.local:3456 
curl: (6) Could not resolve host: notifications.staging.svc.cluster.local
```