### PR TITLE
[origin-js unit tests] Pass thru cmd line args to mocha

### DIFF
--- a/origin-js/README.md
+++ b/origin-js/README.md
@@ -49,7 +49,7 @@ A browser-compatible plain javascript file `origin.js` is available in the [Rele
 
 ### Command Line (All Tests)
 
-Our full test suite can be run with:
+We use the [mocha test framework](https://mochajs.org/). The full test suite can be run with:
 
 ```
 npm run test
@@ -60,6 +60,11 @@ npm run test
 To run tests and automatically re-run when files change:
 ```
 npm run test:jsw
+```
+
+To run a subset of tests, you can use mocha's `-g` option followed by a pattern. For example to run the unit tests for the marketplace resource, do:
+```
+npm run test:js -g "Marketplace Resource"
 ```
 
 ## Troubleshooting

--- a/origin-js/scripts/test-js.js
+++ b/origin-js/scripts/test-js.js
@@ -5,12 +5,13 @@ const startIpfs = require('./helpers/start-ipfs')
 
 const startGanache = require('./helpers/start-ganache')
 
-const runTests = async watch => {
+const runTests = async cmdLineArgs => {
   return new Promise(() => {
-    const args = ['-r', '@babel/register', '-r', '@babel/polyfill', '-t', '10000']
-    if (watch) {
-      args.push('--watch')
-    } else {
+    const args = [
+      '-r', '@babel/register',
+      '-r', '@babel/polyfill',
+      '-t', '10000'].concat(cmdLineArgs)
+    if (!cmdLineArgs.includes('--watch')) {
       args.push('--exit')
     }
     args.push('test')
@@ -40,8 +41,9 @@ const start = async () => {
   console.log(chalk`\n{bold.hex('#6e3bea') ⬢  Deploying Smart Contracts }\n`)
   await deployContracts()
 
-  const watch = process.argv[2] && process.argv[2] == '--watch'
-  await runTests(watch)
+  // Pass to runTests any argument specified on the command line
+  // except argv[0] = <path>/node and argv[1] = <path>/test-js.js
+  await runTests(process.argv.slice(2))
 }
 
 start()


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:
Can be used for example to run a subset of tests:
> npm run test:js --prefix origin-js -- -g "Marketplace Resource"


### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [X] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
