### PR TITLE
Add post install symlinks for difficult packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,5 @@ COPY ./origin-messaging ./origin-messaging
 COPY ./origin-notifications ./origin-notifications
 COPY ./origin-tests ./origin-tests
 
-RUN ln -s ../../node_modules/scrypt origin-js/node_modules/scrypt
-RUN ln -s ../../node_modules/got origin-js/node_modules/got
-
 # Build origin-js for event-listener
 RUN npm run build --prefix origin-js

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "lerna run start --stream --parallel --scope origin --scope origin-dapp",
     "lint": "lerna run lint",
     "format": "eslint **/**/*.js --quiet --fix",
-    "postinstall": "npm run bootstrap",
+    "postinstall": "npm run bootstrap && node scripts/symlink-packages.js",
     "test": "node scripts/test.js"
   }
 }

--- a/scripts/symlink-packages.js
+++ b/scripts/symlink-packages.js
@@ -1,0 +1,7 @@
+// Symlinks packages for origin-js that don't play nicely with lerna --hoist
+
+const { exec } = require('child_process')
+
+exec('ln -s ../../node_modules/scrypt origin-js/node_modules/scrypt')
+exec('ln -s ../../node_modules/got origin-js/node_modules/got')
+


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- These packages don't seem to work well with hoisting so this creates symlinks from `origin-js/node_modules` to `node_modules/` in the root of the repo.
- This was handled for Docker Compose (I thought it was only a problem there) so the fix for that was removed in favour of a separate script.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
