### PR TITLE
Make safari load the private params when it's on the same page

### DIFF
--- a/origin-dapp/dev.env
+++ b/origin-dapp/dev.env
@@ -28,4 +28,6 @@ NOTIFICATIONS_URL=http://localhost:3456
 
 # for origin-mobile
 MOBILE_LOCALHOST_IP=
+SHOW_WALLET_LINKER=true
+WALLET_LANDING_URL=https://www.originprotocol.com/mobile
 WALLET_LINKER_URL=http://localhost:3008

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -390,10 +390,30 @@ class Web3Provider extends Component {
 
   }
 
+  updateSearchWalletLinker() {
+    const { location } = this.props
+    const search = location.search || window.location.search
+
+    if(this.latestSearch != search) {
+      this.latestSearch = search
+      const query = queryString.parse(search)
+      const plink = query['plink']
+
+      if (plink) {
+        origin.contractService.walletLinker.preLinked(plink)
+      }
+      const testWalletLinker = query['testWalletLinker']
+      if (testWalletLinker == '1')
+      {
+        origin.contractService.activeWalletLinker = true
+      }
+    }
+  }
+
   getWalletReturnUrl() {
     const isMobileDevice = this.props.mobileDevice
     const now = this.props.location.pathname
-    
+
     if (isMobileDevice) {
       if (now.startsWith('/listing/'))
       {
@@ -414,8 +434,6 @@ class Web3Provider extends Component {
     } else {
       return ''
     }
-
-    
   }
 
   /**
@@ -435,22 +453,17 @@ class Web3Provider extends Component {
         origin.contractService.walletLinker.setLinkCode = this.setLinkerCode.bind(this)
       }
 
-      origin.contractService.walletLinker.showNextPage = this.showNextPage.bind(this)
       origin.contractService.walletLinker.getReturnUrl = this.getWalletReturnUrl.bind(this)
+      origin.contractService.walletLinker.showNextPage = this.showNextPage.bind(this)
+      this.updateSearchWalletLinker()
 
-      const { location } = this.props
-      const search = location.search || window.location.search
-      const query = queryString.parse(search)
-      const plink = query['plink']
+    }
+  }
 
-      if (plink) {
-        origin.contractService.walletLinker.preLinked(plink)
-      }
-      const testWalletLinker = query['testWalletLinker']
-      if (testWalletLinker == '1')
-      {
-        origin.contractService.activeWalletLinker = true
-      }
+  componentDidUpdate()
+  {
+    if (origin.contractService.walletLinker) {
+      this.updateSearchWalletLinker()
     }
   }
 

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -6,6 +6,8 @@ import clipboard from 'clipboard-polyfill'
 import QRCode from 'qrcode.react'
 import queryString from 'query-string'
 
+import { mobileDevice } from 'utils/mobile'
+
 import { storeWeb3Intent, storeNetwork } from 'actions/App'
 import { fetchProfile } from 'actions/Profile'
 import { getEthBalance, storeAccountAddress } from 'actions/Wallet'
@@ -388,6 +390,34 @@ class Web3Provider extends Component {
 
   }
 
+  getWalletReturnUrl() {
+    const isMobileDevice = this.props.mobileDevice
+    const now = this.props.location.pathname
+    
+    if (isMobileDevice) {
+      if (now.startsWith('/listing/'))
+      {
+        const url = new URL(window.location)
+        url.hash = '#/my-purchases'
+        return url.href
+      }
+      else if (now.startsWith('/create'))
+      {
+        const url = new URL(window.location)
+        url.hash = '#/my-listings'
+        return url.href
+      }
+      else
+      {
+        return window.location.href
+      }
+    } else {
+      return ''
+    }
+
+    
+  }
+
   /**
    * Start polling accounts and network. We poll indefinitely so that we can
    * react to the user changing accounts or networks.
@@ -406,9 +436,11 @@ class Web3Provider extends Component {
       }
 
       origin.contractService.walletLinker.showNextPage = this.showNextPage.bind(this)
+      origin.contractService.walletLinker.getReturnUrl = this.getWalletReturnUrl.bind(this)
 
       const { location } = this.props
-      const query = queryString.parse(location.search)
+      const search = location.search || window.location.search
+      const query = queryString.parse(search)
       const plink = query['plink']
 
       if (plink) {

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -6,8 +6,6 @@ import clipboard from 'clipboard-polyfill'
 import QRCode from 'qrcode.react'
 import queryString from 'query-string'
 
-import { mobileDevice } from 'utils/mobile'
-
 import { storeWeb3Intent, storeNetwork } from 'actions/App'
 import { fetchProfile } from 'actions/Profile'
 import { getEthBalance, storeAccountAddress } from 'actions/Wallet'
@@ -394,17 +392,19 @@ class Web3Provider extends Component {
     const { location } = this.props
     const search = location.search || window.location.search
 
-    if(this.latestSearch != search) {
+    if (this.latestSearch != search) {
       this.latestSearch = search
+
       const query = queryString.parse(search)
       const plink = query['plink']
 
       if (plink) {
         origin.contractService.walletLinker.preLinked(plink)
       }
+
       const testWalletLinker = query['testWalletLinker']
-      if (testWalletLinker == '1')
-      {
+
+      if (testWalletLinker == '1') {
         origin.contractService.activeWalletLinker = true
       }
     }
@@ -415,20 +415,19 @@ class Web3Provider extends Component {
     const now = this.props.location.pathname
 
     if (isMobileDevice) {
-      if (now.startsWith('/listing/'))
-      {
+      if (now.startsWith('/listing/')) {
         const url = new URL(window.location)
+
         url.hash = '#/my-purchases'
+
         return url.href
-      }
-      else if (now.startsWith('/create'))
-      {
+      } else if (now.startsWith('/create')) {
         const url = new URL(window.location)
+
         url.hash = '#/my-listings'
+
         return url.href
-      }
-      else
-      {
+      } else {
         return window.location.href
       }
     } else {
@@ -455,13 +454,12 @@ class Web3Provider extends Component {
 
       origin.contractService.walletLinker.getReturnUrl = this.getWalletReturnUrl.bind(this)
       origin.contractService.walletLinker.showNextPage = this.showNextPage.bind(this)
-      this.updateSearchWalletLinker()
 
+      this.updateSearchWalletLinker()
     }
   }
 
-  componentDidUpdate()
-  {
+  componentDidUpdate() {
     if (origin.contractService.walletLinker) {
       this.updateSearchWalletLinker()
     }
@@ -529,6 +527,7 @@ class Web3Provider extends Component {
     }
 
     const code = origin.contractService.getMobileWalletLink()
+    
     if (this.state.linkerCode != code) {
       // let's set the linker code
       this.setState({ linkerCode: code })

--- a/origin-js/src/resources/wallet-linker.js
+++ b/origin-js/src/resources/wallet-linker.js
@@ -426,7 +426,7 @@ export default class WalletLinker {
           if (this.msg_ws === ws) {
             this.syncLinkMessages()
           }
-        }, 60000) // check in 60 seconds
+        }, 30000) // check in 60 seconds
       }
     }
     this.msg_ws = ws

--- a/origin-js/src/resources/wallet-linker.js
+++ b/origin-js/src/resources/wallet-linker.js
@@ -55,6 +55,11 @@ export default class WalletLinker {
       })
 
       this.linked = linked
+
+      if (linked)
+      {
+        localStorage.setItem(LOCAL_KEY_STORE, priv_key)
+      }
       if (this.session_token != session_token)
       {
         this.session_token = session_token

--- a/origin-linking/src/logic/linker.js
+++ b/origin-linking/src/logic/linker.js
@@ -192,6 +192,7 @@ class Linker {
     // keys have to match
     if (linkedObj.clientPubKey != pubKey)
     {
+      console.log("Pub key: ", linkedObj.clientPubKey, " does not match: ", pubKey)
       linkedObj.clientPubKey = pubKey
       linkedObj.linked = false
     }

--- a/origin-mobile/ios/OriginCatcher/Info.plist
+++ b/origin-mobile/ios/OriginCatcher/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/origin-mobile/src/OriginWallet.js
+++ b/origin-mobile/src/OriginWallet.js
@@ -315,7 +315,7 @@ class OriginWallet {
       {
         if (return_url && this.copied_code == code)
         {
-          Linking.openURL(return_url)
+          Linking.openURL(this.toSaltedUrl(return_url))
         }
         else
         {
@@ -553,7 +553,7 @@ class OriginWallet {
             (success) => {
               if (return_url)
               {
-                Linking.openURL(return_url)
+                Linking.openURL(this.toSaltedUrl(return_url))
               }
               resolve(true)
             })
@@ -576,7 +576,7 @@ class OriginWallet {
                 if (return_url)
                 {
                   console.log("transaction approved returning to:", return_url)
-                  Linking.openURL(return_url)
+                  Linking.openURL(this.toSaltedUrl(return_url))
                 }
                 resolve(true)
               }
@@ -625,7 +625,7 @@ class OriginWallet {
               if (return_url)
               {
                 console.log("transaction approved returning to:", return_url)
-                Linking.openURL(return_url)
+                Linking.openURL(this.toSaltedUrl(return_url))
               }
               resolve(success)
             })
@@ -752,7 +752,7 @@ class OriginWallet {
       for (const link of links) {
         if (stored_link_id == link.link_id)
         {
-          return stored_link_id
+          return randomBytes(4).toString('hex') + stored_link_id
         }
       }
     }
@@ -773,9 +773,33 @@ class OriginWallet {
     return `${link_id}-${code}-${priv_key.toString('hex')}`
   }
 
+  toSaltedUrl(toUrl) {
+    const url = new URL(toUrl)
+    if (!url.search)
+    {
+      url.search = '?'
+    }
+    else
+    {
+      url.search += '&'
+    }
+    url.search += 'salt=' + randomBytes(4).toString('hex')
+    return url.href
+  }
+
   async toLinkedDappUrl(dappUrl) {
     const localUrl = localfy(dappUrl)
-    return localUrl + (localUrl.includes('?') ? '' : '?' ) + 'plink=' + await this.getPrivateLink()
+    const url = new URL(localUrl)
+    if (!url.search)
+    {
+      url.search = '?'
+    }
+    else
+    {
+      url.search += '&'
+    }
+    url.search += 'plink=' + await this.getPrivateLink()
+    return url.href
   }
 
   async openSelling() {

--- a/origin-mobile/src/OriginWallet.js
+++ b/origin-mobile/src/OriginWallet.js
@@ -315,7 +315,7 @@ class OriginWallet {
       {
         if (return_url && this.copied_code == code)
         {
-          Linking.openURL(this.toSaltedUrl(return_url))
+          Linking.openURL(return_url)
         }
         else
         {
@@ -553,7 +553,7 @@ class OriginWallet {
             (success) => {
               if (return_url)
               {
-                Linking.openURL(this.toSaltedUrl(return_url))
+                Linking.openURL(return_url)
               }
               resolve(true)
             })
@@ -576,7 +576,7 @@ class OriginWallet {
                 if (return_url)
                 {
                   console.log("transaction approved returning to:", return_url)
-                  Linking.openURL(this.toSaltedUrl(return_url))
+                  Linking.openURL(return_url)
                 }
                 resolve(true)
               }
@@ -625,7 +625,7 @@ class OriginWallet {
               if (return_url)
               {
                 console.log("transaction approved returning to:", return_url)
-                Linking.openURL(this.toSaltedUrl(return_url))
+                Linking.openURL(return_url)
               }
               resolve(success)
             })
@@ -773,33 +773,9 @@ class OriginWallet {
     return `${link_id}-${code}-${priv_key.toString('hex')}`
   }
 
-  toSaltedUrl(toUrl) {
-    const url = new URL(toUrl)
-    if (!url.search)
-    {
-      url.search = '?'
-    }
-    else
-    {
-      url.search += '&'
-    }
-    url.search += 'salt=' + randomBytes(4).toString('hex')
-    return url.href
-  }
-
   async toLinkedDappUrl(dappUrl) {
     const localUrl = localfy(dappUrl)
-    const url = new URL(localUrl)
-    if (!url.search)
-    {
-      url.search = '?'
-    }
-    else
-    {
-      url.search += '&'
-    }
-    url.search += 'plink=' + await this.getPrivateLink()
-    return url.href
+    return localUrl + (localUrl.includes('?') ? '' : '?' ) + 'plink=' + await this.getPrivateLink()
   }
 
   async openSelling() {

--- a/origin-mobile/src/OriginWallet.js
+++ b/origin-mobile/src/OriginWallet.js
@@ -846,13 +846,15 @@ class OriginWallet {
   }
 
   checkStripOriginUrl(url){
-    if (url.startsWith(ORIGIN_PROTOCOL_PREFIX))
+    const urlWithoutQueryParams = url.split('?')[0]
+    
+    if (urlWithoutQueryParams.startsWith(ORIGIN_PROTOCOL_PREFIX))
     {
-      return url.substr(ORIGIN_PROTOCOL_PREFIX.length)
+      return urlWithoutQueryParams.substr(ORIGIN_PROTOCOL_PREFIX.length)
     }
-    if (url.startsWith(SECURE_ORIGIN_PROTOCOL_PREFIX))
+    if (urlWithoutQueryParams.startsWith(SECURE_ORIGIN_PROTOCOL_PREFIX))
     {
-      return url.substr(SECURE_ORIGIN_PROTOCOL_PREFIX.length)
+      return urlWithoutQueryParams.substr(SECURE_ORIGIN_PROTOCOL_PREFIX.length)
     }
   }
 

--- a/origin-mobile/src/components/wallet-modal.js
+++ b/origin-mobile/src/components/wallet-modal.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { Alert, Clipboard, Image, Modal, SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Alert, Clipboard, Image, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { SafeAreaView } from 'react-navigation'
 import { connect } from 'react-redux'
 
 import Address from 'components/address'


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

When linking from the mobile wallet to safari, sometimes the search params will get lost and not link correctly this hopefully corrects that.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
