### PR TITLE
Add more docker volume mappings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,6 @@ services:
       # written to the build files
       - ./origin-contracts/build:/app/origin-contracts/build
       - ./origin-js/scripts:/app/origin-js/scripts
-      - ./origin-js/src:/app/origin-js/src
-      - ./origin-js/test:/app/origin-js/test
-      - ./origin-js/package.json:/app/origin-js/package.json
-      - ./origin-js/webpack.config.js:/app/origin-js/webpack.config.js
 
   origin-discovery:
     container_name: origin-discovery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       context: .
       dockerfile: development/dockerfiles/event-listener
     volumes:
+      - ./origin-contracts/build:/app/origin-contracts/build
       - ./origin-js/src:/app/origin-js/src
       - ./origin-discovery/src:/app/origin-discovery/src
       - ./development/envfiles/event-listener.env:/app/origin-discovery/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,11 @@ services:
       # Addresses for deployment of contracts to local blockchain will get
       # written to the build files
       - ./origin-contracts/build:/app/origin-contracts/build
+      - ./origin-js/scripts:/app/origin-js/scripts
+      - ./origin-js/src:/app/origin-js/src
+      - ./origin-js/test:/app/origin-js/test
+      - ./origin-js/package.json:/app/origin-js/package.json
+      - ./origin-js/webpack.config.js:/app/origin-js/webpack.config.js
 
   origin-discovery:
     container_name: origin-discovery


### PR DESCRIPTION
### Description:
- add contracts build dir to `event-listener` container. Enabling event listener to interact with local web3
- add some more volumes in `origin-js` developers might want to interact with from the host machine