### PR TITLE
Fix elasticsearch alias bug

### DIFF
--- a/origin-discovery/devops/es-cli.js
+++ b/origin-discovery/devops/es-cli.js
@@ -140,7 +140,7 @@ async function showIndexInfo() {
         .split('\n')
         .filter(listingRow => listingRow.length > 1) // filter out empty rows
         .map(listingRow => {
-          const aliasData = listingRow.split(' ')
+          const aliasData = listingRow.split(/\s+/)
           return {
             index: aliasData[1],
             alias: aliasData[0]


### PR DESCRIPTION
### Description:
Elasticsearch formats the output of aliases in such manner that there can be multiple whitespaces between index and alias words. 