### PR TITLE
Increase TravisCI clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 git:
-  depth: 1
+  depth: 6
 matrix:
   include:
     # Run integration tests using docker compose


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Increase clone depth of TravisCI to avoid errors [like this one](https://travis-ci.org/OriginProtocol/origin/jobs/473940821) where another commit happens and the SHA required by Travis is no longer available because the clone depth of the repo was too small.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
