### PR TITLE
Add underscored: true to production for sequelize for origin-linking

### DIFF
--- a/origin-linking/src/config/config.js
+++ b/origin-linking/src/config/config.js
@@ -16,6 +16,9 @@ module.exports = {
     },
     'production': {
       'use_env_variable':'DATABASE_URL',
-      operatorsAliases: false
+      define: {
+        freezeTableName: true,
+        underscored: true
+      }
     }
   }


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Add underscored: true for production to it queries correct column names
- Removed operatorAliases option since I don't think it is needed, this prints on `origin-linking` start:

`(sequelize) Warning: A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.`

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs]~~(https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
