### PR TITLE
Fix origin.js test

### DIFF
--- a/origin-js/src/resources/attestations.js
+++ b/origin-js/src/resources/attestations.js
@@ -1,5 +1,5 @@
 import AttestationObject from '../models/attestation'
-import RLP from 'rlp'
+import { encode as rlpEncode } from 'rlp'
 import UsersResolver from '../contractInterface/users/resolver'
 import Web3 from 'web3'
 
@@ -190,7 +190,7 @@ export class Attestations {
       })
     })
     const address =
-      '0x' + Web3.utils.sha3(RLP.encode([wallet, nonce])).substring(26, 66)
+      '0x' + Web3.utils.sha3(rlpEncode([wallet, nonce])).substring(26, 66)
     return Web3.utils.toChecksumAddress(address)
   }
 }


### PR DESCRIPTION
It looks like the RLP dependency recently had a new release where they
moved to TypeScript. I'm not clear on why that broke things, but `import
RLP from rlp` was setting `RLP` to `undefined. This fixes things I
believe.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
