### PR TITLE
[Notification] Increase max payload size to 10MB

### DIFF
--- a/origin-notifications/app.js
+++ b/origin-notifications/app.js
@@ -78,7 +78,9 @@ app.all((req, res, next) => {
     })
 })
 
-app.use(bodyParser.json())
+// Note: bump up default payload max size since the event-listener posts
+// payload that may contain user profile with b64 encoded profile picture.
+app.use(bodyParser.json({limit: '10mb'}))
 
 app.get('/', async (req, res) => {
   let markup = `<h1>Origin Notifications</h1><h2><a href="https://github.com/OriginProtocol/origin/issues/806">Learn More</a></h2>`


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Ensure all new and existing tests pass
- [ ] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
The events sent by the event-listener and processed by the notification server exceed the default 100kb limit since they may include user profile with picture from seller + buyer. Each pic can be up to 500x500 which is 750kb uncompressed. So those events could be in the order of couple of MB. There is no reason though to keep the limit on notification server very tight so I'm setting it to 10MB for now.
