### PR TITLE
Fix start command for ipfs proxy and notification

### DIFF
--- a/ipfs-proxy/package.json
+++ b/ipfs-proxy/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint '**/*.js' --rulesdir ../",
-    "start": "if [$NODE_ENV == 'production']; then node src/index.js; else nodemon src/index.js; fi",
+    "start": "if [ $NODE_ENV == 'production' ]; then node src/index.js; else nodemon src/index.js; fi",
     "test": "mocha --timeout=10000",
     "test:load": "node load.js"
   },

--- a/origin-notifications/package.json
+++ b/origin-notifications/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "eslint '**/*.js' --rulesdir ../",
     "migrate": "sequelize db:migrate",
-    "start": "if [$NODE_ENV == 'production']; then node src/app.js; else nodemon src/app.js; fi",
+    "start": "if [ $NODE_ENV == 'production' ]; then node src/app.js; else nodemon src/app.js; fi",
     "test": "echo \"Warning: no tests specified\""
   },
   "author": "Origin Protocol Inc",


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Fix shell syntax for comparison that is causing notification container to fail to start on staging.
Also fix same syntax for ipfs-proxy.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
