### PR TITLE
Hacky fix to allow for all return value types from discovery or the bc

### DIFF
--- a/origin-js/src/resources/marketplace.js
+++ b/origin-js/src/resources/marketplace.js
@@ -64,9 +64,27 @@ export default class Marketplace {
       withBlockInfo: true
     })
 
-    return listings
+    return listings && listings.length && listings
       .map(listing => listing.offers)
-      .reduce((offers = [], offerArr) => offers = [...offers, ...offerArr])
+      .reduce((offers=[], offersCur) => { 
+        //cover all cases
+        if (Array.isArray(offersCur) && Array.isArray(offers))
+        {
+          return [...offers, ...offersCur]
+        }
+        else if (Array.isArray(offerCur))
+        {
+          return [offers, ...offersCur]
+        }
+        else if (Array.isArray(offers))
+        {
+          return [...offers, offersCur]
+        }
+        else
+        {
+          return [offers, offersCur]
+        }
+      })
       // only keep the purchases where user identified by `account` is the buyer
       .filter(offer => offer.buyer === account)
       .map(offer => {
@@ -74,7 +92,7 @@ export default class Marketplace {
           offer,
           listing: listings.find(listing => listing.id === offer.listingId)
         }
-      })
+      }) || []
   }
 
   /**


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- Fix to allow all different return types for offers from getListings to work.


### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
