### PR TITLE
Add WALLET_LINKER_URL to webpack

### DIFF
--- a/origin-dapp/src/components/dapp-info.js
+++ b/origin-dapp/src/components/dapp-info.js
@@ -336,6 +336,10 @@ class DappInfo extends Component {
                   <td>RINKEBY_DAPP_BASEURL</td>
                   <td>{process.env.RINKEBY_DAPP_BASEURL}</td>
                 </tr>
+                <tr>
+                  <td>WALLET_LINKER_URL</td>
+                  <td>{process.env.WALLET_LINKER_URL}</td>
+                </tr>
 
                 <tr>
                   <th colSpan="2">Marketplace Contracts</th>

--- a/origin-dapp/webpack.config.js
+++ b/origin-dapp/webpack.config.js
@@ -41,7 +41,8 @@ const env = {
   NOTIFICATIONS_URL: 'https://notifications.originprotocol.com',
   PROVIDER_URL: null,
   REDUX_LOGGER: false,
-  RINKEBY_DAPP_BASEURL: 'https://demo.staging.originprotocol.com'
+  RINKEBY_DAPP_BASEURL: 'https://demo.staging.originprotocol.com',
+  WALLET_LINKER_URL: null
 }
 
 var config = {


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Add missing WALLET_LINKER_URL var to webpack config and dapp info screen

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
