### PR TITLE
Natasha/only allow jpeg & png uploads

### DIFF
--- a/origin-dapp/src/components/conversation.js
+++ b/origin-dapp/src/components/conversation.js
@@ -371,6 +371,7 @@ class Conversation extends Component {
             />
             <input
               type="file"
+              accept="image/jpeg,image/gif,image/png"
               ref={this.fileInput}
               className="d-none"
               onChange={this.handleInput}

--- a/origin-dapp/src/pages/profile/EditProfile.js
+++ b/origin-dapp/src/pages/profile/EditProfile.js
@@ -144,6 +144,7 @@ class EditProfile extends Component {
                       <input
                         id="edit-profile-image"
                         type="file"
+                        accept="image/jpeg,image/gif,image/png"
                         ref={r => (this.editPic = r)}
                         style={{ opacity: 0, position: 'absolute', zIndex: -1, width: '30px' }}
                         onChange={e => {


### PR DESCRIPTION
### Description:
[Issue #817](https://github.com/OriginProtocol/origin/issues/817)

- only allow jpeg / png uploads
- Try to upload an image:
   - in a conversation
   - when creating or editing a listing
   - profile photo

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
