### PR TITLE
Set web3 version to 34 so that it works in app

### DIFF
--- a/origin-mobile/package.json
+++ b/origin-mobile/package.json
@@ -37,7 +37,7 @@
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
-    "web3": "1.0.0-beta.36"
+    "web3": "1.0.0-beta.34"
   },
   "rnpm": {
     "assets": [


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- A description of the problem you're trying to solve
- An overview of the suggested solution
- If the feature changes current behavior, reasons why your solution is better

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)


For some reason version 36 of web3 does not work in app, it can't receive netId from ganache.