### PR TITLE
Hotfix: Ganache Mining Interval

### DIFF
--- a/origin-js/scripts/helpers/start-ganache.js
+++ b/origin-js/scripts/helpers/start-ganache.js
@@ -9,7 +9,7 @@ const startGanache = () => {
       default_balance_ether: 100,
       network_id: 999,
       seed: 123,
-      blocktime: 0,
+      blockTime: 4,
       mnemonic:
         'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
     })


### PR DESCRIPTION
_This is intentionally pointed at `stable`._

#985 updates the `blockTime` option in the Ganache server to use a four-second mining interval rather than "instant". Here I am cherry-picking that commit and merging it to `stable` so that the blockchain transactions dropdown will work using a local environment for product demos.