### PR TITLE
Register notifications when you are already holding a device token

### DIFF
--- a/origin-mobile/ios/OriginCatcher/Info.plist
+++ b/origin-mobile/ios/OriginCatcher/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/origin-mobile/src/OriginWallet.js
+++ b/origin-mobile/src/OriginWallet.js
@@ -1125,6 +1125,15 @@ class OriginWallet {
         //brand new info
         wallet_info = {walletToken: await UUIDGenerator.getRandomUUID()}
       }
+      else
+      {
+        if (wallet_info.deviceToken)
+        {
+          // if we have a deviceToken store, then assume we already have notifications on
+          // and make sure we have the correct(non-expired) token
+          this.requestNotifictions()
+        }
+      }
       this.state.walletToken = wallet_info.walletToken
       this.save_wallet_info = wallet_info
       this.saveInfo()


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- sometimes switching between dev and stage can cause the deviceToken to be wrong, so need to check when we have one stored.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
