### PR TITLE
Natasha/Prevent background scrolling for fixed modals

### DIFF
--- a/origin-dapp/src/actions/Onboarding.js
+++ b/origin-dapp/src/actions/Onboarding.js
@@ -25,6 +25,9 @@ export function toggleSplitPanel(show) {
 }
 
 export function unblock() {
+  document.body.classList.remove('modal-open')
+  document.body.style.overflow = 'auto'
+
   return { type: OnboardingConstants.UNBLOCK }
 }
 

--- a/origin-dapp/src/css/app.css
+++ b/origin-dapp/src/css/app.css
@@ -23,6 +23,12 @@ body {
   line-height: 1.5;
 }
 
+.modal-open {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+}
+
 /* sticky footer sibling */
 main {
   flex: 1 0 auto;

--- a/origin-dapp/src/css/app.css
+++ b/origin-dapp/src/css/app.css
@@ -23,12 +23,6 @@ body {
   line-height: 1.5;
 }
 
-.modal-open {
-  width: 100%;
-  height: 100%;
-  position: fixed;
-}
-
 /* sticky footer sibling */
 main {
   flex: 1 0 auto;
@@ -1506,6 +1500,11 @@ textarea:-moz-ui-invalid {
 }
 
 /* Modal */
+.modal-open {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+}
 
 .modal-backdrop {
   background-color: rgba(235, 240, 243, 0.6);


### PR DESCRIPTION
### Description:
[Issue #813](https://github.com/OriginProtocol/origin/issues/813)
[Issue #819](https://github.com/OriginProtocol/origin/issues/819)

We want to UI to blocked for modals except in specific cases (i.e. the getting started modal). The removal of JQuery now allows us to control whether we block the ui or not. I did not see a way through react-bootstrap to unblock the ui.

- When a `modal-open` class is applied, enforce not scrolling behind modals
- When `unblock` is called manually unblock the UI

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
