### PR TITLE
[Faucet] Fix config

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/faucet.deployment.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: ENVKEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "eventlistener.fullname" . }}
+              name: {{ template "faucet.fullname" . }}
               key: ENVKEY
         ports:
         - containerPort: 5000

--- a/origin-faucet/faucet/app.js
+++ b/origin-faucet/faucet/app.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 try {
   require('envkey')
+  console.log("USING ENVKEY !")
 } catch (error) {
   console.log('EnvKey not configured')
 }
@@ -104,6 +105,9 @@ const config = {
     DEFAULT_NETWORK_ID
   ).split(',').map(parseInt),
 }
+
+
+console.log("process.env.NETWORK_IDS=", process.env.NETWORK_IDS)
 
 try {
   config.providers = Config.createProviders(config.networkIds)


### PR DESCRIPTION
### Description:

Faucet was using event-listener config which was causing it to bound to default network id 999.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
