### PR TITLE
 Small fix for drag/drop that was breaking listing create

### DIFF
--- a/origin-dapp/src/components/form-widgets/photo-picker.js
+++ b/origin-dapp/src/components/form-widgets/photo-picker.js
@@ -167,7 +167,7 @@ class PhotoPicker extends Component {
               {(provided) => (
                 <div ref={provided.innerRef}>
                   {pictures.map((dataUri, idx) => (
-                    <Draggable key={idx} draggableId={idx} index={idx}>
+                    <Draggable key={idx + 1} draggableId={idx} index={idx}>
                       {(provided) => (
                         <div
                           className="image-container"

--- a/origin-dapp/src/components/form-widgets/photo-picker.js
+++ b/origin-dapp/src/components/form-widgets/photo-picker.js
@@ -167,7 +167,7 @@ class PhotoPicker extends Component {
               {(provided) => (
                 <div ref={provided.innerRef}>
                   {pictures.map((dataUri, idx) => (
-                    <Draggable key={idx + 1} draggableId={idx} index={idx}>
+                    <Draggable key={idx} draggableId={idx + 1} index={idx}>
                       {(provided) => (
                         <div
                           className="image-container"


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Ensure all new and existing tests pass
- [x] Format code to be consistent with the project

### Description:

I'm not sure what caused this to break (assuming maybe a new version of `react-beautiful-dnd`? But it just needs a non-zero value for `draggableId` and it works fine

Ticket here: https://github.com/OriginProtocol/origin/issues/928
