### PR TITLE
Ganache Mining Interval

### DIFF
--- a/origin-js/scripts/helpers/start-ganache.js
+++ b/origin-js/scripts/helpers/start-ganache.js
@@ -9,7 +9,7 @@ const startGanache = () => {
       default_balance_ether: 100,
       network_id: 999,
       seed: 123,
-      blocktime: 0,
+      blockTime: 4,
       mnemonic:
         'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
     })


### PR DESCRIPTION
1. In April, [`blocktime` was renamed to `blockTime`](https://github.com/trufflesuite/ganache-core/pull/101).
2. I can't find a good reason why [using the `blockTime` flag is discouraged](https://github.com/trufflesuite/ganache-cli#using-ganache-cli).
3. With an `undefined` value for `blockTime`, I don't know how our blockchain transaction confirmation UI ever worked with Ganache. Regardless, it currently doesn't in my experience, and this fixes it.