### PR TITLE
Sparrow dom/multi unit fixes

### DIFF
--- a/origin-dapp/src/components/listing-card-prices.js
+++ b/origin-dapp/src/components/listing-card-prices.js
@@ -72,7 +72,7 @@ class ListingCardPrices extends Component {
                         &nbsp;ETH
                     </span>
                     {isMultiUnit && (<span className="append">
-                      &nbsp;/{this.props.intl.formatMessage(this.intlMessages.each)}
+                      &nbsp;{this.props.intl.formatMessage(this.intlMessages.each)}
                     </span>)}
                   </div>
                   <div className="fiat">

--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -548,7 +548,7 @@ class ListingCreate extends Component {
 
   onBoostLimitChange({ formData }) {
     const boostLimit = formData.boostLimit
-    if (boostLimit && boostLimit !== this.state.formListing.formData.boostLimit
+    if (boostLimit !== undefined && boostLimit !== this.state.formListing.formData.boostLimit
     ) {
       this.setState({
         formListing: {

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -384,7 +384,8 @@ class ListingsDetail extends Component {
       userIsBuyerOffers,
       userIsSellerOffer,
       userIsBuyer,
-      userIsSeller
+      userIsSeller,
+      showRemainingBoost
     } = getDerivedListingData(listing, wallet.address)
 
     // only expose where user is a buyer or a seller
@@ -613,7 +614,7 @@ class ListingsDetail extends Component {
                       })}
                         &nbsp;ETH
                         {isMultiUnit && <Fragment>
-                          &nbsp;/{this.props.intl.formatMessage(this.intlMessages.each)}&nbsp;
+                          &nbsp;{this.props.intl.formatMessage(this.intlMessages.each)}&nbsp;
                         </Fragment>}
                     </div>
                   }
@@ -702,7 +703,7 @@ class ListingsDetail extends Component {
                         </div>
                       </div>
                       <hr className="pt-1 mt-4 mb-2"/>
-                      <div className="d-flex justify-content-between mt-4 mb-2">
+                      {showRemainingBoost && <div className="d-flex justify-content-between mt-4 mb-2">
                         <div className="ml-3">
                           <FormattedMessage
                             id={'listing-detail.remainingBoost'}
@@ -727,7 +728,7 @@ class ListingsDetail extends Component {
                             </Link>
                           </span>
                         </div>
-                      </div>
+                      </div>}
                     </Fragment>
                   )}
                   {this.renderButtonContainer(userIsSeller, isFractional, this.props.listingId, isMultiUnit, unitsPending, isAvailable)}

--- a/origin-dapp/src/utils/listing.js
+++ b/origin-dapp/src/utils/listing.js
@@ -210,7 +210,8 @@ export function getDerivedListingData(listing, usersWalletAddress = null) {
     offers,
     display,
     seller,
-    unitsRemaining
+    unitsRemaining,
+    totalBoostValue
   } = listing
 
   /* Find the most relevant offer where user is a seller. If there is a pending offer choose
@@ -264,6 +265,7 @@ export function getDerivedListingData(listing, usersWalletAddress = null) {
   const isAvailable = isMultiUnit ? unitsRemaining > 0 : (!isPending && !isSold && !isWithdrawn)
   const showPendingBadge = isPending && !isWithdrawn
   const showSoldBadge = isSold || isWithdrawn
+  const showRemainingBoost = isMultiUnit && totalBoostValue > 0
 
   /* When ENABLE_PERFORMANCE_MODE env var is set to false even the search result page won't
    * show listings with the Featured badge, because listings are loaded from web3. We could

--- a/origin-dapp/src/utils/listing.js
+++ b/origin-dapp/src/utils/listing.js
@@ -289,7 +289,8 @@ export function getDerivedListingData(listing, usersWalletAddress = null) {
     userIsBuyerOffers,
     userIsBuyerOffer: userIsBuyerOffers.length > 0 ? userIsBuyerOffers[0] : undefined,
     userIsBuyer: userIsBuyerOffers.length > 0,
-    userIsSeller: usersWalletAddress !== null && formattedAddress(usersWalletAddress) === formattedAddress(seller)
+    userIsSeller: usersWalletAddress !== null && formattedAddress(usersWalletAddress) === formattedAddress(seller),
+    showRemainingBoost
   }
 }
 


### PR DESCRIPTION
### Description:
Fixes the following bugs for multi unit listings: 
 - removes slash `/` before the `each` word in pricing
 - hides boost remaining when listing has not been boosted for multi unit listings
 - solves a bug where `boost limit` form would report an error when boost slider is reduced to 0