### PR TITLE
Unsupported Network Repair 📡

### DIFF
--- a/origin-dapp/src/components/dapp-info.js
+++ b/origin-dapp/src/components/dapp-info.js
@@ -301,6 +301,10 @@ class DappInfo extends Component {
                   <td>{process.env.IPFS_SWARM}</td>
                 </tr>
                 <tr>
+                  <td>MAINNET_DAPP_BASEURL</td>
+                  <td>{process.env.MAINNET_DAPP_BASEURL}</td>
+                </tr>
+                <tr>
                   <td>MESSAGING_ACCOUNT</td>
                   <td>{process.env.MESSAGING_ACCOUNT}</td>
                 </tr>
@@ -327,6 +331,10 @@ class DappInfo extends Component {
                 <tr>
                   <td>REDUX_LOGGER</td>
                   <td>{process.env.REDUX_LOGGER}</td>
+                </tr>
+                <tr>
+                  <td>RINKEBY_DAPP_BASEURL</td>
+                  <td>{process.env.RINKEBY_DAPP_BASEURL}</td>
                 </tr>
 
                 <tr>

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -11,7 +11,10 @@ import { getEthBalance, storeAccountAddress } from 'actions/Wallet'
 
 import Modal from 'components/modal'
 
-import getCurrentNetwork, { supportedNetworkId } from 'utils/currentNetwork'
+import getCurrentNetwork, {
+  supportedNetwork,
+  supportedNetworkId
+} from 'utils/currentNetwork'
 import detectMobile from 'utils/detectMobile'
 import getCurrentProvider from 'utils/getCurrentProvider'
 import { formattedAddress } from 'utils/user'
@@ -208,7 +211,7 @@ const UnconnectedNetwork = () => (
 )
 
 const UnsupportedNetwork = props => {
-  const { currentProvider, networkId, currentNetworkName, supportedNetworkName } = props
+  const { currentNetworkName, currentProvider, networkId, supportedNetworkName } = props
   const url = new URL(window.location)
   const path = url.pathname + url.hash
   const goToUrl = (url) => () => window.location.href = url + path
@@ -350,7 +353,6 @@ class Web3Provider extends Component {
     this.handleAccounts = this.handleAccounts.bind(this)
     this.state = {
       networkConnected: null,
-      networkId: null,
       networkError: null,
       currentProvider: getCurrentProvider(web3),
       provider: null,
@@ -457,6 +459,7 @@ class Web3Provider extends Component {
    */
   fetchNetwork() {
     const providerExists = web3.currentProvider
+    const previousNetworkId = this.props.networkId
     const networkConnected =
       web3.currentProvider.connected ||
       (typeof web3.currentProvider.isConnected === 'function' &&
@@ -485,14 +488,11 @@ class Web3Provider extends Component {
           this.setState({
             networkError: err
           })
-        } else {
-          if (networkId !== this.state.networkId) {
-            this.props.storeNetwork(networkId)
-            this.setState({
-              networkError: null,
-              networkId
-            })
-          }
+        } else if (networkId !== previousNetworkId) {
+          this.props.storeNetwork(networkId)
+          this.setState({
+            networkError: null
+          })
         }
 
         if (!this.state.networkConnected) {
@@ -541,14 +541,13 @@ class Web3Provider extends Component {
   }
 
   render() {
-    const { mobileDevice, wallet, web3Intent, storeWeb3Intent } = this.props
-    const { currentProvider, linkerCode, linkerPopUp, networkConnected, networkId } = this.state
-    const currentNetwork = getCurrentNetwork(networkId)
-    const currentNetworkName = currentNetwork
-      ? currentNetwork.name
-      : networkId
+    const { mobileDevice, networkId, storeWeb3Intent, wallet, web3Intent } = this.props
+    const { currentProvider, linkerCode, linkerPopUp, networkConnected } = this.state
+    const currentNetwork = getCurrentNetwork(networkId) || {}
+    const currentNetworkName = currentNetwork.name || networkId
     const isProduction = process.env.NODE_ENV === 'production'
     const networkNotSupported = supportedNetworkId !== networkId
+    const supportedNetworkName = supportedNetwork && supportedNetwork.name
     const walletLinkerEnabled = origin.contractService.walletLinker
 
     return (
@@ -564,7 +563,12 @@ class Web3Provider extends Component {
           networkId &&
           isProduction &&
           networkNotSupported &&
-          <UnsupportedNetwork currentNetworkName={currentNetworkName} currentProvider={currentProvider} />
+          <UnsupportedNetwork
+            currentNetworkName={currentNetworkName}
+            currentProvider={currentProvider}
+            networkId={networkId}
+            supportedNetworkName={supportedNetworkName}
+          />
         }
 
         {/* attempting to use web3 in unsupported mobile browser */
@@ -620,6 +624,7 @@ const mapStateToProps = ({ activation, app, wallet }) => {
   return {
     messagingInitialized: activation.messaging.initialized,
     mobileDevice: app.mobileDevice,
+    networkId: app.web3.networkId,
     wallet,
     web3Intent: app.web3.intent
   }

--- a/origin-dapp/src/css/app.css
+++ b/origin-dapp/src/css/app.css
@@ -1684,6 +1684,10 @@ textarea:-moz-ui-invalid {
   cursor: pointer;
 }
 
+.web3-unavailable .modal-content .btn {
+  width: auto;
+}
+
 .onboarding .modal-backdrop {
   z-index: 1000;
 }


### PR DESCRIPTION
This adds a couple of environment variables to /dapp-info for debugging, but more importantly repairs the "wrong network" modal and consolidates the redundant storage of network id to Redux and not the component state.