### PR TITLE
Add ServiceMonitor for nginx ingress

### DIFF
--- a/deployment/kubernetes/misc/ingress.servicemonitor.yaml
+++ b/deployment/kubernetes/misc/ingress.servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-ingress-service-monitor
+  namespace: monitoring
+  labels:
+    app: nginx-ingress-service-monitor
+    prometheus: kube-prometheus
+spec:
+  jobLabel: nginx-ingress
+  selector:
+    matchLabels:
+      app: nginx-ingress
+  namespaceSelector:
+    any: true
+  endpoints:
+    - port: metrics
+      interval: 30s


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:

- Adds a ServiceMonitor to the Kubernetes config so that Prometheus picks up nginx-ingress metrics.
