### PR TITLE
DApp Cleanup, Reorganization & Repairs

### DIFF
--- a/origin-dapp/src/Store.js
+++ b/origin-dapp/src/Store.js
@@ -4,6 +4,7 @@ import { createStore, applyMiddleware, combineReducers } from 'redux'
 import notifications from 'reducers/Notifications'
 import exchangeRates from 'reducers/ExchangeRates'
 import transactions from 'reducers/Transactions'
+import activation from 'reducers/Activation'
 import onboarding from 'reducers/Onboarding'
 import listings from 'reducers/Listings'
 import messages from 'reducers/Messages'
@@ -26,6 +27,7 @@ const store = createStore(
     notifications,
     exchangeRates,
     transactions,
+    activation,
     onboarding,
     listings,
     messages,

--- a/origin-dapp/src/actions/Activation.js
+++ b/origin-dapp/src/actions/Activation.js
@@ -1,0 +1,97 @@
+import { showAlert } from 'actions/Alert'
+
+import keyMirror from 'utils/keyMirror'
+import { createSubscription } from 'utils/notifications'
+
+import origin from '../services/origin'
+
+export const ActivationConstants = keyMirror(
+  {
+    MESSAGING_ENABLED: null,
+    MESSAGING_INITIALIZED: null,
+    NOTIFICATIONS_HARD_PERMISSION: null,
+    NOTIFICATIONS_SOFT_PERMISSION: null,
+    NOTIFICATIONS_SUBSCRIPTION_PROMPT: null,
+    SERVICE_WORKER_REGISTRATION: null
+  },
+  'ACTIVATION'
+)
+
+export function handleNotificationsSubscription(role, props = {}) {
+  return async function(dispatch) {
+    const {
+      notificationsHardPermission,
+      notificationsSoftPermission,
+      pushNotificationsSupported,
+      serviceWorkerRegistration,
+      wallet
+    } = props
+
+    if (!pushNotificationsSupported) {
+      return
+    }
+
+    if (notificationsHardPermission === 'default') {
+      if ([null, 'warning'].includes(notificationsSoftPermission)) {
+        dispatch(handleNotificationsSubscriptionPrompt(role))
+      }
+    // existing subscription may need to be replicated for current account
+    } else if (notificationsHardPermission === 'granted') {
+      createSubscription(serviceWorkerRegistration, wallet.address)
+    }
+  }
+}
+
+export function handleNotificationsSubscriptionPrompt(role) {
+  return {
+    type: ActivationConstants.NOTIFICATIONS_SUBSCRIPTION_PROMPT,
+    role
+  }
+}
+
+export function setNotificationsHardPermission(result) {
+  return {
+    type: ActivationConstants.NOTIFICATIONS_HARD_PERMISSION,
+    result
+  }
+}
+
+export function setNotificationsSoftPermission(result) {
+  localStorage.setItem('notificationsPermissionResponse', result)
+
+  return {
+    type: ActivationConstants.NOTIFICATIONS_SOFT_PERMISSION,
+    result
+  }
+}
+
+export function enableMessaging() {
+  return function(dispatch) {
+    try {
+      origin.messaging.startConversing()
+    } catch (error) {
+      dispatch(showAlert(error.message))
+    }
+  }
+}
+
+export function setMessagingEnabled(enabled) {
+  return {
+    type: ActivationConstants.MESSAGING_ENABLED,
+    enabled
+  }
+}
+
+export function setMessagingInitialized(initialized) {
+  return {
+    type: ActivationConstants.MESSAGING_INITIALIZED,
+    initialized
+  }
+}
+
+export function saveServiceWorkerRegistration(registration) {
+  return {
+    type: ActivationConstants.SERVICE_WORKER_REGISTRATION,
+    registration
+  }
+}

--- a/origin-dapp/src/actions/App.js
+++ b/origin-dapp/src/actions/App.js
@@ -2,10 +2,8 @@ import moment from 'moment'
 import store from 'store'
 
 import { unblock } from 'actions/Onboarding'
-import { showAlert } from 'actions/Alert'
 
 import keyMirror from 'utils/keyMirror'
-import { createSubscription } from 'utils/notifications'
 import {
   addLocales,
   getAvailableLanguages,
@@ -14,25 +12,16 @@ import {
   getBestAvailableLanguage
 } from 'utils/translationUtils'
 
-import origin from '../services/origin'
-
 import translations from '../../translations/translated-messages.json'
 
 export const AppConstants = keyMirror(
   {
     BETA_MODAL_DISMISSED: null,
     MESSAGING_DISMISSED: null,
-    MESSAGING_ENABLED: null,
-    MESSAGING_INITIALIZED: null,
     NOTIFICATIONS_DISMISSED: null,
-    NOTIFICATIONS_HARD_PERMISSION: null,
-    NOTIFICATIONS_SOFT_PERMISSION: null,
-    NOTIFICATIONS_SUBSCRIPTION_PROMPT: null,
     ON_MOBILE: null,
     SHOW_MAIN_NAV: null,
-    SAVE_SERVICE_WORKER_REGISTRATION: null,
     TRANSLATIONS: null,
-    WEB3_ACCOUNT: null,
     WEB3_INTENT: null,
     WEB3_NETWORK: null
   },
@@ -70,78 +59,6 @@ export function dismissNotifications(ids) {
   }
 }
 
-export function handleNotificationsSubscription(role, props = {}) {
-  return async function(dispatch) {
-    const {
-      notificationsHardPermission,
-      notificationsSoftPermission,
-      pushNotificationsSupported,
-      serviceWorkerRegistration,
-      web3Account
-    } = props
-
-    if (!pushNotificationsSupported) {
-      return
-    }
-
-    if (notificationsHardPermission === 'default') {
-      if ([null, 'warning'].includes(notificationsSoftPermission)) {
-        dispatch(handleNotificationsSubscriptionPrompt(role))
-      }
-    // existing subscription may need to be replicated for current account
-    } else if (notificationsHardPermission === 'granted') {
-      createSubscription(serviceWorkerRegistration, web3Account)
-    }
-  }
-}
-
-export function handleNotificationsSubscriptionPrompt(role) {
-  return {
-    type: AppConstants.NOTIFICATIONS_SUBSCRIPTION_PROMPT,
-    role
-  }
-}
-
-export function setNotificationsHardPermission(result) {
-  return {
-    type: AppConstants.NOTIFICATIONS_HARD_PERMISSION,
-    result
-  }
-}
-
-export function setNotificationsSoftPermission(result) {
-  localStorage.setItem('notificationsPermissionResponse', result)
-
-  return {
-    type: AppConstants.NOTIFICATIONS_SOFT_PERMISSION,
-    result
-  }
-}
-
-export function enableMessaging() {
-  return function(dispatch) {
-    try {
-      origin.messaging.startConversing()
-    } catch (error) {
-      dispatch(showAlert(error.message))
-    }
-  }
-}
-
-export function setMessagingEnabled(messagingEnabled) {
-  return {
-    type: AppConstants.MESSAGING_ENABLED,
-    messagingEnabled
-  }
-}
-
-export function setMessagingInitialized(messagingInitialized) {
-  return {
-    type: AppConstants.MESSAGING_INITIALIZED,
-    messagingInitialized
-  }
-}
-
 export function setMobile(device) {
   return { type: AppConstants.ON_MOBILE, device }
 }
@@ -152,10 +69,6 @@ export function showMainNav(showNav) {
 
 export function storeNetwork(networkId) {
   return { type: AppConstants.WEB3_NETWORK, networkId }
-}
-
-export function storeWeb3Account(address) {
-  return { type: AppConstants.WEB3_ACCOUNT, address }
 }
 
 export function storeWeb3Intent(intent) {
@@ -211,12 +124,5 @@ export function localizeApp() {
     selectedLanguageFull: getLanguageNativeName(selectedLanguageCode),
     availableLanguages: getAvailableLanguages(),
     messages
-  }
-}
-
-export function saveServiceWorkerRegistration(registration) {
-  return {
-    type: AppConstants.SAVE_SERVICE_WORKER_REGISTRATION,
-    registration
   }
 }

--- a/origin-dapp/src/actions/Profile.js
+++ b/origin-dapp/src/actions/Profile.js
@@ -28,13 +28,11 @@ export const ProfileConstants = keyMirror(
 
 export function fetchProfile() {
   return async function(dispatch) {
-    const user = await origin.users.get(),
-      wallet = await origin.contractService.currentAccount()
+    const user = await origin.users.get()
 
     dispatch({
       type: ProfileConstants.FETCH_SUCCESS,
-      user,
-      wallet
+      user
     })
   }
 }

--- a/origin-dapp/src/actions/Wallet.js
+++ b/origin-dapp/src/actions/Wallet.js
@@ -4,29 +4,16 @@ import origin from '../services/origin'
 
 export const WalletConstants = keyMirror(
   {
-    INIT: null,
-    INIT_SUCCESS: null,
-    INIT_ERROR: null,
-
     ETH_BALANCE_SUCCESS: null,
     ETH_BALANCE_ERROR: null,
 
     OGN_BALANCE_SUCCESS: null,
-    OGN_BALANCE_ERROR: null
+    OGN_BALANCE_ERROR: null,
+
+    ACCOUNT_ADDRESS: null
   },
   'WALLET'
 )
-
-export function init() {
-  return async function(dispatch) {
-    const address = await origin.contractService.currentAccount()
-
-    dispatch({
-      type: WalletConstants.INIT_SUCCESS,
-      address
-    })
-  }
-}
 
 export function getEthBalance() {
   return async function(dispatch) {
@@ -64,6 +51,22 @@ export function getOgnBalance() {
     dispatch({
       type: WalletConstants.OGN_BALANCE_SUCCESS,
       ognBalance: ognBalance
+    })
+  }
+}
+
+export function storeAccountAddress(address) {
+  return async function(dispatch) {
+    const initialized = true
+
+    if (!address) {
+      address = await origin.contractService.currentAccount()
+    }
+
+    dispatch({
+      type: WalletConstants.ACCOUNT_ADDRESS,
+      address,
+      initialized
     })
   }
 }

--- a/origin-dapp/src/components/app.js
+++ b/origin-dapp/src/components/app.js
@@ -3,12 +3,13 @@ import { HashRouter as Router, Route, Switch } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { IntlProvider } from 'react-intl'
 
-import { localizeApp, saveServiceWorkerRegistration, setMobile } from 'actions/App'
+import { saveServiceWorkerRegistration } from 'actions/Activation'
+import { localizeApp, setMobile } from 'actions/App'
 import { fetchProfile } from 'actions/Profile'
 import {
   getEthBalance,
   getOgnBalance,
-  init as initWallet
+  storeAccountAddress
 } from 'actions/Wallet'
 
 // Components
@@ -100,8 +101,8 @@ class App extends Component {
   }
 
   async componentDidMount() {
+    this.props.storeAccountAddress()
     this.props.fetchProfile()
-    this.props.initWallet()
     this.props.getEthBalance()
     this.props.getOgnBalance()
 
@@ -197,10 +198,10 @@ const mapDispatchToProps = dispatch => ({
   fetchProfile: () => dispatch(fetchProfile()),
   getEthBalance: () => dispatch(getEthBalance()),
   getOgnBalance: () => dispatch(getOgnBalance()),
-  initWallet: () => dispatch(initWallet()),
+  localizeApp: () => dispatch(localizeApp()),
   saveServiceWorkerRegistration: reg => dispatch(saveServiceWorkerRegistration(reg)),
   setMobile: device => dispatch(setMobile(device)),
-  localizeApp: () => dispatch(localizeApp())
+  storeAccountAddress: () => dispatch(storeAccountAddress())
 })
 
 export default connect(

--- a/origin-dapp/src/components/arbitration.js
+++ b/origin-dapp/src/components/arbitration.js
@@ -18,6 +18,7 @@ import TransactionHistory from 'components/transaction-history'
 import UserCard from 'components/user-card'
 
 import { getListing } from 'utils/listing'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -93,16 +94,18 @@ class Arbitration extends Component {
   }
 
   validateUser() {
-    const { history, offerId, web3Account } = this.props
+    const { history, offerId, wallet } = this.props
 
     if (
-      web3Account &&
-      this.props.web3Account.toUpperCase() !== ARBITRATOR_ACCOUNT.toUpperCase()
+      wallet.address &&
+      formattedAddress(wallet.address) !== formattedAddress(ARBITRATOR_ACCOUNT)
     ) {
       alert(
         `⚠️ Warning:\nCurrent account (${
-          this.props.web3Account
-        }) is not equal to the ARBITRATOR_ACCOUNT environment variable (${ARBITRATOR_ACCOUNT})`
+          formattedAddress(wallet.address)
+        }) is not equal to the ARBITRATOR_ACCOUNT environment variable (${
+          ARBITRATOR_ACCOUNT
+        })`
       )
 
       history.push(`/purchases/${offerId}`)
@@ -110,9 +113,9 @@ class Arbitration extends Component {
   }
 
   render() {
-    const { messages, web3Account } = this.props
+    const { messages, wallet } = this.props
 
-    if (!web3Account) {
+    if (!wallet.address) {
       return null
     }
 
@@ -136,10 +139,10 @@ class Arbitration extends Component {
 
     const buyerConversationId =
       buyer.address &&
-      origin.messaging.generateRoomId(web3Account, buyer.address)
+      origin.messaging.generateRoomId(wallet.address, buyer.address)
     const sellerConversationId =
       seller.address &&
-      origin.messaging.generateRoomId(web3Account, seller.address)
+      origin.messaging.generateRoomId(wallet.address, seller.address)
     const participantsConversationId =
       buyer.address &&
       seller.address &&
@@ -191,8 +194,8 @@ class Arbitration extends Component {
                           <SellerBadge />
                         </div>
                         <div className="name">{sellerName}</div>
-                        <div className="address text-muted text-truncate" title={seller.address}>
-                          {seller.address}
+                        <div className="address text-muted text-truncate" title={formattedAddress(seller.address)}>
+                          {formattedAddress(seller.address)}
                         </div>
                       </div>
                     </div>
@@ -206,8 +209,8 @@ class Arbitration extends Component {
                           <BuyerBadge />
                         </div>
                         <div className="name">{buyerName}</div>
-                        <div className="address text-muted text-truncate" title={buyer.address}>
-                          {buyer.address}
+                        <div className="address text-muted text-truncate" title={formattedAddress(buyer.address)}>
+                          {formattedAddress(buyer.address)}
                         </div>
                       </div>
                       <Avatar
@@ -315,7 +318,7 @@ class Arbitration extends Component {
                   <div className="conversation-container">
                     <Conversation
                       id={origin.messaging.generateRoomId(
-                        web3Account,
+                        wallet.address,
                         buyer.address
                       )}
                       messages={messages
@@ -355,10 +358,10 @@ class Arbitration extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ messages, wallet }) => {
   return {
-    messages: state.messages,
-    web3Account: state.app.web3.account
+    messages,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/compact-messages.js
+++ b/origin-dapp/src/components/compact-messages.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import Message from 'components/message'
 
+import { formattedAddress } from 'utils/user'
+
 const MAX_MINUTES = 10
 
 function getElapsedTime(recentTime, previousTime) {
@@ -14,7 +16,7 @@ const CompactMessages = ({ messages = [] }) =>
   messages.map((message, i) => {
     const { senderAddress, created, hash } = message
     const previousMessage = i === 0 ? {} : messages[i - 1]
-    const sameSender = senderAddress === previousMessage.senderAddress
+    const sameSender = formattedAddress(senderAddress) === formattedAddress(previousMessage.senderAddress)
     const timeElapsed = getElapsedTime(created, previousMessage.created)
     const contentOnly = sameSender && timeElapsed < MAX_MINUTES
 

--- a/origin-dapp/src/components/conversation-list-item.js
+++ b/origin-dapp/src/components/conversation-list-item.js
@@ -5,6 +5,8 @@ import Avatar from 'components/avatar'
 import { getListing } from 'utils/listing'
 import { defineMessages, injectIntl } from 'react-intl'
 
+import { formattedAddress } from 'utils/user'
+
 class ConversationListItem extends Component {
   constructor(props) {
     super(props)
@@ -108,22 +110,22 @@ class ConversationListItem extends Component {
       active,
       conversation,
       handleConversationSelect,
+      mobileDevice,
       users,
-      web3Account,
-      mobileDevice
+      wallet
     } = this.props
     const { listing, lastMessage, createdAt } = this.state
 
     const { content, recipients, senderAddress } = lastMessage
-    const role = senderAddress === web3Account ? 'sender' : 'recipient'
+    const role = formattedAddress(senderAddress) === formattedAddress(wallet.address) ? 'sender' : 'recipient'
     const counterpartyAddress =
       role === 'sender'
-        ? recipients.find(addr => addr !== senderAddress)
+        ? recipients.find(addr => formattedAddress(addr) !== formattedAddress(senderAddress))
         : senderAddress
     const counterparty =
-      users.find(u => u.address === counterpartyAddress) || {}
+      users.find(u => formattedAddress(u.address) === formattedAddress(counterpartyAddress)) || {}
     const unreadCount = conversation.values.filter(msg => {
-      return msg.status === 'unread' && msg.senderAddress !== web3Account
+      return msg.status === 'unread' && formattedAddress(msg.senderAddress) !== formattedAddress(wallet.address)
     }).length
     const { profile } = counterparty
     const conversationItem = mobileDevice ? 'mobile-conversation-list-item' : `conversation-list-item${active ? ' active' : ''}`
@@ -136,7 +138,7 @@ class ConversationListItem extends Component {
         <Avatar image={profile && profile.avatar} placeholderStyle="blue" />
         <div className="content-container text-truncate">
           <div className="sender text-truncate">
-            <span>{counterparty.fullName || counterpartyAddress}</span>
+            <span>{counterparty.fullName || formattedAddress(counterpartyAddress)}</span>
           </div>
           { mobileDevice && <div className="listing-title text-truncate">{listing.name}</div> }
           <div className={`message text-truncate ${!listing.name ? 'no-listing' : ''}`}>{content}</div>
@@ -158,12 +160,12 @@ class ConversationListItem extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ app, users, wallet }) => {
   return {
-    users: state.users,
-    web3Account: state.app.web3.account,
-    mobileDevice: state.app.mobileDevice,
-    selectedLanguageCode: state.app.translations.selectedLanguageCode
+    mobileDevice: app.mobileDevice,
+    selectedLanguageCode: app.translations.selectedLanguageCode,
+    users,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/conversation.js
+++ b/origin-dapp/src/components/conversation.js
@@ -11,6 +11,7 @@ import PurchaseProgress from 'components/purchase-progress'
 
 import { getDataUri, generateCroppedImage } from 'utils/fileUtils'
 import { getListing } from 'utils/listing'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -155,10 +156,15 @@ class Conversation extends Component {
   }
 
   identifyCounterparty() {
-    const { fetchUser, id, users, web3Account } = this.props
+    const { fetchUser, id, users, wallet } = this.props
+
+    if (!id) {
+      return this.setState({ counterparty: {} })
+    }
+
     const recipients = origin.messaging.getRecipients(id)
-    const address = recipients.find(addr => addr !== web3Account)
-    const counterparty = users.find(u => u.address === address) || { address }
+    const address = recipients.find(addr => formattedAddress(addr) !== formattedAddress(wallet.address))
+    const counterparty = users.find(u => formattedAddress(u.address) === formattedAddress(address)) || { address }
 
     !counterparty.address && fetchUser(address)
 
@@ -180,7 +186,7 @@ class Conversation extends Component {
   }
 
   async loadPurchase() {
-    const { web3Account } = this.props
+    const { wallet } = this.props
     const { counterparty, listing, purchase } = this.state
 
     // listing may not be found
@@ -190,7 +196,7 @@ class Conversation extends Component {
 
     const offers = await origin.marketplace.getOffers(listing.id)
     const involvingCounterparty = offers.filter(
-      o => o.buyer === counterparty.address || o.buyer === web3Account
+      o => formattedAddress(o.buyer) === formattedAddress(counterparty.address) || formattedAddress(o.buyer) === formattedAddress(wallet.address)
     )
     const mostRecent = involvingCounterparty.sort(
       (a, b) => (a.createdAt > b.createdAt ? -1 : 1)
@@ -235,7 +241,7 @@ class Conversation extends Component {
   }
 
   render() {
-    const { id, intl, messages, web3Account, withListingSummary, mobileDevice } = this.props
+    const { id, intl, messages, mobileDevice, wallet, withListingSummary } = this.props
     const {
       counterparty,
       files,
@@ -246,18 +252,17 @@ class Conversation extends Component {
     const { name, pictures } = listing
     const { buyer, status } = purchase
     const perspective = buyer
-      ? buyer === web3Account
+      ? formattedAddress(buyer) === formattedAddress(wallet.address)
         ? 'buyer'
         : 'seller'
       : null
     const photo = pictures && pictures.length > 0 && pictures[0]
     const canDeliverMessage =
       counterparty.address &&
-      origin.messaging.canConverseWith(counterparty.address)
-    const shouldEnableForm =
-      origin.messaging.getRecipients(id).includes(web3Account) &&
-      canDeliverMessage &&
-      id
+      origin.messaging.canConverseWith(formattedAddress(counterparty.address))
+    const shouldEnableForm = id &&
+      origin.messaging.getRecipients(id).includes(formattedAddress(wallet.address)) &&
+      canDeliverMessage
 
     const classNames = mobileDevice ? 'justify-content-start' : 'justify-content-center'
 
@@ -387,10 +392,10 @@ class Conversation extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ users, wallet }) => {
   return {
-    users: state.users,
-    web3Account: state.app.web3.account
+    users,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/dropdowns/messages.js
+++ b/origin-dapp/src/components/dropdowns/messages.js
@@ -5,11 +5,13 @@ import { withRouter } from 'react-router'
 import { Link } from 'react-router-dom'
 import $ from 'jquery'
 
-import { dismissMessaging, enableMessaging, storeWeb3Intent } from 'actions/App'
+import { enableMessaging } from 'actions/Activation'
+import { dismissMessaging, storeWeb3Intent } from 'actions/App'
 
 import ConversationListItem from 'components/conversation-list-item'
 
 import groupByArray from 'utils/groupByArray'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../../services/origin'
 
@@ -62,9 +64,9 @@ class MessagesDropdown extends Component {
   }
 
   handleClick() {
-    const { intl, storeWeb3Intent, web3Account } = this.props
+    const { intl, storeWeb3Intent, wallet } = this.props
 
-    if (!web3Account) {
+    if (!wallet.address) {
       storeWeb3Intent(intl.formatMessage(this.intlMessages.viewMessages))
     }
 
@@ -72,9 +74,9 @@ class MessagesDropdown extends Component {
   }
 
   handleEnable() {
-    const { enableMessaging, intl, storeWeb3Intent, web3Account } = this.props
+    const { enableMessaging, intl, storeWeb3Intent, wallet } = this.props
 
-    if (web3Account) {
+    if (wallet.address) {
       enableMessaging()
     } else {
       storeWeb3Intent(intl.formatMessage(this.intlMessages.enableMessaging))
@@ -82,7 +84,7 @@ class MessagesDropdown extends Component {
   }
 
   render() {
-    const { conversations, history, messages, messagingEnabled } = this.props
+    const { conversations, history, messages, messagingEnabled, wallet } = this.props
 
     return (
       <div className="nav-item messages dropdown">
@@ -137,7 +139,8 @@ class MessagesDropdown extends Component {
               {!messagingEnabled &&
                 <button className="btn btn-sm btn-primary d-none d-md-block ml-auto" onClick={() => {
                   this.handleEnable()
-                  if(!this.props.web3Account) {
+
+                  if (!wallet.address) {
                     this.props.storeWeb3Intent('Enable messaging.')
                     origin.contractService.showLinkPopUp()
                   }
@@ -186,16 +189,14 @@ class MessagesDropdown extends Component {
   }
 }
 
-const mapStateToProps = ({ app, messages }) => {
-  const { messagingDismissed, messagingEnabled, web3 } = app
-  const web3Account = web3.account
+const mapStateToProps = ({ activation, app, messages, wallet }) => {
   const filteredMessages = messages.filter(
     ({ content, conversationId, senderAddress, status }) => {
       return (
         content &&
         status === 'unread' &&
-        senderAddress !== web3Account &&
-        origin.messaging.getRecipients(conversationId).includes(web3Account)
+        formattedAddress(senderAddress) !== formattedAddress(wallet.address) &&
+        origin.messaging.getRecipients(conversationId).includes(wallet.address)
       )
     }
   )
@@ -214,9 +215,9 @@ const mapStateToProps = ({ app, messages }) => {
   return {
     conversations: sortedConversations,
     messages: filteredMessages,
-    messagingDismissed,
-    messagingEnabled,
-    web3Account,
+    messagingDismissed: app.messagingDismissed,
+    messagingEnabled: activation.messaging.enabled,
+    wallet,
     web3Intent: web3.intent
   }
 }

--- a/origin-dapp/src/components/dropdowns/notifications.js
+++ b/origin-dapp/src/components/dropdowns/notifications.js
@@ -9,6 +9,8 @@ import { dismissNotifications } from 'actions/App'
 
 import Notification from 'components/notification'
 
+import { formattedAddress } from 'utils/user'
+
 class NotificationsDropdown extends Component {
   constructor(props) {
     super(props)
@@ -139,7 +141,7 @@ class NotificationsDropdown extends Component {
   }
 }
 
-const mapStateToProps = ({ app, notifications }) => {
+const mapStateToProps = ({ app, notifications, wallet }) => {
   return {
     // add perspective and filter
     notifications: notifications
@@ -148,7 +150,7 @@ const mapStateToProps = ({ app, notifications }) => {
 
         return {
           ...n,
-          perspective: app.web3.account === seller ? 'seller' : 'buyer'
+          perspective: formattedAddress(wallet.address) === formattedAddress(seller) ? 'seller' : 'buyer'
         }
       })
       .filter(n => n.status === 'unread'),

--- a/origin-dapp/src/components/identicon.js
+++ b/origin-dapp/src/components/identicon.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import IdenticonJS from 'identicon.js'
 
+import { formattedAddress } from 'utils/user'
+
 const Identicon = ({ address, size = 30 }) => {
   let data = null
   if (!address) {
@@ -8,7 +10,7 @@ const Identicon = ({ address, size = 30 }) => {
     data =
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='
   } else {
-    data = new IdenticonJS(address, size).toString()
+    data = new IdenticonJS(formattedAddress(address), size).toString()
   }
 
   return (

--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -7,10 +7,8 @@ import Form from 'react-jsonschema-form'
 
 import { showAlert } from 'actions/Alert'
 
-import {
-  handleNotificationsSubscription,
-  storeWeb3Intent
-} from 'actions/App'
+import { handleNotificationsSubscription } from 'actions/Activation'
+import { storeWeb3Intent } from 'actions/App'
 import {
   update as updateTransaction,
   upsert as upsertTransaction
@@ -29,9 +27,11 @@ import listingSchemaMetadata from 'utils/listingSchemaMetadata.js'
 import WalletCard from 'components/wallet-card'
 import { ProviderModal, ProcessingModal } from 'components/modals/wait-modals'
 
+import { getBoostLevel, defaultBoostValue } from 'utils/boostUtils'
 import { dappFormDataToOriginListing } from 'utils/listing'
 import { getFiatPrice } from 'utils/priceUtils'
-import { getBoostLevel, defaultBoostValue } from 'utils/boostUtils'
+import { formattedAddress } from 'utils/user'
+
 import {
   translateSchema,
   translateListingCategory
@@ -155,9 +155,11 @@ class ListingCreate extends Component {
   }
 
   ensureUserIsSeller(sellerAccount) {
-    const { web3Account } = this.props
+    const { wallet } = this.props
 
-    if ( web3Account && web3Account.toUpperCase() !== sellerAccount.toUpperCase()) {
+    if (
+      wallet.address &&
+      formattedAddress(wallet.address) !== formattedAddress(sellerAccount)) {
       alert('⚠️ Only the seller can update a listing')
       window.location.href = '/'
     }
@@ -243,7 +245,6 @@ class ListingCreate extends Component {
         this.setState({
           selectedSchemaType,
           schemaFetched: true,
-          step: this.STEP.DETAILS,
           fractionalTimeIncrement: !isFractionalListing ? null : 
             selectedSchemaType === 'housing' ? 'daily' : 'hourly',
           showNoSchemaSelectedError: false,
@@ -255,8 +256,6 @@ class ListingCreate extends Component {
             translatedSchema.properties.examples &&
             translatedSchema.properties.examples.enumNames
         })
-
-        window.scrollTo(0, 0)
       })
   }
 
@@ -1198,26 +1197,14 @@ class ListingCreate extends Component {
   }
 }
 
-const mapStateToProps = ({
-  app: {
-    messagingEnabled,
-    notificationsHardPermission,
-    notificationsSoftPermission,
-    pushNotificationsSupported,
-    serviceWorkerRegistration,
-    web3
-  }, exchangeRates, wallet
-}) => {
+const mapStateToProps = ({ activation, app, exchangeRates, wallet }) => {
   return {
     exchangeRates,
-    messagingEnabled,
-    notificationsHardPermission,
-    notificationsSoftPermission,
-    pushNotificationsSupported,
-    serviceWorkerRegistration,
+    messagingEnabled: activation.messaging.enabled,
+    pushNotificationsSupported: activation.notifications.pushEnabled,
+    serviceWorkerRegistration: activation.notifications.serviceWorkerRegistration,
     wallet,
-    web3Account: web3.account,
-    web3Intent: web3.intent
+    web3Intent: app.web3.intent
   }
 }
 

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -8,27 +8,27 @@ import {
   injectIntl
 } from 'react-intl'
 
-import { showAlert } from 'actions/Alert'
 import {
-  handleNotificationsSubscription,
-  storeWeb3Intent
-} from 'actions/App'
+  handleNotificationsSubscription } from 'actions/Activation'
+import { showAlert } from 'actions/Alert'
+import { storeWeb3Intent } from 'actions/App'
 import {
   update as updateTransaction,
   upsert as upsertTransaction
 } from 'actions/Transaction'
 
 import { PendingBadge, SoldBadge, FeaturedBadge } from 'components/badges'
+import Calendar from 'components/calendar'
 import Modal from 'components/modal'
+import { ProcessingModal, ProviderModal } from 'components/modals/wait-modals'
 import Reviews from 'components/reviews'
 import UserCard from 'components/user-card'
-import Calendar from './calendar'
-import { ProcessingModal, ProviderModal } from 'components/modals/wait-modals'
 
+import { prepareSlotsToSave } from 'utils/calendarHelpers'
 import getCurrentProvider from 'utils/getCurrentProvider'
 import { getListing, transformPurchasesOrSales } from 'utils/listing'
 import { offerStatusToListingAvailability } from 'utils/offer'
-import { prepareSlotsToSave } from 'utils/calendarHelpers'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -101,14 +101,14 @@ class ListingsDetail extends Component {
 
   componentDidUpdate(prevProps) {
     // on account found
-    if (this.props.web3Account && !prevProps.web3Account) {
+    if (this.props.wallet.address && !prevProps.wallet.address) {
       this.loadBuyerPurchases()
     }
   }
 
   async handleMakeOffer(skip, slotsToReserve) {
     // onboard if no identity, purchases, and not already completed
-    const { isFractional } = this.state
+    const {  } = this.state
     const shouldOnboard =
       !this.props.profile.strength &&
       !this.state.purchases.length &&
@@ -116,7 +116,7 @@ class ListingsDetail extends Component {
 
     this.props.storeWeb3Intent('purchase this listing')
 
-    if ((web3.givenProvider && this.props.web3Account) || origin.contractService.walletLinker) {
+    if ((web3.givenProvider && this.props.wallet.address) || origin.contractService.walletLinker) {
       if (!skip && shouldOnboard) {
         return this.setState({
           onboardingCompleted: true,
@@ -138,8 +138,7 @@ class ListingsDetail extends Component {
     this.setState({ step: this.STEP.METAMASK })
 
     const slots = slotsToReserve || this.state.slotsToReserve
-    const price =
-      isFractional ?
+    const price = this.state.isFractional ?
         slots.reduce((totalPrice, nextPrice) => totalPrice + nextPrice.price, 0).toString() :
         this.state.price
 
@@ -192,8 +191,8 @@ class ListingsDetail extends Component {
 
   async loadBuyerPurchases() {
     try {
-      const { web3Account } = this.props
-      const purchases = await origin.marketplace.getPurchases(web3Account)
+      const { wallet } = this.props
+      const purchases = await origin.marketplace.getPurchases(wallet.address)
       const transformedPurchases = transformPurchasesOrSales(purchases)
       this.setState({ purchases: transformedPurchases })
     } catch (error) {
@@ -245,7 +244,7 @@ class ListingsDetail extends Component {
   }
 
   render() {
-    const { web3Account } = this.props
+    const { wallet } = this.props
     const {
       // boostLevel,
       // boostValue,
@@ -287,8 +286,8 @@ class ListingsDetail extends Component {
      * true, and show "featured" badge.
      */
     const showFeaturedBadge = display === 'featured' && isAvailable
-    const userIsBuyer = currentOffer && web3Account === currentOffer.buyer
-    const userIsSeller = web3Account === seller
+    const userIsBuyer = currentOffer && formattedAddress(wallet.address) === formattedAddress(currentOffer.buyer)
+    const userIsSeller = formattedAddress(wallet.address) === formattedAddress(seller)
 
     return (
       <div className="listing-detail">
@@ -821,15 +820,15 @@ class ListingsDetail extends Component {
   }
 }
 
-const mapStateToProps = ({ app, profile }) => {
+const mapStateToProps = ({ activation, app, profile, wallet }) => {
   return {
-    messagingEnabled: app.messagingEnabled,
-    notificationsHardPermission: app.notificationsHardPermission,
-    notificationsSoftPermission: app.notificationsSoftPermission,
+    messagingEnabled: activation.messaging.enabled,
+    notificationsHardPermission: activation.notifications.permissions.hard,
+    notificationsSoftPermission: activation.notifications.permissions.soft,
     profile,
-    pushNotificationsSupported: app.pushNotificationsSupported,
-    serviceWorkerRegistration: app.serviceWorkerRegistration,
-    web3Account: app.web3.account,
+    pushNotificationsSupported: activation.notifications.pushEnabled,
+    serviceWorkerRegistration: activation.notifications.serviceWorkerRegistration,
+    wallet,
     web3Intent: app.web3.intent
   }
 }

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -108,7 +108,6 @@ class ListingsDetail extends Component {
 
   async handleMakeOffer(skip, slotsToReserve) {
     // onboard if no identity, purchases, and not already completed
-    const {  } = this.state
     const shouldOnboard =
       !this.props.profile.strength &&
       !this.state.purchases.length &&
@@ -159,7 +158,7 @@ class ListingsDetail extends Component {
         finalizes: 365 * 24 * 60 * 60
       }
 
-      if (isFractional) {
+      if (this.state.isFractional) {
         offerData.slots = prepareSlotsToSave(slots)
       } else {
         offerData.unitsPurchased = 1

--- a/origin-dapp/src/components/message-new.js
+++ b/origin-dapp/src/components/message-new.js
@@ -3,10 +3,12 @@ import { FormattedMessage } from 'react-intl'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 
-import { enableMessaging } from 'actions/App'
+import { enableMessaging } from 'actions/Activation'
 
 import Identicon from 'components/identicon'
 import Modal from 'components/modal'
+
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -74,7 +76,7 @@ class MessageNew extends Component {
           <h2>
             {'ETH Address:'}
             <br />
-            <span className="address">{recipientAddress}</span>
+            <span className="address">{formattedAddress(recipientAddress)}</span>
           </h2>
         </div>
         {/* Recipient needs to enable messaging. */}
@@ -150,9 +152,9 @@ class MessageNew extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ activation }) => {
   return {
-    messagingEnabled: state.app.messagingEnabled
+    messagingEnabled: activation.messaging.enabled
   }
 }
 

--- a/origin-dapp/src/components/message.js
+++ b/origin-dapp/src/components/message.js
@@ -3,10 +3,12 @@ import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { connect } from 'react-redux'
 
-import { enableMessaging } from 'actions/App'
+import { enableMessaging } from 'actions/Activation'
 import { updateMessage } from 'actions/Message'
 
 import Avatar from 'components/avatar'
+
+import { formattedAddress } from 'utils/user'
 
 const imageMaxSize = process.env.IMAGE_MAX_SIZE || (2 * 1024 * 1024) // 2 MiB
 
@@ -79,7 +81,7 @@ class Message extends Component {
           <div className="meta-container d-flex">
             <div className="sender text-truncate">
               {fullName && <span className="name">{fullName}</span>}
-              <span className="address text-muted">{address}</span>
+              <span className="address text-muted">{formattedAddress(address)}</span>
             </div>
             <div className="timestamp text-right ml-auto">
               {moment(created).format('MMM Do h:mm a')}
@@ -145,12 +147,13 @@ class Message extends Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = ({ activation, app, users }, ownProps) => {
   return {
-    messagingEnabled: state.app.messagingEnabled,
-    mobileDevice: state.app.mobileDevice,
-    user:
-      state.users.find(u => u.address === ownProps.message.senderAddress) || {}
+    messagingEnabled: activation.messaging.enabled,
+    mobileDevice: app.mobileDevice,
+    user: users.find(u => {
+      return formattedAddress(u.address) === formattedAddress(ownProps.message.senderAddress)
+    }) || {}
   }
 }
 

--- a/origin-dapp/src/components/messages.js
+++ b/origin-dapp/src/components/messages.js
@@ -74,13 +74,11 @@ class Messages extends Component {
     const filteredAndSorted = messages
       .filter(m => m.conversationId === selectedConversationId)
       .sort((a, b) => (a.created < b.created ? -1 : 1))
-
     const conversation = conversations.find((conv) => conv.key === selectedConversationId)
     const lastMessage = conversation && conversation.values.sort(
       (a, b) => (a.created < b.created ? -1 : 1)
     )[conversation.values.length - 1]
-
-    const { recipients, senderAddress } = lastMessage || {}
+    const { recipients, senderAddress } = lastMessage || { recipients: [] }
     const role = formattedAddress(senderAddress) === formattedAddress(wallet.address) ? 'sender' : 'recipient'
     const counterpartyAddress =
       role === 'sender'
@@ -185,7 +183,8 @@ const mapStateToProps = ({ activation, app, messages, users, wallet }) => {
     messagingEnabled: activation.messaging.enabled,
     mobileDevice,
     showNav,
-    users
+    users,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/my-listings.js
+++ b/origin-dapp/src/components/my-listings.js
@@ -28,7 +28,10 @@ class MyListings extends Component {
   }
 
   componentDidMount() {
-    if (this.props.web3Account && (web3.givenProvider || origin.contractService.walletLinker)) {
+    if (
+      this.props.wallet.address &&
+      (web3.givenProvider || origin.contractService.walletLinker)
+    ) {
       this.loadListings()
     } else if (!web3.givenProvider) {
       this.props.storeWeb3Intent('view your listings')
@@ -37,10 +40,10 @@ class MyListings extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { web3Account } = this.props
+    const { wallet } = this.props
 
     // on account change
-    if (web3Account && web3Account !== prevProps.web3Account) {
+    if (wallet.address && wallet.address !== prevProps.wallet.address) {
       this.loadListings()
     }
   }
@@ -49,7 +52,7 @@ class MyListings extends Component {
     try {
       const ids = await origin.marketplace.getListings({
         idsOnly: true,
-        listingsFor: this.props.web3Account
+        listingsFor: this.props.wallet.address
       })
       const listings = await Promise.all(
         ids.map(id => {
@@ -283,10 +286,10 @@ class MyListings extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ app, wallet }) => {
   return {
-    web3Account: state.app.web3.account,
-    web3Intent: state.app.web3.intent
+    wallet,
+    web3Intent: app.web3.intent
   }
 }
 

--- a/origin-dapp/src/components/my-purchases.js
+++ b/origin-dapp/src/components/my-purchases.js
@@ -17,7 +17,10 @@ class MyPurchases extends Component {
   }
 
   componentDidMount() {
-    if (this.props.web3Account && (web3.givenProvider || origin.contractService.walletLinker)) {
+    if (
+      this.props.wallet.address &&
+      (web3.givenProvider || origin.contractService.walletLinker)
+    ) {
       this.loadPurchases()
     } else {
       this.props.storeWeb3Intent('view your purchases')
@@ -26,17 +29,17 @@ class MyPurchases extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { web3Account } = this.props
+    const { wallet } = this.props
 
     // on account change
-    if (web3Account && web3Account !== prevProps.web3Account) {
+    if (wallet.address && wallet.address !== prevProps.wallet.address) {
       this.loadPurchases()
     }
   }
 
   async loadPurchases() {
-    const { web3Account } = this.props
-    const purchases = await origin.marketplace.getPurchases(web3Account)
+    const { wallet } = this.props
+    const purchases = await origin.marketplace.getPurchases(wallet.address)
     const transformedPurchases = transformPurchasesOrSales(purchases)
     this.setState({ loading: false, purchases: transformedPurchases })
   }
@@ -177,10 +180,10 @@ class MyPurchases extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ app, wallet }) => {
   return {
-    web3Account: state.app.web3.account,
-    web3Intent: state.app.web3.intent
+    wallet,
+    web3Intent: app.web3.intent
   }
 }
 

--- a/origin-dapp/src/components/my-sale-card.js
+++ b/origin-dapp/src/components/my-sale-card.js
@@ -11,6 +11,7 @@ import PurchaseProgress from 'components/purchase-progress'
 import UnnamedUser from 'components/unnamed-user'
 
 import { offerStatusToStep } from 'utils/offer'
+import { formattedAddress } from 'utils/user'
 
 class MySaleCard extends Component {
   constructor(props) {
@@ -93,7 +94,7 @@ class MySaleCard extends Component {
                   />
                 )}
               </h2>
-              <p className="address text-muted">{user.address}</p>
+              <p className="address text-muted">{formattedAddress(user.address)}</p>
               <div className="d-flex">
                 <p className="price">
                   <FormattedMessage

--- a/origin-dapp/src/components/my-sales.js
+++ b/origin-dapp/src/components/my-sales.js
@@ -19,7 +19,10 @@ class MySales extends Component {
   }
 
   componentDidMount() {
-    if (this.props.web3Account && (web3.givenProvider || origin.contractService.walletLinker)) {
+    if (
+      this.props.wallet.address &&
+      (web3.givenProvider || origin.contractService.walletLinker)
+    ) {
       this.loadPurchases()
     } else if (!web3.givenProvider) {
       this.props.storeWeb3Intent('view your sales')
@@ -28,17 +31,17 @@ class MySales extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { web3Account } = this.props
+    const { wallet } = this.props
 
     // on account change
-    if (web3Account && web3Account !== prevProps.web3Account) {
+    if (wallet.address && wallet.address !== prevProps.wallet.address) {
       this.loadPurchases()
     }
   }
 
   async loadPurchases() {
-    const { web3Account } = this.props
-    const sales = await origin.marketplace.getSales(web3Account)
+    const { wallet } = this.props
+    const sales = await origin.marketplace.getSales(wallet.address)
     const transformedSales = transformPurchasesOrSales(sales)
 
     this.setState({ loading: false, purchases: transformedSales })
@@ -179,10 +182,10 @@ class MySales extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ app, wallet }) => {
   return {
-    web3Account: state.app.web3.account,
-    web3Intent: state.app.web3.intent
+    wallet,
+    web3Intent: app.web3.intent
   }
 }
 

--- a/origin-dapp/src/components/navbar.js
+++ b/origin-dapp/src/components/navbar.js
@@ -161,10 +161,8 @@ class NavBar extends Component {
 
 const mapStateToProps = ({ app }) => {
   return {
-    web3Account: app.web3.account,
-    web3Intent: app.web3.intent,
-    showNav: app.showNav,
-    mobileDevice: app.mobileDevice
+    mobileDevice: app.mobileDevice,
+    showNav: app.showNav
   }
 }
 

--- a/origin-dapp/src/components/notification.js
+++ b/origin-dapp/src/components/notification.js
@@ -10,14 +10,16 @@ import { fetchUser } from 'actions/User'
 import NotificationMessage from 'components/notification-message'
 import UnnamedUser from 'components/unnamed-user'
 
+import { formattedAddress } from 'utils/user'
+
 class Notification extends Component {
   constructor(props) {
     super(props)
 
-    const { notification, web3Account } = this.props
+    const { notification, wallet } = this.props
     const { listing, purchase } = notification.resources
     const counterpartyAddress = [listing.seller, purchase.buyer].find(
-      addr => addr !== web3Account
+      addr => formattedAddress(addr) !== formattedAddress(wallet.address)
     )
 
     this.handleClick = this.handleClick.bind(this)
@@ -35,7 +37,7 @@ class Notification extends Component {
 
   componentDidUpdate() {
     const user = this.props.users.find(
-      u => u.address === this.state.counterpartyAddress
+      u => formattedAddress(u.address) === formattedAddress(this.state.counterpartyAddress)
     )
     const counterpartyName = user && user.fullName
 
@@ -113,8 +115,8 @@ class Notification extends Component {
                     </strong>: &nbsp;
                     {counterpartyName || <UnnamedUser />}
                   </div>
-                  <div className="text-truncate text-muted" title={counterpartyAddress}>
-                    {counterpartyAddress}
+                  <div className="text-truncate text-muted" title={formattedAddress(counterpartyAddress)}>
+                    {formattedAddress(counterpartyAddress)}
                   </div>
                 </div>
               )}
@@ -135,10 +137,10 @@ class Notification extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ users, wallet }) => {
   return {
-    users: state.users,
-    web3Account: state.app.web3.account
+    users,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/notifications.js
+++ b/origin-dapp/src/components/notifications.js
@@ -4,6 +4,8 @@ import { connect } from 'react-redux'
 
 import Notification from 'components/notification'
 
+import { formattedAddress } from 'utils/user'
+
 class Notifications extends Component {
   constructor(props) {
     super(props)
@@ -11,13 +13,13 @@ class Notifications extends Component {
   }
 
   render() {
-    const { notifications, web3Account } = this.props
+    const { notifications, wallet } = this.props
     const { filter } = this.state
     const notificationsWithPerspective = notifications.map(n => {
       const { seller } = n.resources.listing
       return {
         ...n,
-        perspective: web3Account === seller ? 'seller' : 'buyer'
+        perspective: formattedAddress(wallet.address) === formattedAddress(seller) ? 'seller' : 'buyer'
       }
     })
     const filteredNotifications =
@@ -110,10 +112,10 @@ class Notifications extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ notifications, wallet }) => {
   return {
-    notifications: state.notifications,
-    web3Account: state.app.web3.account
+    notifications,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/onboarding-modal/index.js
+++ b/origin-dapp/src/components/onboarding-modal/index.js
@@ -202,7 +202,11 @@ class OnboardingModal extends Component {
   }
 }
 
-const mapStateToProps = ({ onboarding, wallet, app }) => ({ onboarding, wallet, mobileDevice: app.mobileDevice })
+const mapStateToProps = ({ onboarding, wallet, app: { mobileDevice } }) => ({
+  mobileDevice,
+  onboarding,
+  wallet
+})
 const mapDispatchToProps = dispatch => ({
   fetchSteps: () => dispatch(fetchSteps()),
   getOgnBalance: () => dispatch(getOgnBalance()),

--- a/origin-dapp/src/components/onboarding-modal/panel-buttons.js
+++ b/origin-dapp/src/components/onboarding-modal/panel-buttons.js
@@ -85,7 +85,7 @@ export default class PanelButtons extends Component {
       'Origin Tokens': (
         <div className="col-auto">
           <Link
-            to="/about-tokens"
+            to="/about-tokens?skip-onboarding=true"
             target="_blank"
             ga-category="seller_onboarding"
             ga-label="learn_more_cta"

--- a/origin-dapp/src/components/purchase-detail.js
+++ b/origin-dapp/src/components/purchase-detail.js
@@ -4,7 +4,8 @@ import { Link } from 'react-router-dom'
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl'
 import $ from 'jquery'
 
-import { enableMessaging, storeWeb3Intent } from 'actions/App'
+import { enableMessaging } from 'actions/Activation'
+import { storeWeb3Intent } from 'actions/App'
 import {
   update as updateTransaction,
   upsert as upsertTransaction
@@ -38,6 +39,7 @@ import {
   offerStatusToStep
 } from 'utils/offer'
 import { translateSchema } from 'utils/translationUtils'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -588,7 +590,7 @@ class PurchaseDetail extends Component {
   }
 
   async initiateDispute() {
-    const { web3Account } = this.props
+    const { wallet } = this.props
     const { issue, listing, purchase } = this.state
 
     try {
@@ -616,9 +618,11 @@ class PurchaseDetail extends Component {
       })
 
       const counterpartyAddress =
-        web3Account === purchase.buyer ? listing.seller : purchase.buyer
+        formattedAddress(wallet.address === purchase.buyer) ?
+        listing.seller :
+        purchase.buyer
       const roomId = origin.messaging.generateRoomId(
-        web3Account,
+        wallet.address,
         counterpartyAddress
       )
       const keys = origin.messaging.getSharedKeys(roomId)
@@ -656,9 +660,9 @@ class PurchaseDetail extends Component {
   }
 
   handleEnableMessaging() {
-    const { enableMessaging, intl, storeWeb3Intent, web3Account } = this.props
+    const { enableMessaging, intl, storeWeb3Intent, wallet } = this.props
 
-    if (web3Account) {
+    if (wallet.address) {
       enableMessaging()
     } else {
       storeWeb3Intent(intl.formatMessage(this.intlMessages.enableMessaging))
@@ -684,7 +688,7 @@ class PurchaseDetail extends Component {
   }
 
   render() {
-    const { messagingEnabled, web3Account } = this.props
+    const { messagingEnabled, wallet } = this.props
     const {
       buyer,
       form,
@@ -709,9 +713,9 @@ class PurchaseDetail extends Component {
 
     let perspective
     // may potentially be neither buyer nor seller
-    if (web3Account === purchase.buyer) {
+    if (formattedAddress(wallet.address) === formattedAddress(purchase.buyer)) {
       perspective = 'buyer'
-    } else if (web3Account === listing.seller) {
+    } else if (formattedAddress(wallet.address) === formattedAddress(listing.seller)) {
       perspective = 'seller'
     }
 
@@ -757,7 +761,7 @@ class PurchaseDetail extends Component {
       <UnnamedUser />
     )
     const arbitrationIsAvailable =
-      ARBITRATOR_ACCOUNT && web3Account !== ARBITRATOR_ACCOUNT
+      ARBITRATOR_ACCOUNT && formattedAddress(wallet.address) !== formattedAddress(ARBITRATOR_ACCOUNT)
 
     return (
       <div className="purchase-detail">
@@ -883,8 +887,8 @@ class PurchaseDetail extends Component {
                           <SellerBadge />
                         </div>
                         <div className="name" title={sellerName}>{sellerName}</div>
-                        <div className="address text-muted text-truncate" title="{seller.address}">
-                          {seller.address}
+                        <div className="address text-muted text-truncate" title={formattedAddress(seller.address)}>
+                          {formattedAddress(seller.address)}
                         </div>
                       </div>
                     </div>
@@ -902,8 +906,8 @@ class PurchaseDetail extends Component {
                           <BuyerBadge />
                         </div>
                         <div className="name" title={buyerName}>{buyerName}</div>
-                        <div className="address text-muted text-truncate" title={buyer.address}>
-                          {buyer.address}
+                        <div className="address text-muted text-truncate" title={formattedAddress(buyer.address)}>
+                          {formattedAddress(buyer.address)}
                         </div>
                       </div>
                       <Avatar
@@ -1280,14 +1284,10 @@ class PurchaseDetail extends Component {
   }
 }
 
-const mapStateToProps = ({ app }) => {
-  const { messagingEnabled, web3 } = app
-  const web3Account = web3.account
-  return {
-    web3Account: web3Account,
-    messagingEnabled
-  }
-}
+const mapStateToProps = ({ activation, wallet }) => ({
+  messagingEnabled: activation.messaging.enabled,
+  wallet
+})
 
 const mapDispatchToProps = dispatch => ({
   updateTransaction: (confirmationCount, transactionReceipt) =>

--- a/origin-dapp/src/components/review.js
+++ b/origin-dapp/src/components/review.js
@@ -8,6 +8,8 @@ import { fetchUser } from 'actions/User'
 import Avatar from 'components/avatar'
 import UnnamedUser from 'components/unnamed-user'
 
+import { formattedAddress } from 'utils/user'
+
 class Review extends Component {
   componentWillMount() {
     this.props.fetchUser(this.props.review.reviewer)
@@ -29,7 +31,9 @@ class Review extends Component {
             />
             <div className="identification d-flex flex-column justify-content-center text-truncate">
               <div className="name">{fullName || <UnnamedUser />}</div>
-              <div className="address text-muted text-truncate" title={address}>{address}</div>
+              <div className="address text-muted text-truncate" title={formattedAddress(address)}>
+                {formattedAddress(address)}
+              </div>
             </div>
             <div className="rating d-flex flex-column justify-content-center text-right">
               <div className="stars">
@@ -59,7 +63,9 @@ class Review extends Component {
 
 const mapStateToProps = (state, { review }) => {
   return {
-    user: state.users.find(u => u.address === review.reviewer) || {}
+    user: state.users.find(u => {
+      return formattedAddress(u.address) === formattedAddress(review.reviewer)
+    }) || {}
   }
 }
 

--- a/origin-dapp/src/components/reviews.js
+++ b/origin-dapp/src/components/reviews.js
@@ -3,6 +3,8 @@ import { FormattedMessage, FormattedNumber } from 'react-intl'
 
 import Review from 'components/review'
 
+import { formattedAddress } from 'utils/user'
+
 import origin from '../services/origin'
 
 class Reviews extends Component {
@@ -36,7 +38,7 @@ class Reviews extends Component {
   render() {
     const { userAddress } = this.props
     const userReviews = this.state.reviews.filter(
-      r => r.reviewer !== userAddress
+      r => formattedAddress(r.reviewer) !== formattedAddress(userAddress)
     )
 
     return (

--- a/origin-dapp/src/components/user-card.js
+++ b/origin-dapp/src/components/user-card.js
@@ -12,6 +12,8 @@ import Identicon from 'components/identicon'
 import MessageNew from 'components/message-new'
 import UnnamedUser from 'components/unnamed-user'
 
+import { formattedAddress } from 'utils/user'
+
 import origin from '../services/origin'
 
 const { web3 } = origin.contractService
@@ -37,11 +39,11 @@ class UserCard extends Component {
 
   handleToggle(e) {
     e.preventDefault()
-    const { storeWeb3Intent, intl, web3Account } = this.props
+    const { storeWeb3Intent, intl, wallet } = this.props
     const intent = intl.formatMessage(this.intlMessages.sendMessages)
     storeWeb3Intent(intent)
 
-    if (web3.givenProvider && web3Account) {
+    if (web3.givenProvider && wallet.address) {
       this.setState({ modalOpen: !this.state.modalOpen })
     }
   }
@@ -53,7 +55,7 @@ class UserCard extends Component {
       title,
       user,
       userAddress,
-      web3Account
+      wallet
     } = this.props
     const { fullName, profile, attestations } = user
 
@@ -150,7 +152,7 @@ class UserCard extends Component {
           </div>
         </div>
         {userAddress &&
-          userAddress !== web3Account && (
+          formattedAddress(userAddress) !== formattedAddress(wallet.address) && (
           <a
             href="#"
             onClick={this.handleToggle}
@@ -191,14 +193,16 @@ class UserCard extends Component {
   }
 }
 
-const mapStateToProps = (state, { userAddress }) => {
+const mapStateToProps = ({ activation, users, wallet }, { userAddress }) => {
   return {
     // for reactivity
-    messagingEnabled: state.app.messagingEnabled,
+    messagingEnabled: activation.messaging.enabled,
     // for reactivity
-    messagingInitialized: state.app.messagingInitialized,
-    user: state.users.find(u => u.address === userAddress) || {},
-    web3Account: state.app.web3.account
+    messagingInitialized: activation.messaging.initialized,
+    user: users.find(u => {
+      return formattedAddress(u.address) === formattedAddress(userAddress)
+    }) || {},
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/wallet-card.js
+++ b/origin-dapp/src/components/wallet-card.js
@@ -14,6 +14,7 @@ import MessageNew from 'components/message-new'
 import UnnamedUser from 'components/unnamed-user'
 
 import { getFiatPrice } from 'utils/priceUtils'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -94,12 +95,11 @@ class WalletCard extends Component {
     const {
       users,
       wallet,
-      web3Account,
       withBalanceTooltip,
       withMenus,
       withProfile
     } = this.props
-    const user = users.find(u => u.address === wallet.address) || {}
+    const user = users.find(u => formattedAddress(u.address) === formattedAddress(wallet.address)) || {}
     const { attestations = [], fullName, profile = {} } = user
     const { address, ethBalance, ognBalance } = wallet
     const ethToUsdBalance = getFiatPrice(
@@ -107,7 +107,8 @@ class WalletCard extends Component {
       'USD'
     )
     const userCanReceiveMessages =
-      address !== web3Account && origin.messaging.canReceiveMessages(address)
+      formattedAddress(address) !== formattedAddress(wallet.address) && 
+      origin.messaging.canReceiveMessages(address)
     const balanceTooltip = `
       <div>
         <p class='tooltip-balance-heading tooltip-align-left'>
@@ -360,15 +361,15 @@ class WalletCard extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ activation, exchangeRates, users, wallet }) => {
   return {
+    exchangeRates,
     // for reactivity
-    messagingEnabled: state.app.messagingEnabled,
+    messagingEnabled: activation.messaging.enabled,
     // for reactivity
-    messagingInitialized: state.app.messagingInitialized,
-    users: state.users,
-    web3Account: state.app.web3.account,
-    exchangeRates: state.exchangeRates
+    messagingInitialized: activation.messaging.initialized,
+    users,
+    wallet
   }
 }
 

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -506,11 +506,11 @@ class Web3Provider extends Component {
   handleAccounts(accounts) {
     const { messagingInitialized, storeAccountAddress, wallet } = this.props
     const current = accounts[0]
-    const previous = formattedAddress(wallet.address)
+    const previous = wallet.address ? formattedAddress(wallet.address) : null
     const walletLinkerEnabled = origin.contractService.walletLinker
 
     // on account detection
-    if (formattedAddress(current) !== formattedAddress(previous)) {
+    if (formattedAddress(current) !== previous) {
       // TODO: fix this with some route magic!
       if (
         !walletLinkerEnabled ||
@@ -532,6 +532,9 @@ class Web3Provider extends Component {
 
       // update global state
       storeAccountAddress(current)
+    }
+
+    if (current && !messagingInitialized) {
       // trigger messaging service
       origin.messaging.onAccount(current)
     }

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -5,15 +5,16 @@ import { withRouter } from 'react-router'
 import clipboard from 'clipboard-polyfill'
 import QRCode from 'qrcode.react'
 
-import { storeWeb3Account, storeWeb3Intent, storeNetwork } from 'actions/App'
+import { storeWeb3Intent, storeNetwork } from 'actions/App'
 import { fetchProfile } from 'actions/Profile'
-import { getEthBalance } from 'actions/Wallet'
+import { getEthBalance, storeAccountAddress } from 'actions/Wallet'
 
 import Modal from 'components/modal'
 
+import getCurrentNetwork, { supportedNetworkId } from 'utils/currentNetwork'
 import detectMobile from 'utils/detectMobile'
 import getCurrentProvider from 'utils/getCurrentProvider'
-import getCurrentNetwork, { supportedNetworkId } from 'utils/currentNetwork'
+import { formattedAddress } from 'utils/user'
 
 import origin from '../services/origin'
 
@@ -503,20 +504,21 @@ class Web3Provider extends Component {
   }
 
   handleAccounts(accounts) {
-    const curr = accounts[0]
-    const prev = this.props.web3Account
+    const { messagingInitialized, storeAccountAddress, wallet } = this.props
+    const current = accounts[0]
+    const previous = formattedAddress(wallet.address)
     const walletLinkerEnabled = origin.contractService.walletLinker
 
     // on account detection
-    if (curr !== prev) {
+    if (formattedAddress(current) !== formattedAddress(previous)) {
       // TODO: fix this with some route magic!
-      if(
+      if (
         !walletLinkerEnabled ||
         ['/my-listings', '/my-purchases','/my-sales'].includes(this.props.location.pathname) ||
-        !curr
+        !current
       ) {
         // reload if changed from a prior account
-        prev !== null && window.location.reload()
+        previous !== null && window.location.reload()
       } else {
         // load data on account change
         this.props.fetchProfile()
@@ -525,19 +527,19 @@ class Web3Provider extends Component {
 
       // set user_id to wallet address in Google Analytics
       const gtag = window.gtag || function(){}
-      gtag('set', { 'user_id': curr })
+
+      gtag('set', { 'user_id': current })
 
       // update global state
-      this.props.storeWeb3Account(curr)
-
+      storeAccountAddress(current)
       // trigger messaging service
-      origin.messaging.onAccount(curr)
+      origin.messaging.onAccount(current)
     }
   }
 
   render() {
-    const { mobileDevice, web3Account, web3Intent, storeWeb3Intent } = this.props
-    const { networkConnected, networkId, currentProvider, linkerCode, linkerPopUp } = this.state
+    const { mobileDevice, wallet, web3Intent, storeWeb3Intent } = this.props
+    const { currentProvider, linkerCode, linkerPopUp, networkConnected, networkId } = this.state
     const currentNetwork = getCurrentNetwork(networkId)
     const currentNetworkName = currentNetwork
       ? currentNetwork.name
@@ -597,7 +599,7 @@ class Web3Provider extends Component {
         { /* attempting to use web3 without being signed in */
           web3Intent &&
           web3.givenProvider &&
-          web3Account === undefined && (
+          wallet.address === undefined && (
             <NoWeb3Account
               web3Intent={web3Intent}
               storeWeb3Intent={storeWeb3Intent}
@@ -611,20 +613,21 @@ class Web3Provider extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ({ activation, app, wallet }) => {
   return {
-    mobileDevice: state.app.mobileDevice,
-    web3Account: state.app.web3.account,
-    web3Intent: state.app.web3.intent
+    messagingInitialized: activation.messaging.initialized,
+    mobileDevice: app.mobileDevice,
+    wallet,
+    web3Intent: app.web3.intent
   }
 }
 
 const mapDispatchToProps = dispatch => ({
   fetchProfile: () => dispatch(fetchProfile()),
   getEthBalance: () => dispatch(getEthBalance()),
-  storeWeb3Account: addr => dispatch(storeWeb3Account(addr)),
-  storeWeb3Intent: intent => dispatch(storeWeb3Intent(intent)),
-  storeNetwork: networkId => dispatch(storeNetwork(networkId))
+  storeAccountAddress: addr => dispatch(storeAccountAddress(addr)),
+  storeNetwork: networkId => dispatch(storeNetwork(networkId)),
+  storeWeb3Intent: intent => dispatch(storeWeb3Intent(intent))
 })
 
 export default withRouter(

--- a/origin-dapp/src/css/app.css
+++ b/origin-dapp/src/css/app.css
@@ -2011,15 +2011,19 @@ textarea:-moz-ui-invalid {
 }
 
 .modal.getting-started.fade .modal-dialog {
-    bottom: -320px;
-    -webkit-transition: opacity 0.3s linear, bottom 0.3s ease-out;
-    -moz-transition: opacity 0.3s linear, bottom 0.3s ease-out;
-    -o-transition: opacity 0.3s linear, bottom 0.3s ease-out;
-    transition: opacity 0.3s linear, bottom 0.3s ease-out;
+  bottom: -320px;
+  -webkit-transition: opacity 0.3s linear, bottom 0.3s ease-out;
+  -moz-transition: opacity 0.3s linear, bottom 0.3s ease-out;
+  -o-transition: opacity 0.3s linear, bottom 0.3s ease-out;
+  transition: opacity 0.3s linear, bottom 0.3s ease-out;
 }
 
 .modal.getting-started.fade.show .modal-dialog {
-    bottom: 0;
+  bottom: 0;
+}
+
+.modal.getting-started.fade.show .modal-content {
+  margin-top: auto;
 }
 
 .getting-started img {

--- a/origin-dapp/src/pages/profile/Profile.js
+++ b/origin-dapp/src/pages/profile/Profile.js
@@ -173,7 +173,7 @@ class Profile extends Component {
       this.props.intl.formatMessage(this.intlMessages.manageYourProfile)
     )
 
-    if ((web3.givenProvider && this.props.web3Account) || origin.contractService.walletLinker) {
+    if ((web3.givenProvider && this.props.wallet.address) || origin.contractService.walletLinker) {
       const { modal } = e.currentTarget.dataset
 
       /*
@@ -500,7 +500,6 @@ class Profile extends Component {
         <VerifyFacebook
           open={modalsOpen.facebook}
           handleToggle={this.handleToggle}
-          account={wallet.address}
           onSuccess={data => {
             this.props.addAttestation(data)
             this.setState({
@@ -538,7 +537,6 @@ class Profile extends Component {
           open={modalsOpen.airbnb}
           handleToggle={this.handleToggle}
           intl={this.props.intl}
-          web3Account={this.props.web3Account}
           onSuccess={data => {
             this.props.addAttestation(data)
             this.setState({
@@ -716,7 +714,6 @@ const mapStateToProps = state => {
     profile: state.profile,
     identityAddress: state.profile.user.identityAddress,
     wallet: state.wallet,
-    web3Account: state.app.web3.account,
     web3Intent: state.app.web3.intent,
     networkId: state.app.web3.networkId,
     mobileDevice: state.app.mobileDevice

--- a/origin-dapp/src/pages/user/User.js
+++ b/origin-dapp/src/pages/user/User.js
@@ -9,6 +9,8 @@ import Reviews from 'components/reviews'
 import UnnamedUser from 'components/unnamed-user'
 import WalletCard from 'components/wallet-card'
 
+import { formattedAddress } from 'utils/user'
+
 class User extends Component {
   async componentDidMount() {
     fetchUser(this.props.userAddress)
@@ -139,7 +141,9 @@ class User extends Component {
 
 const mapStateToProps = (state, { userAddress }) => {
   return {
-    user: state.users.find(u => u.address === userAddress) || {}
+    user: state.users.find(u => {
+      return formattedAddress(u.address) === formattedAddress(userAddress)
+    }) || {}
   }
 }
 

--- a/origin-dapp/src/reducers/Activation.js
+++ b/origin-dapp/src/reducers/Activation.js
@@ -1,0 +1,90 @@
+import { ActivationConstants } from 'actions/Activation'
+
+const initialState = {
+  messaging: {
+    // whether or not a public key has been added to the global registry
+    enabled: false,
+    // whether or not the global keys have loaded
+    initialized: false,
+  },
+  notifications: {
+    permissions: {
+      // get existing permission state if feature detected
+      hard: 'Notification' in window ? Notification.permission : undefined,
+      // initial reponses before submitting native request
+      soft: localStorage.getItem('notificationsPermissionResponse')
+    },
+    pushEnabled: !!(process.env.NOTIFICATIONS_KEY && process.env.NOTIFICATIONS_URL),
+    serviceWorkerRegistration: null,
+    // which soft permission request prompt to display: buyer, seller, warning
+    subscriptionPrompt: null
+  }
+}
+
+export default function Activation(state = initialState, action = {}) {
+  switch (action.type) {
+
+  case ActivationConstants.MESSAGING_ENABLED:
+    return {
+      ...state,
+      messaging: {
+        ...state.messaging,
+        enabled: action.enabled
+      }
+    }
+
+  case ActivationConstants.MESSAGING_INITIALIZED:
+    return {
+      ...state,
+      messaging: {
+        ...state.messaging,
+        initialized: action.initialized
+      }
+    }
+
+  case ActivationConstants.NOTIFICATIONS_HARD_PERMISSION:
+    return {
+      ...state,
+      notifications: {
+        ...state.notifications,
+        permissions: {
+          ...state.notifications.permissions,
+          hard: action.result
+        }
+      }
+    }
+
+  case ActivationConstants.NOTIFICATIONS_SOFT_PERMISSION:
+    return {
+      ...state,
+      notifications: {
+        ...state.notifications,
+        permissions: {
+          ...state.notifications.permissions,
+          soft: action.result
+        }
+      }
+    }
+
+  case ActivationConstants.NOTIFICATIONS_SUBSCRIPTION_PROMPT:
+    return {
+      ...state,
+      notifications: {
+        ...state.notifications,
+        subscriptionPrompt: action.role
+      }
+    }
+
+  case ActivationConstants.SERVICE_WORKER_REGISTRATION:
+    return {
+      ...state,
+      notifications: {
+        ...state.notifications,
+        serviceWorkerRegistration: action.registration
+      }
+    }
+
+  default:
+    return state
+  }
+}

--- a/origin-dapp/src/reducers/App.js
+++ b/origin-dapp/src/reducers/App.js
@@ -4,22 +4,10 @@ const initialState = {
   betaModalDismissed: false,
   // a timestamp for when the messages dropdown was last closed
   messagingDismissed: null,
-  // whether or not a public key has been added to the global registry
-  messagingEnabled: false,
-  // whether or not the global keys have loaded
-  messagingInitialized: false,
   mobileDevice: null,
-  showNav: true,
   // a list of ids that were present last time the notifications dropdown was closed
   notificationsDismissed: [],
-  // get existing permission state if feature detected
-  notificationsHardPermission: 'Notification' in window ? Notification.permission : undefined,
-  // initial reponses before submitting native request
-  notificationsSoftPermission: localStorage.getItem('notificationsPermissionResponse'),
-  // which soft permission request prompt to display: buyer, seller, warning
-  notificationsSubscriptionPrompt: null,
-  pushNotificationsSupported: !!(process.env.NOTIFICATIONS_KEY && process.env.NOTIFICATIONS_URL),
-  serviceWorkerRegistration: null,
+  showNav: true,
   translations: {
     selectedLanguageCode: null,
     selectedLanguageFull: null,
@@ -27,7 +15,6 @@ const initialState = {
     messages: null
   },
   web3: {
-    account: null,
     intent: null,
     networkId: null
   }
@@ -41,32 +28,14 @@ export default function App(state = initialState, action = {}) {
   case AppConstants.MESSAGING_DISMISSED:
     return { ...state, messagingDismissed: action.closedAt }
 
-  case AppConstants.MESSAGING_ENABLED:
-    return { ...state, messagingEnabled: action.messagingEnabled }
-
-  case AppConstants.MESSAGING_INITIALIZED:
-    return { ...state, messagingInitialized: action.messagingInitialized }
-
   case AppConstants.NOTIFICATIONS_DISMISSED:
     return { ...state, notificationsDismissed: action.ids }
-
-  case AppConstants.NOTIFICATIONS_HARD_PERMISSION:
-    return { ...state, notificationsHardPermission: action.result }
-
-  case AppConstants.NOTIFICATIONS_SOFT_PERMISSION:
-    return { ...state, notificationsSoftPermission: action.result }
-
-  case AppConstants.NOTIFICATIONS_SUBSCRIPTION_PROMPT:
-    return { ...state, notificationsSubscriptionPrompt: action.role }
 
   case AppConstants.ON_MOBILE:
     return { ...state, mobileDevice: action.device }
 
   case AppConstants.SHOW_MAIN_NAV:
     return { ...state, showNav: action.showNav }
-
-  case AppConstants.SAVE_SERVICE_WORKER_REGISTRATION:
-    return { ...state, serviceWorkerRegistration: action.registration }
 
   case AppConstants.TRANSLATIONS:
     return {
@@ -78,9 +47,6 @@ export default function App(state = initialState, action = {}) {
         messages: action.messages
       }
     }
-
-  case AppConstants.WEB3_ACCOUNT:
-    return { ...state, web3: { ...state.web3, account: action.address } }
 
   case AppConstants.WEB3_INTENT:
     return { ...state, web3: { ...state.web3, intent: action.intent } }

--- a/origin-dapp/src/reducers/Users.js
+++ b/origin-dapp/src/reducers/Users.js
@@ -1,5 +1,7 @@
 import { UserConstants } from 'actions/User'
 
+import { formattedAddress } from 'utils/user'
+
 export default function Users(state = [], action = {}) {
   switch (action.type) {
   case UserConstants.FETCH_ERROR:
@@ -8,7 +10,7 @@ export default function Users(state = [], action = {}) {
   case UserConstants.FETCH_SUCCESS: {
     const { user } = action
     const users = [...state]
-    const i = users.findIndex(u => u.address === user.address)
+    const i = users.findIndex(u => formattedAddress(u.address) === formattedAddress(user.address))
     const { firstName, lastName } = user.profile || {}
     const userWithName = {
       ...user,
@@ -17,7 +19,9 @@ export default function Users(state = [], action = {}) {
 
     return i === -1
       ? [...users, userWithName]
-      : users.map(u => (u.address === user.address ? userWithName : u))
+      : users.map(u => (
+        formattedAddress(u.address) === formattedAddress(user.address) ? userWithName : u
+      ))
   }
 
   default:

--- a/origin-dapp/src/reducers/Wallet.js
+++ b/origin-dapp/src/reducers/Wallet.js
@@ -1,17 +1,17 @@
-import { ProfileConstants } from 'actions/Profile'
 import { WalletConstants } from 'actions/Wallet'
 
 const initialState = {
   address: undefined,
+  initialized: false,
   ethBalance: '0',
-  ognBalance: '0',
-  initialized: false
+  ognBalance: '0'
 }
 
 export default function Wallet(state = initialState, action = {}) {
   switch (action.type) {
-  case WalletConstants.INIT_SUCCESS:
-    return { ...state, address: action.address, initialized: true }
+
+  case WalletConstants.ACCOUNT_ADDRESS:
+    return { ...state, address: action.address, initialized: action.initialized }
 
   case WalletConstants.ETH_BALANCE_SUCCESS:
     return { ...state, ethBalance: action.ethBalance }
@@ -19,8 +19,6 @@ export default function Wallet(state = initialState, action = {}) {
   case WalletConstants.OGN_BALANCE_SUCCESS:
     return { ...state, ognBalance: action.ognBalance }
 
-  case ProfileConstants.FETCH_SUCCESS:
-    return { ...state, address: action.wallet }
   }
 
   return state

--- a/origin-dapp/src/utils/user.js
+++ b/origin-dapp/src/utils/user.js
@@ -1,0 +1,14 @@
+import origin from '../services/origin'
+
+const { web3 } = origin.contractService
+
+/**
+ * Takes an Ethereum address and formats it for reliable comparison or display
+ * e.g. 0x627306090abab3a6e1400e9345bc60c78a8bef57 becomes 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
+ * @param {string} an address in any case
+ * @return {string} a case-specific address (currently checksum)
+ */
+
+export function formattedAddress(string) {
+  return web3.utils.toChecksumAddress(string)
+}

--- a/origin-dapp/src/utils/user.js
+++ b/origin-dapp/src/utils/user.js
@@ -5,8 +5,9 @@ const { web3 } = origin.contractService
 /**
  * Takes an Ethereum address and formats it for reliable comparison or display
  * e.g. 0x627306090abab3a6e1400e9345bc60c78a8bef57 becomes 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
- * @param {string} an address in any case
+ * @param {string} an Ethereum address in any case
  * @return {string} a case-specific address (currently checksum)
+ * @throws {Error} if the input is not a valid Ethereum address
  */
 
 export function formattedAddress(string) {

--- a/origin-js/src/resources/messaging.js
+++ b/origin-js/src/resources/messaging.js
@@ -591,7 +591,10 @@ class Messaging {
   }
 
   generateRoomId(converser1, converser2) {
-    const keys = [converser1, converser2]
+    const keys = [
+      this.web3.utils.toChecksumAddress(converser1),
+      this.web3.utils.toChecksumAddress(converser2)
+    ]
     keys.sort()
 
     return keys.join('-')
@@ -864,19 +867,21 @@ class Messaging {
 
   canConverseWith(remote_eth_address) {
     const { account_key, global_keys } = this
+    const address = this.web3.utils.toChecksumAddress(remote_eth_address)
 
     return (
       this.canSendMessages() &&
-      account_key !== remote_eth_address &&
+      account_key !== address &&
       global_keys &&
-      global_keys.get(remote_eth_address)
+      global_keys.get(address)
     )
   }
 
   canReceiveMessages(remote_eth_address) {
     const { global_keys } = this
+    const address = this.web3.utils.toChecksumAddress(remote_eth_address)
 
-    return global_keys && global_keys.get(remote_eth_address)
+    return global_keys && global_keys.get(address)
   }
 
   canSendMessages() {


### PR DESCRIPTION
### 😇 Included:
- activation-related Redux state moved from `app` to `activation`
- new `formattedAddress` util added for comparison and display of Ethereum accounts
- prevention of listing creation step 1 skipping to step 2 before "Continue" is clicked
- consolidation of `app.web3.account` into previously-redundant `wallet.address`
- bug fix for when no "support" messaging account was enabled
- fix for https://github.com/OriginProtocol/origin/issues/1024
- prevention of modals when "about token" is visited from seller onboarding
- repair of seller onboarding modal vertical position
- enforcement of checksum format in messaging resource

### 😬 Tested:
- [x] listing creation without OGN
- [x] listing creation with OGN
- [x] blockchain transactions indicator
- [x] offer creation
- [x] offer withdrawal
- [x] offer rejection
- [x] offer acceptance
- [x] offer finalization
- [x] offer data addition
- [x] profile publication
- [x] phone attestation
- [x] email attestation
- [x] facebook attestation
- [x] twitter attestation

Looking for one ✅ but alerting others to changes; let me know if I can help resolve conflicts caused by this.