### PR TITLE
Adjust mining block time to fix unit tests timeout failures

### DIFF
--- a/origin-js/scripts/helpers/start-ganache.js
+++ b/origin-js/scripts/helpers/start-ganache.js
@@ -9,7 +9,7 @@ const startGanache = () => {
       default_balance_ether: 100,
       network_id: 999,
       seed: 123,
-      blockTime: 4,
+      blockTime: 1,
       mnemonic:
         'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
     })


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:
It seems PR #985 is causing unit tests timeouts.
Reducing block mining to 1 sec which should fix the timeouts while still allowing to test features in the DApp such as block confirmation widget.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
