### PR TITLE
John/fractional bugs

### DIFF
--- a/origin-dapp/public/schemas/forRent-housing_1.0.0.json
+++ b/origin-dapp/public/schemas/forRent-housing_1.0.0.json
@@ -3,34 +3,18 @@
   "type": "object",
   "required": [
     "name",
-    "description"
+    "description",
+    "price"
   ],
   "properties": {
     "dappSchemaId": {
       "const": "https://dapp.originprotocol.com/schemas/forRent-housing_1.0.0.json"
     },
     "listingType": {
-      "const": "fractional"
+      "const": "unit"
     },
     "category": {
       "const": "schema.forRent"
-    },
-    "slotLength": {
-      "type": "integer",
-      "title": "schema.slotLength",
-      "default": 1
-    },
-    "slotLengthUnit": {
-      "type": "string",
-      "enum": [
-        "schema.minutes",
-        "schema.hours",
-        "schema.days",
-        "schema.weeks",
-        "schema.months",
-        "schema.years"
-      ],
-      "default": "schema.days"
     },
     "name": {
       "type": "string",
@@ -44,14 +28,6 @@
       "minLength": 10,
       "maxLength": 1024
     },
-    "pictures": {
-      "type": "array",
-      "title": "schema.selectPhotos",
-      "items": {
-        "type": "string",
-        "format": "data-url"
-      }
-    },
     "sellerSteps": {
       "type": "string",
       "title": "schema.sellerSteps",
@@ -62,7 +38,19 @@
       ]
     },
     "subCategory": {
-      "const": "schema.housing"
+      "const": "schema.furniture"
+    },
+    "price": {
+      "type": "number",
+      "title": "schema.priceInETH"
+    },
+    "pictures": {
+      "type": "array",
+      "title": "schema.selectPhotos",
+      "items": {
+        "type": "string",
+        "format": "data-url"
+      }
     }
   }
 }

--- a/origin-dapp/public/schemas/forRent-housing_1.0.0.json
+++ b/origin-dapp/public/schemas/forRent-housing_1.0.0.json
@@ -3,18 +3,34 @@
   "type": "object",
   "required": [
     "name",
-    "description",
-    "price"
+    "description"
   ],
   "properties": {
     "dappSchemaId": {
       "const": "https://dapp.originprotocol.com/schemas/forRent-housing_1.0.0.json"
     },
     "listingType": {
-      "const": "unit"
+      "const": "fractional"
     },
     "category": {
       "const": "schema.forRent"
+    },
+    "slotLength": {
+      "type": "integer",
+      "title": "schema.slotLength",
+      "default": 1
+    },
+    "slotLengthUnit": {
+      "type": "string",
+      "enum": [
+        "schema.minutes",
+        "schema.hours",
+        "schema.days",
+        "schema.weeks",
+        "schema.months",
+        "schema.years"
+      ],
+      "default": "schema.days"
     },
     "name": {
       "type": "string",
@@ -28,6 +44,14 @@
       "minLength": 10,
       "maxLength": 1024
     },
+    "pictures": {
+      "type": "array",
+      "title": "schema.selectPhotos",
+      "items": {
+        "type": "string",
+        "format": "data-url"
+      }
+    },
     "sellerSteps": {
       "type": "string",
       "title": "schema.sellerSteps",
@@ -39,18 +63,6 @@
     },
     "subCategory": {
       "const": "schema.housing"
-    },
-    "price": {
-      "type": "number",
-      "title": "schema.priceInETH"
-    },
-    "pictures": {
-      "type": "array",
-      "title": "schema.selectPhotos",
-      "items": {
-        "type": "string",
-        "format": "data-url"
-      }
     }
   }
 }

--- a/origin-dapp/public/schemas/forRent-housing_2.0.0.json
+++ b/origin-dapp/public/schemas/forRent-housing_2.0.0.json
@@ -3,18 +3,34 @@
   "type": "object",
   "required": [
     "name",
-    "description",
-    "price"
+    "description"
   ],
   "properties": {
     "dappSchemaId": {
-      "const": "https://dapp.originprotocol.com/schemas/forRent-jewelry_1.0.0.json"
+      "const": "https://dapp.originprotocol.com/schemas/forRent-housing_1.0.0.json"
     },
     "listingType": {
-      "const": "unit"
+      "const": "fractional"
     },
     "category": {
       "const": "schema.forRent"
+    },
+    "slotLength": {
+      "type": "integer",
+      "title": "schema.slotLength",
+      "default": 1
+    },
+    "slotLengthUnit": {
+      "type": "string",
+      "enum": [
+        "schema.minutes",
+        "schema.hours",
+        "schema.days",
+        "schema.weeks",
+        "schema.months",
+        "schema.years"
+      ],
+      "default": "schema.days"
     },
     "name": {
       "type": "string",
@@ -28,6 +44,14 @@
       "minLength": 10,
       "maxLength": 1024
     },
+    "pictures": {
+      "type": "array",
+      "title": "schema.selectPhotos",
+      "items": {
+        "type": "string",
+        "format": "data-url"
+      }
+    },
     "sellerSteps": {
       "type": "string",
       "title": "schema.sellerSteps",
@@ -38,19 +62,7 @@
       ]
     },
     "subCategory": {
-      "const": "schema.furniture"
-    },
-    "price": {
-      "type": "number",
-      "title": "schema.priceInETH"
-    },
-    "pictures": {
-      "type": "array",
-      "title": "schema.selectPhotos",
-      "items": {
-        "type": "string",
-        "format": "data-url"
-      }
+      "const": "schema.housing"
     }
   }
 }

--- a/origin-dapp/public/schemas/forRent-jewelry_2.0.0.json
+++ b/origin-dapp/public/schemas/forRent-jewelry_2.0.0.json
@@ -3,18 +3,34 @@
   "type": "object",
   "required": [
     "name",
-    "description",
-    "price"
+    "description"
   ],
   "properties": {
     "dappSchemaId": {
       "const": "https://dapp.originprotocol.com/schemas/forRent-jewelry_1.0.0.json"
     },
     "listingType": {
-      "const": "unit"
+      "const": "fractional"
     },
     "category": {
       "const": "schema.forRent"
+    },
+    "slotLength": {
+      "type": "integer",
+      "title": "schema.slotLength",
+      "default": 1
+    },
+    "slotLengthUnit": {
+      "type": "string",
+      "enum": [
+        "schema.minutes",
+        "schema.hours",
+        "schema.days",
+        "schema.weeks",
+        "schema.months",
+        "schema.years"
+      ],
+      "default": "schema.hours"
     },
     "name": {
       "type": "string",
@@ -28,6 +44,14 @@
       "minLength": 10,
       "maxLength": 1024
     },
+    "pictures": {
+      "type": "array",
+      "title": "schema.selectPhotos",
+      "items": {
+        "type": "string",
+        "format": "data-url"
+      }
+    },
     "sellerSteps": {
       "type": "string",
       "title": "schema.sellerSteps",
@@ -38,19 +62,7 @@
       ]
     },
     "subCategory": {
-      "const": "schema.furniture"
-    },
-    "price": {
-      "type": "number",
-      "title": "schema.priceInETH"
-    },
-    "pictures": {
-      "type": "array",
-      "title": "schema.selectPhotos",
-      "items": {
-        "type": "string",
-        "format": "data-url"
-      }
+      "const": "schema.housing"
     }
   }
 }

--- a/origin-dapp/src/components/arbitration.js
+++ b/origin-dapp/src/components/arbitration.js
@@ -168,8 +168,8 @@ class Arbitration extends Component {
               </div>
               <h1>
                 {listing.name}
-                {isPending && <PendingBadge />}
-                {isSold && <SoldBadge />}
+                {isPending && listing.listingType !== 'fractional' && <PendingBadge />}
+                {isSold && listing.listingType !== 'fractional' && <SoldBadge />}
                 {/*listing.boostLevel &&
                   <span className={ `boosted badge boost-${listing.boostLevel}` }>
                     <img src="images/boost-icon-arrow.svg" role="presentation" />

--- a/origin-dapp/src/components/calendar.js
+++ b/origin-dapp/src/components/calendar.js
@@ -227,7 +227,7 @@ class Calendar extends Component {
   }
 
   saveEvent(selectedEvent) {
-    const thisEvent = (selectedEvent && selectedEvent.id ? selectedEvent : false) || this.state.selectedEvent
+    const thisEvent = (selectedEvent && selectedEvent.id) ? selectedEvent : this.state.selectedEvent
     const allOtherEvents = this.state.events.filter((event) => event.id !== thisEvent.id)
     const stateToSet = {
       events: [...allOtherEvents, thisEvent],
@@ -246,6 +246,7 @@ class Calendar extends Component {
     })
   }
 
+  // used by seller's calendar only
   deleteEvent() {
     const confirmation = confirm('Are you sure you want to delete this event?')
     const { selectedEvent, events } = this.state
@@ -300,18 +301,24 @@ class Calendar extends Component {
   onDateDropdownChange(event) {
     const whichDropdown = event.target.name
     const value = event.target.value
+    const selectedEvent = {
+      ...this.state.selectedEvent,
+      slots: getSlotsForDateChange(this.state.selectedEvent, whichDropdown, value, this.props.viewType),
+      [whichDropdown]: new Date(value)
+    }
 
-    this.setState({
-      selectedEvent: {
-        ...this.state.selectedEvent,
-        slots: getSlotsForDateChange(this.state.selectedEvent, whichDropdown, value, this.props.viewType),
-        [whichDropdown]: new Date(value)
-      }
-    })
+    this.setState({ selectedEvent })
 
-    setTimeout(() => {
-      this.saveEvent(this.state.selectedEvent)
-    })
+    if (this.props.userType === 'seller') {
+      setTimeout(() => {
+        this.saveEvent(this.state.selectedEvent)
+      })
+    } else {
+      // user is buyer
+      setTimeout(() => {
+        this.onSelectSlot(this.state.selectedEvent)
+      })
+    }
   }
 
   onIsRecurringEventChange(event) {
@@ -443,7 +450,7 @@ class Calendar extends Component {
 
   render() {
     const selectedEvent = this.state.selectedEvent
-    const { viewType, userType } = this.props
+    const { viewType, userType, offers } = this.props
     const { events } = this.state
 
     return (
@@ -505,7 +512,14 @@ class Calendar extends Component {
                         onChange={ this.onDateDropdownChange }
                         value={ selectedEvent.start.toString() }>
                         { 
-                          getDateDropdownOptions(selectedEvent.start, viewType, selectedEvent, events).map((date) => (
+                          getDateDropdownOptions(
+                            selectedEvent.start,
+                            viewType,
+                            userType,
+                            selectedEvent,
+                            events,
+                            offers
+                          ).map((date) => (
                             ((viewType === 'daily' && date <= selectedEvent.end) ||
                             (viewType === 'hourly' && date < selectedEvent.end)) &&
                             <option
@@ -524,7 +538,14 @@ class Calendar extends Component {
                         onChange={ this.onDateDropdownChange }
                         value={selectedEvent.end.toString()}>
                         { 
-                          getDateDropdownOptions(selectedEvent.end, viewType, selectedEvent, events).map((date) => (
+                          getDateDropdownOptions(
+                            selectedEvent.end,
+                            viewType,
+                            userType,
+                            selectedEvent,
+                            events,
+                            offers
+                          ).map((date) => (
                             ((viewType === 'daily' && date >= selectedEvent.start) ||
                             (viewType === 'hourly' && date > selectedEvent.start)) &&
                             <option

--- a/origin-dapp/src/components/listing-card.js
+++ b/origin-dapp/src/components/listing-card.js
@@ -66,7 +66,8 @@ class ListingCard extends Component {
       pictures,
       price,
       status,
-      unitsRemaining
+      unitsRemaining,
+      listingType
     } = this.state
     const photo = pictures && pictures.length && pictures[0]
     const isPending = offers.find(
@@ -76,8 +77,8 @@ class ListingCard extends Component {
       o => offerStatusToListingAvailability(o.status) === 'sold'
     )
     const isWithdrawn = status === 'inactive'
-    const showPendingBadge = isPending && !isWithdrawn
-    const showSoldBadge = isSold || isWithdrawn
+    const showPendingBadge = isPending && !isWithdrawn && listingType !== 'fractional'
+    const showSoldBadge = isSold || isWithdrawn && listingType !== 'fractional'
     const showFeaturedBadge = this.state.display == 'featured' && !showSoldBadge && !showPendingBadge
 
     return (

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -273,8 +273,8 @@ class ListingsDetail extends Component {
     const isPending = currentOfferAvailability === 'pending'
     const isSold = currentOfferAvailability === 'sold'
     const isAvailable = !isPending && !isSold && !isWithdrawn
-    const showPendingBadge = isPending && !isWithdrawn
-    const showSoldBadge = isSold || isWithdrawn
+    const showPendingBadge = isPending && !isWithdrawn && !isFractional
+    const showSoldBadge = isSold || isWithdrawn && !isFractional
     /* When ENABLE_PERFORMANCE_MODE env var is set to false even the search result page won't
      * show listings with the Featured badge, because listings are loaded from web3. We could
      * pass along featured information from elasticsearch, but that would increase the code
@@ -584,7 +584,7 @@ class ListingsDetail extends Component {
                   */}
                 </div>
               )}
-              {!isAvailable && (
+              {!isAvailable && !isFractional && (
                 <div className="buy-box placehold unavailable text-center">
                   {!loading && (
                     <div className="reason">

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -490,7 +490,7 @@ class ListingsDetail extends Component {
               */}
             </div>
             <div className="col-12 col-md-4">
-              {isAvailable && ((!!price && !!parseFloat(price)) || isFractional) && (
+              {isAvailable && ((!!price && !!parseFloat(price)) || (isFractional && userIsSeller)) && (
                 <div className="buy-box placehold">
                   {!isFractional &&
                     <div className="price text-nowrap">

--- a/origin-dapp/src/components/purchase-detail.js
+++ b/origin-dapp/src/components/purchase-detail.js
@@ -791,8 +791,8 @@ class PurchaseDetail extends Component {
               />
               <h1>
                 {listing.name}
-                {isPending && <PendingBadge />}
-                {isSold && <SoldBadge />}
+                {isPending && listing.listingType !== 'fractional' && <PendingBadge />}
+                {isSold && listing.listingType !== 'fractional' && <SoldBadge />}
                 {/*!!listing.boostValue && (
                   <span className={`boosted badge boost-${listing.boostLevel}`}>
                     <img

--- a/origin-dapp/src/utils/calendarHelpers.js
+++ b/origin-dapp/src/utils/calendarHelpers.js
@@ -124,16 +124,17 @@ export function getSlotsForDateChange(selectedEvent, whichDropdown, value, viewT
   return slots
 }
 
-export function getDateDropdownOptions(date, viewType, selectedEvent, allEvents) {
+export function getDateDropdownOptions(date, viewType, userType, selectedEvent, allEvents, offers) {
   const numDatesToShow = 10
   const timeToAdd = viewType === 'daily' ? 'days' : 'hours'
   let beforeSelectedConflict
   let afterSelectedConflict
-  const eventsWithoutSelected = allEvents &&
-    allEvents.length &&
-    allEvents.filter((event) => event.id !== selectedEvent.id)
 
   const isSlotAvailable = (date) => {
+    const eventsWithoutSelected = allEvents &&
+      allEvents.length &&
+      allEvents.filter((event) => event.id !== selectedEvent.id)
+
     if (!eventsWithoutSelected || !eventsWithoutSelected.length) {
       return true
     }
@@ -151,7 +152,15 @@ export function getDateDropdownOptions(date, viewType, selectedEvent, allEvents)
     .map((_, i) => {
       const thisDate = moment(date).subtract(i + 1, timeToAdd).toDate()
       if (!beforeSelectedConflict) {
-        const isAvailable = isSlotAvailable(thisDate)
+        let isAvailable
+
+        if (userType === 'seller') {
+          isAvailable = isSlotAvailable(thisDate)
+        } else {
+          const availData = getDateAvailabilityAndPrice(thisDate, allEvents, offers)
+          isAvailable = availData.isAvailable
+        }
+
         if (isAvailable) {
           return thisDate
         } else {
@@ -166,8 +175,15 @@ export function getDateDropdownOptions(date, viewType, selectedEvent, allEvents)
     .reverse()
 
   if (viewType === 'hourly') {
-    const isNextSlotAvailable = isSlotAvailable(date)
-    if (!isNextSlotAvailable) {
+    let isAvailable
+
+    if (userType === 'seller') {
+      isAvailable = isSlotAvailable(date)
+    } else {
+      const availData = getDateAvailabilityAndPrice(date, allEvents, offers)
+      isAvailable = availData.isAvailable
+    }
+    if (!isAvailable) {
       afterSelectedConflict = true
     }
   }
@@ -176,7 +192,15 @@ export function getDateDropdownOptions(date, viewType, selectedEvent, allEvents)
     .map((_, i) => {
       const thisDate = moment(date).add(i + 1, timeToAdd).toDate()
       if (!afterSelectedConflict) {
-        const isAvailable = isSlotAvailable(thisDate)
+        let isAvailable
+
+        if (userType === 'seller') {
+          isAvailable = isSlotAvailable(thisDate)
+        } else {
+          const availData = getDateAvailabilityAndPrice(thisDate, allEvents, offers)
+          isAvailable = availData.isAvailable
+        }
+
         if (isAvailable) {
           return thisDate
         } else {

--- a/origin-dapp/src/utils/calendarHelpers.js
+++ b/origin-dapp/src/utils/calendarHelpers.js
@@ -353,8 +353,10 @@ export function getDateAvailabilityAndPrice(date, events, offers) {
         !moment(date).isBefore(moment().startOf('day'))
       ) {
 
-        event.isAvailable = event.isAvailable ? !isDateBooked(date) : false
-        eventsInSlot.push(event)
+        const eventClone = JSON.parse(JSON.stringify(event))
+
+        eventClone.isAvailable = eventClone.isAvailable ? !isDateBooked(date) : false
+        eventsInSlot.push(eventClone)
       }
     }
   }

--- a/origin-dapp/src/utils/listingSchemaMetadata.js
+++ b/origin-dapp/src/utils/listingSchemaMetadata.js
@@ -731,4 +731,13 @@ const listingSchemaMetadata = {
   }
 }
 
+// TODO(John) - 
+if (process.env.ENABLE_FRACTIONAL) {
+  listingSchemaMetadata.listingSchemasByCategory.forRent.forEach(schemaObj => {
+    if (schemaObj.schema === 'forRent-housing_1.0.0.json' || schemaObj.schema === 'forRent-jewelry_1.0.0.json') {
+      schemaObj.schema = schemaObj.schema.replace('1.0.0', '2.0.0')
+    }
+  })
+}
+
 export default listingSchemaMetadata

--- a/origin-js/src/models/offer.js
+++ b/origin-js/src/models/offer.js
@@ -23,9 +23,10 @@ export class Offer {
    *  - {string} schemaId - schema used to validate the offer
    *  - {string} listingType - 'unit', 'fractional'
    *  - {Object} ipfs - ipfs offer data
+   *  - {Array{Object}} - slots - fractional usage time slot data
    */
   constructor({ id, listingId, status, createdAt, buyer, events, refund, totalPrice, unitsPurchased, blockInfo,
-    schemaId, listingType, ipfs, commission }) {
+    schemaId, listingType, ipfs, commission, slots }) {
       this.id = id
       this.listingId = listingId
       this.status = status
@@ -40,6 +41,7 @@ export class Offer {
       this.listingType = listingType
       this.ipfs = ipfs
       this.commission = commission
+      this.slots = slots
   }
 
   // creates an Offer using on-chain and off-chain data
@@ -61,7 +63,8 @@ export class Offer {
       schemaId: ipfsData.schemaId,
       listingType: ipfsData.listingType,
       ipfs: ipfsData.ipfs,
-      commission: ipfsData.commission
+      commission: ipfsData.commission,
+      slots: ipfsData.slots
     })
   }
 
@@ -91,7 +94,8 @@ export class Offer {
       ipfs: discoveryNode.data.ipfs,
       // See https://github.com/OriginProtocol/origin/issues/1087
       // as to why we extract commission from the ipfs data.
-      commission: discoveryNode.data.ipfs.data.commission
+      commission: discoveryNode.data.ipfs.data.commission,
+      slots: discoveryNode.slots
     })
   }
 


### PR DESCRIPTION
### Description:

First round of Q4 fractional usage bug fixes

#### Bugs Fixed
- Fixes buyer's date dropdown menus
- Fixes bug on buyer's calendar that blocked off more time than the offers' slots had reserved
- Hides "pending" and "sold" messaging and badges for fractional listings (b/c they can accept multiple offers, so that messaging doesn't make sense)
- Other minor improvements

- @wanderingstan - this also stubs in fractional schemas for "For Rent Housing" and "For Rent Jewelry" as the "2.0.0" versions of those schamas, and the dapp uses those new schemas only if the `ENABLE_FRACTIONAL` env var is set to true. 

So, we should be able save ourselves some hassle by merging these schemas in and use them for local dev without messing up the production dapp.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
