### PR TITLE
rename from index.js to app.js in the remainder of the places

### DIFF
--- a/ipfs-proxy/load.js
+++ b/ipfs-proxy/load.js
@@ -10,7 +10,7 @@ const imageHash = 'QmcJwbSPxVgpLsnN3ESAeZ7FRSapYKa27pWFhY9orsZat7'
 const ipfsFactory = ipfsdCtl.create({
   type: 'js',
 })
-require('./src/index')
+require('./src/app')
 
 async function spawnIpfs() {
   return new Promise((resolve, reject) => {

--- a/ipfs-proxy/package.json
+++ b/ipfs-proxy/package.json
@@ -2,7 +2,7 @@
   "name": "ipfs-proxy",
   "version": "1.0.0",
   "description": "A proxy that validates Origin content being uploaded and downloaded from Origin's IPFS servers",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
     "lint": "eslint '**/*.js' --rulesdir ../",
     "start": "per-env",

--- a/ipfs-proxy/test.js
+++ b/ipfs-proxy/test.js
@@ -24,7 +24,7 @@ describe('upload', () => {
   let ipfsd
 
   before((done) => {
-    server = require('./src/index')
+    server = require('./src/app')
     ipfsFactory = ipfsdCtl.create({
       type: 'js',
     })
@@ -152,7 +152,7 @@ describe('download', () => {
   let ipfsd
 
   before((done) => {
-    server = require('./src/index')
+    server = require('./src/app')
 
     ipfsFactory = ipfsdCtl.create({
       type: 'js',


### PR DESCRIPTION
### Description:
PR: https://github.com/OriginProtocol/origin/pull/983 besides other things renames `index.js` to `app.js` in `ipfs-proxy`. This PR renames the files in the remainder of the places. ( without this fix `ipfs-proxy` container wouldn't start for me)

### Checklist:
- [x] Test your work and double-check to confirm that you didn't break anything
