### PR TITLE
Use block epoch to speed up origin.js unit tests

### DIFF
--- a/origin-js/test/resource_marketplace.test.js
+++ b/origin-js/test/resource_marketplace.test.js
@@ -104,7 +104,8 @@ describe('Marketplace Resource', function() {
       ipfsService,
       affiliate: validAffiliate,
       arbitrator: validArbitrator,
-      store
+      store,
+      blockEpoch: await web3.eth.getBlockNumber()
     })
 
     // Set default account for contract calls.

--- a/origin-js/test/resource_users.test.js
+++ b/origin-js/test/resource_users.test.js
@@ -68,7 +68,11 @@ describe('User Resource', function() {
       ipfsGatewayProtocol: 'http'
     })
     const attestations = new Attestations({ contractService })
-    users = new Users({ contractService, ipfsService })
+    users = new Users({
+      contractService,
+      ipfsService,
+      blockEpoch: await web3.eth.getBlockNumber()
+    })
 
     // clear user before each test because blockchain persists between tests
     // sort of a hack to force clean state at beginning of each test


### PR DESCRIPTION
This change adds the optional blockEpoch parameter to the origin.js
resources we use in our tests. This results in a substantial speed
increase for our tests, because they don't have to scan over blocks
generated by previous tests.

**This change seems to decreased Travis CI Origin.js unit test runtime from ~8 minutes to ~4.5 minutes.**

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
