### PR TITLE
Increase integration tests timeouts

### DIFF
--- a/origin-tests/package.json
+++ b/origin-tests/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "mocha --timeout 10000 --exit test"
+    "test": "mocha --timeout 30000 --exit test"
   },
   "author": "Tom Linton <tom@originprotocol.com>",
   "license": "MIT",

--- a/origin-tests/test/1-create-listing.js
+++ b/origin-tests/test/1-create-listing.js
@@ -24,7 +24,10 @@ describe('create listing and retrieve using discovery', () => {
     await this.origin.marketplace.createListing(listingData)
 
     // Wait to allow event-listener to process listing
-    return new Promise(resolve => setTimeout(resolve, 5000))
+    // TODO: As opposed to sleeping for a fixed amount of time, it would make the tests
+    // run faster if we would poll the event-listener or the discovery server until the
+    // newly created listing is returned.
+    return new Promise(resolve => setTimeout(resolve, 20000))
   })
 
   it('should allow created listing to be retrieved from discovery', async () => {


### PR DESCRIPTION
### Description:
Increase delay between listing created and testing for discovery to return it to allow more time for the event-listener to process it.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
