### PR TITLE
This allow wallet linker to on without showing the QR code on stage.

### DIFF
--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -402,6 +402,11 @@ class Web3Provider extends Component {
       {
         origin.contractService.walletLinker.preLinked(plink)
       }
+      const testWalletLinker = query['testWalletLinker']
+      if (testWalletLinker == '1')
+      {
+        origin.contractService.activeWalletLinker = true
+      }
     }
   }
 
@@ -529,7 +534,7 @@ class Web3Provider extends Component {
     const { messagingInitialized, storeAccountAddress, wallet } = this.props
     const current = accounts[0]
     const previous = wallet.address ? formattedAddress(wallet.address) : null
-    const walletLinkerEnabled = origin.contractService.walletLinker
+    const walletLinkerEnabled = origin.contractService.isActiveWalletLinker()
 
     // on account detection
     if (formattedAddress(current) !== previous) {
@@ -580,7 +585,7 @@ class Web3Provider extends Component {
     const isProduction = process.env.NODE_ENV === 'production'
     const networkNotSupported = supportedNetworkId !== networkId
     const supportedNetworkName = supportedNetwork && supportedNetwork.name
-    const walletLinkerEnabled = origin.contractService.walletLinker
+    const walletLinkerEnabled = origin.contractService.isActiveWalletLinker() 
 
     return (
       <Fragment>

--- a/origin-dapp/src/services/origin.js
+++ b/origin-dapp/src/services/origin.js
@@ -29,6 +29,7 @@ const attestationServerUrl = `${bridgeUrl}/api/attestations`
 const walletLinkerBaseUrl = mobilize(process.env.WALLET_LINKER_URL)
 const walletLinkerUrl = walletLinkerBaseUrl && `${walletLinkerBaseUrl}/api/wallet-linker`
 const ipfsSwarm = mobilize(process.env.IPFS_SWARM)
+const activeWalletLinker = process.env.SHOW_WALLET_LINKER
 
 // See: https://gist.github.com/bitpshr/076b164843f0414077164fe7fe3278d9#file-provider-enable-js
 const getWeb3 = () => {
@@ -95,6 +96,7 @@ const config = {
   blockAttestattionV1: process.env.BLOCK_ATTESTATION_V1,
   attestationServerUrl,
   walletLinkerUrl,
+  activeWalletLinker,
   ipfsCreator,
   OrbitDB,
   ecies,

--- a/origin-js/src/index.js
+++ b/origin-js/src/index.js
@@ -29,6 +29,7 @@ export default class Origin {
     attestationServerUrl = defaultAttestationServerUrl,
     discoveryServerUrl = defaultDiscoveryServerUrl,
     walletLinkerUrl = null,
+    activeWalletLinker = false,
     affiliate,
     arbitrator,
     contractAddresses,
@@ -47,7 +48,8 @@ export default class Origin {
     //
     // Services (Internal, should not be used directly by the Origin client).
     //
-    this.contractService = new ContractService({ contractAddresses, web3, ethereum, walletLinkerUrl, fetch, ecies })
+    this.contractService = new ContractService({ contractAddresses, web3, ethereum, walletLinkerUrl, 
+      activeWalletLinker, fetch, ecies })
     this.ipfsService = new IpfsService({
       ipfsDomain,
       ipfsApiPort,

--- a/origin-js/src/services/contract-service.js
+++ b/origin-js/src/services/contract-service.js
@@ -23,7 +23,7 @@ const SUPPORTED_ERC20 = [
 ]
 
 class ContractService {
-  constructor({ web3, contractAddresses, ethereum, walletLinkerUrl, fetch, ecies } = {}) {
+  constructor({ web3, contractAddresses, ethereum, walletLinkerUrl, activeWalletLinker, fetch, ecies } = {}) {
     const externalWeb3 = web3 || ((typeof window !== 'undefined') && window.web3)
     if (!externalWeb3) {
       throw new Error(
@@ -36,6 +36,7 @@ class ContractService {
     if (walletLinkerUrl && fetch){
       this.initWalletLinker(walletLinkerUrl, fetch, ecies)
     }
+    this.activeWalletLinker = activeWalletLinker
 
     this.marketplaceContracts = { V00_Marketplace }
 
@@ -94,6 +95,10 @@ class ContractService {
     this.web3.setProvider(this.walletLinker.getProvider())
     // Fake it till you make it
     this.web3.currentProvider.isOrigin = true
+  }
+
+  isActiveWalletLinker() {
+    return this.walletLinker && (this.walletLinker.linked || this.activeWalletLinker)
   }
 
   initWalletLinker(walletLinkerUrl, fetch, ecies) {
@@ -448,7 +453,7 @@ class ContractService {
     // set gas
     opts.gas = (opts.gas || (await method.estimateGas(opts))) + additionalGas
     const transactionReceipt = await new Promise((resolve, reject) => {
-      if (!opts.from && this.walletLinker && !this.walletLinker.linked) {
+      if (!opts.from && this.isActiveWalletLinker() && !this.walletLinker.linked) {
         opts.from = this.walletPlaceholderAccount()
       }
       const sendCallback = method

--- a/origin-mobile/ios/OriginCatcher/Info.plist
+++ b/origin-mobile/ios/OriginCatcher/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.3</string>
+	<string>0.1.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

currently if you want to link a wallet on stage, you need to set the WALLET_LINKER_URL on the dapp, but the problem is that setting the WALLET_LINKER_URL will show the QR code prompt on stage, which we probably don't want to do yet.


### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
