### PR TITLE
Fix notification server errors

### DIFF
--- a/origin-notifications/src/app.js
+++ b/origin-notifications/src/app.js
@@ -120,6 +120,7 @@ app.post('/events', async (req, res) => {
 
   // Return 200 to the event-listener without
   // waiting for processing of the event.
+  res.json({ status: 'ok' })
   res.sendStatus(200)
 
   if (!listing || (!seller.address && !buyer.address)) {
@@ -196,7 +197,6 @@ app.post('/events', async (req, res) => {
       }
     }
   })
-  res.json({ status: 'ok' })
 })
 
 app.listen(port, () => console.log(`Notifications server listening on port ${port}!`))


### PR DESCRIPTION

### Description:

Fix this error that shows up in the server logs when processing a notification:
```
Info: Processing event eventName=OfferCreated blockNumber=3533915 logIndex=15
(node:77) UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:470:11)
    at ServerResponse.header (/app/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/app/node_modules/express/lib/response.js:170:12)
    at ServerResponse.json (/app/node_modules/express/lib/response.js:267:15)
    at app.post (/app/src/app.js:199:7)
```

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
