### PR TITLE
Smaller welcome message on mobile devices

### DIFF
--- a/origin-dapp/public/images/caret-down.svg
+++ b/origin-dapp/public/images/caret-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="9" viewBox="0 0 14 9">
+    <path fill="#98A7B4" fill-rule="evenodd" d="M13.931 2.446L12.274.76 7.306 5.727 2.338.759.683 2.446 7.306 9.04z"/>
+</svg>

--- a/origin-dapp/public/images/caret-up.svg
+++ b/origin-dapp/public/images/caret-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="9" viewBox="0 0 14 9">
+    <path fill="#98A7B4" fill-rule="evenodd" d="M13.931 6.554L12.274 8.24 7.306 3.273 2.338 8.241.683 6.554 7.306-.04z"/>
+</svg>

--- a/origin-dapp/src/components/badges.js
+++ b/origin-dapp/src/components/badges.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
 export const BetaBadge = () => (
-  <span className="badge badge-primary">
+  <span className="badge badge-primary mt-1">
     <FormattedMessage
       id={'badges.beta'}
       defaultMessage={'Beta'}

--- a/origin-dapp/src/components/warning.js
+++ b/origin-dapp/src/components/warning.js
@@ -6,29 +6,48 @@ import { BetaBadge } from 'components/badges'
 import getCurrentNetwork from 'utils/currentNetwork'
 
 class Warning extends Component {
+  constructor() {
+    super()
+    this.state = {
+      warningExpanded: false
+    }
+
+    this.onWarningClick = this.onWarningClick.bind(this)
+  }
+
+  onWarningClick() {
+    this.setState({ warningExpanded: !this.state.warningExpanded })
+  }
+
   render() {
     const { web3NetworkId } = this.props
     const currentNetwork = getCurrentNetwork(web3NetworkId)
     const networkType = currentNetwork && currentNetwork.type
 
     return (
-      <div className="warning alert alert-warning">
+      <div className={`warning alert alert-warning ${this.state.warningExpanded ? 'expanded' : ''}`} onClick={this.onWarningClick}>
         <div className="container">
           <div className="row">
             <div className="col">
-              <div className="d-flex align-items-center">
+              <div className="d-flex align-items-start">
                 <BetaBadge />
-                <div className="text-container">
+                <div className="text-container mr-auto pt-1">
                   <p>
-                    <strong>
+                    <strong id="desktop-message">
                       <FormattedMessage
-                        id={'warning.message'}
+                        id={'warning.desktopMessage'}
                         defaultMessage={`You're currently using the Origin {networkType}.`}
                         values={{ networkType }}
                       />
                     </strong>
+                    <strong id="mobile-message">
+                      <FormattedMessage
+                        id={'warning.mobileMessage'}
+                        defaultMessage={`Welcome to the Origin Beta!`}
+                      />
+                    </strong>
                   </p>
-                  <p>
+                  <p id="invitation-message">
                     <FormattedMessage
                       id={'warning.invitation'}
                       defaultMessage={`Found a bug? Open an issue on {github} or report it in our #bug-reports channel on {discord}.`}
@@ -40,6 +59,7 @@ class Warning extends Component {
                             rel="noopener noreferrer"
                             ga-category="beta"
                             ga-label="banner_discord_report_bug"
+                            onClick={(e) => e.stopPropagation()} // prevent parent divs receiving onClick event
                           >
                             Discord
                           </a>
@@ -51,6 +71,7 @@ class Warning extends Component {
                             rel="noopener noreferrer"
                             ga-category="beta"
                             ga-label="banner_github_report_bug"
+                            onClick={(e) => e.stopPropagation()} // prevent parent divs receiving onClick event
                           >
                             GitHub
                           </a>
@@ -58,6 +79,10 @@ class Warning extends Component {
                       }}
                     />
                   </p>
+                </div>
+                <div className="pr-1 pl-3 caret">
+                  <img id="caret-up" src="images/caret-up.svg" />
+                  <img id="caret-down" src="images/caret-down.svg" />
                 </div>
               </div>
             </div>

--- a/origin-dapp/src/css/app.css
+++ b/origin-dapp/src/css/app.css
@@ -5148,10 +5148,6 @@ a:not([href]):not([tabindex]).span-link {
     }
   }
 
-  .warning .badge {
-    display: none;
-  }
-
   .warning p {
     font-size: 0.875rem;
   }
@@ -5277,10 +5273,50 @@ a:not([href]):not([tabindex]).span-link {
   }
 }
 
+/* anything smaller than md */
+@media (max-width: 767px) {
+  .warning.alert {
+    padding: 0.25rem 0.25rem;
+  }
+
+  .warning.alert #desktop-message {
+    display: none;
+  }
+
+  .warning.alert .col {
+    padding-left: 5px;
+  }
+
+  .warning.alert:not(.expanded) #invitation-message {
+    display: none;
+  }
+
+  .warning.alert.expanded #caret-down {
+    display: none;
+  }
+
+  .warning.alert:not(.expanded) #caret-up {
+    display: none;
+  }
+
+  .warning.alert .caret {
+    margin-top: -0.15rem;
+  }
+}
+
 /* md + */
 @media (min-width: 768px) {
   .video-placeholder {
     padding-top: 100px;
+  }
+
+  .warning.alert #caret-up,
+  .warning.alert #caret-down {
+    display: none;
+  }
+
+  .warning.alert #mobile-message {
+    display: none;
   }
 
   .modal-content {


### PR DESCRIPTION
### Description:

Welcome message on mobile devices takes up less vertical space now and is expandable when clicked on.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
- ~[ ] Map any new environment variables with a default value in the Webpack config~
- ~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~

**Fixes issue:** https://github.com/OriginProtocol/origin/issues/934

**Open Zepplin designs:**
https://app.zeplin.io/project/59fa2311bac7acbc8d953da9/screen/5bd24ee31311fc09c26a2484
https://app.zeplin.io/project/59fa2311bac7acbc8d953da9/screen/5bd24ee513f4bb09f4dfbda9

Looks like this: 
<img width="381" alt="screenshot 2018-11-21 19 02 02" src="https://user-images.githubusercontent.com/579910/48860267-bde1dd80-edc0-11e8-81a8-24193ceec337.png">
<img width="379" alt="screenshot 2018-11-21 19 02 08" src="https://user-images.githubusercontent.com/579910/48860271-bf130a80-edc0-11e8-98a1-c3c81b5f53b1.png">