### PR TITLE
[Disco server] Enable GraphQL playground in prod

### DIFF
--- a/origin-discovery/src/apollo/app.js
+++ b/origin-discovery/src/apollo/app.js
@@ -41,8 +41,9 @@ const server = new ApolloServer({
     listingMetadata.updateHiddenFeaturedListings()
     return {}
   },
-  // Always enable schema introspection, regardless of NODE_ENV value.
-  introspection: true
+  // Always enable GraphQL playground and schema introspection, regardless of NODE_ENV value.
+  introspection: true,
+  playground: true,
 })
 
 server.applyMiddleware({ app })


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:
GraphQL playground is disabled by default if NODE_ENV is set to production.
Enabling it since it is nice to run graphql queries in prod using the playground to debug things.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
