### PR TITLE
[Notifications] Do no crash server when receiving non offer related events

### DIFF
--- a/origin-discovery/listener/listener.js
+++ b/origin-discovery/listener/listener.js
@@ -488,14 +488,24 @@ async function handleLog(log, rule, contractVersion, context) {
 
   if (context.config.webhook) {
     console.log('\n-- WEBHOOK to ' + context.config.webhook + ' --\n')
-    await withRetrys(async () => {
-      await postToWebhook(context.config.webhook, json)
-    })
+    try {
+      await withRetrys(async () => {
+        await postToWebhook(context.config.webhook, json)
+      }, exitOnError=false)
+    } catch(e) {
+      console.log(`Skipping webhook for ${logDetails}`)
+    }
   }
 
   if (context.config.discordWebhook) {
-    postToDiscordWebhook(context.config.discordWebhook, output)
     console.log('\n-- Discord WEBHOOK to ' + context.config.discordWebhook + ' --')
+    try {
+      await withRetrys(async () => {
+        postToDiscordWebhook(context.config.discordWebhook, output)
+      }, exitOnError=false)
+    } catch(e) {
+      console.log(`Skipping discord webhook for ${logDetails}`)
+    }
   }
 }
 

--- a/origin-notifications/app.js
+++ b/origin-notifications/app.js
@@ -112,17 +112,25 @@ app.post('/', async(req, res) => {
 
 app.post('/events', async (req, res) => {
   const { log = {}, related = {} } = req.body
+  const { decoded = {}, eventName } = log
   const { buyer = {}, listing, offer, seller = {} } = related
+  const eventDetails = `eventName=${eventName} blockNumber=${log.blockNumber} logIndex=${log.logIndex}`
 
   res.sendStatus(200)
 
   if (!listing || (!buyer.address && !seller.address)) {
+    console.log(`Missing listing or buyer/seller address. Skipping ${eventDetails}`)
     return
   }
 
-  const { decoded = {}, eventName } = log
-  const { party } = decoded
+  if (!eventNotificationMap[eventName]) {
+    console.log(`Not a processable event. Skipping ${eventDetails}`)
+    return
+  }
   const { body, title } = eventNotificationMap[eventName]
+  const { party } = decoded
+
+  console.log(`Processing event ${eventDetails}`)
 
   const subs = await PushSubscription.findAll({
     where: {


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [X] Ensure all new and existing tests pass
- [X] Format code to be consistent with the project
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Description:
A few fixes to harden the notification server and its integration in the event listener:
 - Fix bug in notifier where non offer events (for ex. ListingCreated) would cause a crash
 - Do not crash the listener if a webhook calls fails: after maximum number of reties reached, skip the webhook call.
