### PR TITLE
Make redis server used by origin-linking configurable

### DIFF
--- a/deployment/kubernetes/values/origin/values-dev.yaml
+++ b/deployment/kubernetes/values/origin/values-dev.yaml
@@ -22,7 +22,7 @@ faucetImageTag: '98315f6'
 
 # event-listener
 eventlistenerImage: event-listener
-eventlistenerImageTag: '299fede'
+eventlistenerImageTag: '5a87eef'
 
 # origin-discovery
 discoveryImage: origin-discovery

--- a/origin-linking/dot.env
+++ b/origin-linking/dot.env
@@ -5,6 +5,8 @@ APNS_TEAM_ID=<your team id goes here>
 
 DATABASE_URL=postgresql://localhost/origin
 
+REDIS_URL=redis://127.0.0.1:6379
+
 IPFS_API_PORT=5002
 IPFS_DOMAIN=localhost
 IPFS_GATEWAY_PORT=8080

--- a/origin-linking/src/utils/message-queue.js
+++ b/origin-linking/src/utils/message-queue.js
@@ -8,7 +8,7 @@ const PUBSUB_PREFIX = "ps."
 class MessageQueue {
   constructor({queueTimeout=24 * 3600, maxQueueSize = 255, redis = _redis} = {}) {
     // TODO: pass config in here, for now connect to local client
-    this.redis = redis.createClient()
+    this.redis = redis.createClient(process.env.REDIS_URL)
     this.redis_sub = this.redis.duplicate()
     this.queueTimeout = queueTimeout
     this.maxQueueSize = maxQueueSize


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Add an env var to allow configurable REDIS_URL

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs]~~(https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
