### PR TITLE
Adding multi unit support to GraphQL

### DIFF
--- a/experimental/origin-admin/src/pages/accounts/_populate.js
+++ b/experimental/origin-admin/src/pages/accounts/_populate.js
@@ -202,7 +202,8 @@ export default async function populate(NodeAccount, gqlClient) {
           category: listing.category,
           subCategory: listing.subCategory,
           media: listing.media,
-          unitsTotal: listing.unitsTotal
+          unitsTotal: listing.unitsTotal,
+          isMultiUnit: listing.isMultiUnit
         }
       }
     })).data.createListing.id

--- a/experimental/origin-admin/src/pages/listings/Listing.js
+++ b/experimental/origin-admin/src/pages/listings/Listing.js
@@ -172,7 +172,7 @@ class Listing extends Component {
     const sellerPresent = accounts.find(
       a => listing.seller && a.id === listing.seller.id
     )
-    const units = listing.unitsTotal <= 1 ? '' : `${listing.unitsTotal} items `
+    const units = listing.unitsRemaining <= 1 ? '' : `${listing.unitsRemaining} items `
     return (
       <div style={{ marginBottom: 10 }}>
         {`${units}${listing.categoryStr} by `}

--- a/experimental/origin-admin/src/pages/listings/_ListingsList.js
+++ b/experimental/origin-admin/src/pages/listings/_ListingsList.js
@@ -75,7 +75,7 @@ const Listings = ({ listings, history }) => {
               {a.createdEvent ? formatDate(a.createdEvent.timestamp) : null}
             </td>
             <td>{a.totalEvents > 1 ? a.totalEvents : null}</td>
-            <td>{a.unitsTotal}</td>
+            <td>{a.unitsRemaining}</td>
           </tr>
         ))}
       </tbody>

--- a/experimental/origin-admin/src/pages/marketplace/mutations/CreateListing.js
+++ b/experimental/origin-admin/src/pages/marketplace/mutations/CreateListing.js
@@ -54,11 +54,13 @@ class CreateListing extends Component {
         from: seller ? seller.id : '',
         deposit: 0,
         category: props.listing.category || 'For Sale',
+        subCategory: props.listing.subCategory || '', // TODO: There's no subcategory dropdown in the modal yet
         description: props.listing.description || '',
         autoApprove: true,
         media,
         initialMedia: media,
-        unitsTotal: props.listing.unitsTotal
+        unitsTotal: props.listing.unitsTotal,
+        isMultiUnit: props.listing.isMultiUnit
       }
     } else {
       this.state = {
@@ -69,11 +71,13 @@ class CreateListing extends Component {
         from: seller ? seller.id : '',
         deposit: 5,
         category: '',
+        subCategory: '',
         description: '',
         autoApprove: true,
         media: [],
         initialMedia: [],
-        unitsTotal: 1
+        unitsTotal: 1,
+        isMultiUnit: false
       }
     }
   }
@@ -169,7 +173,7 @@ class CreateListing extends Component {
                   </FormGroup>
                 </div>
                 <div style={{ flex: 1 }}>
-                  <FormGroup label="Units">
+                  <FormGroup label="Total Units">
                     <InputGroup {...input('unitsTotal')} />
                   </FormGroup>
                 </div>
@@ -201,7 +205,7 @@ class CreateListing extends Component {
                   </FormGroup>
                 </div>
 
-                <div style={{ flex: 1, marginRight: 30, padding: '0 5px' }}>
+                <div style={{ flex: 1, padding: '0 5px' }}>
                   <FormGroup label="Deposit" labelInfo="(OGN)">
                     <Slider
                       fill={true}
@@ -214,12 +218,24 @@ class CreateListing extends Component {
                     />
                   </FormGroup>
                 </div>
-                <div style={{ flex: 1 }}>
+              </div>
+              <div style={{ display: 'flex' }}>
+                <div style={{ flex: 1, marginRight: 30 }}>
                   <FormGroup label="Auto-Approve">
                     <Checkbox
                       checked={this.state.autoApprove}
                       onChange={e =>
                         this.setState({ autoApprove: e.target.checked })
+                      }
+                    />
+                  </FormGroup>
+                </div>
+                <div style={{ flex: 1 }}>
+                  <FormGroup label="Multi Unit?">
+                    <Checkbox
+                      checked={this.state.isMultiUnit}
+                      onChange={e =>
+                        this.setState({ isMultiUnit: e.target.checked })
                       }
                     />
                   </FormGroup>
@@ -274,10 +290,12 @@ class CreateListing extends Component {
         title: '',
         price: '',
         category: '',
+        subCategory: '',
         description: '',
         media: [],
         initialMedia: [],
-        unitsTotal: 1
+        unitsTotal: 1,
+        isMultiUnit: false
       })
       return
     }
@@ -286,10 +304,12 @@ class CreateListing extends Component {
       title: egListing.title,
       price: egListing.price.amount,
       category: egListing.category,
+      subCategory: egListing.subCategory,
       description: egListing.description,
       media: egListing.media,
       initialMedia: egListing.media,
-      unitsTotal: egListing.unitsTotal
+      unitsTotal: egListing.unitsTotal,
+      isMultiUnit: egListing.isMultiUnit
     })
   }
 
@@ -305,8 +325,10 @@ class CreateListing extends Component {
           description: this.state.description,
           price: { currency: this.state.currency, amount: this.state.price },
           category: this.state.category,
+          subCategory: this.state.subCategory,
           media: this.state.media,
-          unitsTotal: Number(this.state.unitsTotal)
+          unitsTotal: Number(this.state.unitsTotal),
+          isMultiUnit: this.state.isMultiUnit
         }
       }
     }
@@ -324,8 +346,10 @@ class CreateListing extends Component {
           description: this.state.description,
           price: { currency: this.state.currency, amount: this.state.price },
           category: this.state.category,
+          subCategory: this.state.subCategory,
           media: this.state.media.map(m => pick(m, 'contentType', 'url')),
-          unitsTotal: Number(this.state.unitsTotal)
+          unitsTotal: Number(this.state.unitsTotal),
+          isMultiUnit: this.state.isMultiUnit
         }
       }
     }

--- a/experimental/origin-admin/src/pages/marketplace/mutations/_demoListings.js
+++ b/experimental/origin-admin/src/pages/marketplace/mutations/_demoListings.js
@@ -10,6 +10,7 @@ const HawaiiHouse = {
   description:
     "Built on the slopes of Hualalai Mountain in Kailua, Hawaii, the Mamalahoa Estate knows how to make a first impression. You enter the property through a grove of citrus and macadamia trees. A floating walkway takes you across a koi pond, surrounded by lush greenery and a waterfall. Once inside, the 5,391-square-foot home is comprised of a master and two guest suites, each with a private staircase leading down to the garden courtyard. A chef's kitchen with koa cabinetry looks onto a double-height living area. Flanked by sliding doors, the room opens to a veranda that overlooks two swimming pools and the Kona coastline. Consisting of 90 acres, the grounds also feature a driving range, tennis court, bocce courts, and a three-car garage.",
   unitsTotal: 1,
+  isMultiUnit: false,
   price: {
     currency: 'ETH',
     amount: '8.5'
@@ -54,6 +55,7 @@ const LakeHouse = {
   description:
     'Overlooking Lake Llanquihue, Casa Wulf is inspired by the terrain. The home sits on a steep slope. This lead to its three-story design, creating a natural balcony facing the water. Among the levels, the main living area is at the center, with the bedrooms above and a basement workshop below. Each floor was constructed using a different system, resulting in a range of facades. Their orientation takes advantage of the incoming sunlight and while also exposing the interiors to the surrounding landscape.',
   unitsTotal: 1,
+  isMultiUnit: false,
   price: {
     currency: 'ETH',
     amount: '1.5'
@@ -98,6 +100,7 @@ const Car = {
   description:
     "Introduced in 1971, the International Scout II rode on a stretched-wheelbase version of the rugged Scout chassis as a competitor to trucks like the larger Chevrolet Blazer. The highly customizable Scout was popular for work and racing, taking home a class win in the 1977 Baja 1000. This restored beautifully restored 1977 Scout II's customizations run more than skin deep, with a 6.0-liter GM engine and transmission to go along with the wheels and suspension lift.",
   unitsTotal: 1,
+  isMultiUnit: false,
   price: {
     currency: 'ETH',
     amount: '0.6'
@@ -138,6 +141,7 @@ const TaylorSwiftTickets = {
   description:
     "Taylor Swift's Reputation Stadium Tour is the fifth world concert tour by American singer-songwriter Taylor Swift, in support of her sixth studio album, Reputation.",
   unitsTotal: 10,
+  isMultiUnit: true,
   price: {
     currency: 'ETH',
     amount: '0.3'
@@ -182,6 +186,7 @@ const ZincHouse = {
   description:
     'Overlooking Lake Llanquihue, Casa Wulf is inspired by the terrain. The home sits on a steep slope. This lead to its three-story design, creating a natural balcony facing the water. Among the levels, the main living area is at the center, with the bedrooms above and a basement workshop below. Each floor was constructed using a different system, resulting in a range of facades. Their orientation takes advantage of the incoming sunlight and while also exposing the interiors to the surrounding landscape.',
   unitsTotal: 1,
+  isMultiUnit: false,
   price: {
     currency: 'ETH',
     amount: '3.999'

--- a/experimental/origin-admin/src/queries/Fragments.js
+++ b/experimental/origin-admin/src/queries/Fragments.js
@@ -37,10 +37,15 @@ export default {
 
         category
         categoryStr
+        subCategory
         title
         description
         currencyId
         unitsTotal
+        unitsRemaining
+        unitsSold
+        unitsPending
+        isMultiUnit
         featured
         hidden
         price {

--- a/experimental/origin-dapp2/src/pages/create-listing/mutations/CreateListing.js
+++ b/experimental/origin-dapp2/src/pages/create-listing/mutations/CreateListing.js
@@ -66,7 +66,8 @@ class CreateListing extends Component {
           category: listing.category,
           subCategory: listing.subCategory,
           media: listing.media,
-          unitsTotal: Number(listing.quantity)
+          unitsTotal: Number(listing.quantity),
+          isMultiUnit: Number(listing.quantity) > 1
         },
         autoApprove: true
       }

--- a/experimental/origin-dapp2/src/pages/create-listing/mutations/UpdateListing.js
+++ b/experimental/origin-dapp2/src/pages/create-listing/mutations/UpdateListing.js
@@ -66,7 +66,8 @@ class UpdateListing extends Component {
           category: listing.category,
           subCategory: listing.subCategory,
           media: listing.media || [],
-          unitsTotal: Number(listing.quantity)
+          unitsTotal: Number(listing.quantity),
+          isMultiUnit: Number(listing.quantity) > 1
         },
         autoApprove: true
       }

--- a/experimental/origin-dapp2/src/queries/Fragments.js
+++ b/experimental/origin-dapp2/src/queries/Fragments.js
@@ -42,6 +42,10 @@ export default {
         description
         currencyId
         unitsTotal
+        unitsRemaining
+        unitsPending
+        unitsSold
+        isMultiUnit
         featured
         hidden
         price {

--- a/experimental/origin-graphql/src/mutations/marketplace/createListing.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/createListing.js
@@ -15,6 +15,7 @@ export function listingInputToIPFS(data) {
     description: data.description,
     media: data.media,
     unitsTotal: data.unitsTotal,
+    isMultiUnit: data.isMultiUnit,
     price: data.price,
     commission: {
       currency: 'OGN',

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -175,6 +175,9 @@ export default `
     status: String
     hidden: Boolean
     featured: Boolean
+    unitsRemaining: Int
+    unitsPending: Int
+    unitsSold: Int
 
     # IPFS
     title: String
@@ -185,6 +188,7 @@ export default `
     subCategory: String
     categoryStr: String
     unitsTotal: Int
+    isMultiUnit: Boolean
     media: [Media]
   }
 
@@ -228,6 +232,7 @@ export default `
     subCategory: String
     currency: String
     price: PriceInput
+    isMultiUnit: Boolean
     unitsTotal: Int
     media: [MediaInput]
   }


### PR DESCRIPTION
### Description:

Allowing GraphQL to support `isMultiUnit` boolean, and a few other `unit`-related counts.

Also needed to add a couple of other things for some basic functionality to continue working.

Fixes #1162

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)

### Screenshots:

Here's the admin create/update listing modal:

<img width="750" alt="screen shot 2019-01-06 at 08 24 50" src="https://user-images.githubusercontent.com/1239616/50735601-cc862780-11a9-11e9-8838-f29e93d71101.png">
