### PR TITLE
fix tooltips in boost slider and purchase progress

### DIFF
--- a/origin-dapp/src/components/boost-slider.js
+++ b/origin-dapp/src/components/boost-slider.js
@@ -52,6 +52,7 @@ class BoostSlider extends Component {
         <Tooltip
           placement="top"
           trigger="click"
+          triggerClass="info-icon"
           content={
             <div className="boost-tooltip">
               <p>
@@ -62,7 +63,6 @@ class BoostSlider extends Component {
           }
         >
           <img
-            className="info-icon"
             src="images/info-icon-inactive.svg"
             role="presentation"
           />

--- a/origin-dapp/src/components/purchase-progress.js
+++ b/origin-dapp/src/components/purchase-progress.js
@@ -84,13 +84,14 @@ class PurchaseProgress extends Component {
           {offerCreated && (
             <Tooltip
               placement="top"
+              triggerClass="progress-circle checked"
               content={
                 <Fragment>
                   <div>Offer made on</div>
                   <strong>{formatDate(offerCreated.timestamp)}</strong>
                 </Fragment>
               }
-              children={<span className="progress-circle checked" />}
+              children={<span/>}
             />
           )}
           {!offerAccepted && !offerWithdrawn && (
@@ -99,25 +100,27 @@ class PurchaseProgress extends Component {
           {offerAccepted && (
             <Tooltip
               placement="top"
+              triggerClass="progress-circle checked"
               content={
                 <Fragment>
                   <div>Offer accepted on</div>
                   <strong>{formatDate(offerAccepted.timestamp)}</strong>
                 </Fragment>
               }
-              children={<span className="progress-circle checked" />}
+              children={<span />}
             />
           )}
           {offerWithdrawn && (
             <Tooltip
               placement="top"
+              triggerClass="progress-circle checked"
               content={
                 <Fragment>
                   <div>Offer {withdrawnOrRejected} on</div>
                   <strong>{formatDate(offerWithdrawn.timestamp)}</strong>
                 </Fragment>
               }
-              children={<span className="progress-circle checked" />}
+              children={<span />}
             />
           )}
           {!offerFinalized && !offerDisputed && (
@@ -126,13 +129,14 @@ class PurchaseProgress extends Component {
           {offerFinalized && (
             <Tooltip
               placement="top"
+              triggerClass="progress-circle checked"
               content={
                 <Fragment>
                   <div>Sale completed on</div>
                   <strong>{formatDate(offerFinalized.timestamp)}</strong>
                 </Fragment>
               }
-              children={<span className="progress-circle checked" />}
+              children={<span />}
             />
           )}
           {perspective === 'seller' && !offerDisputed && !offerData && (
@@ -141,19 +145,21 @@ class PurchaseProgress extends Component {
           {perspective === 'seller' && offerData && (
             <Tooltip
               placement="top"
+              triggerClass="progress-circle checked"
               content={
                 <Fragment>
                   <div>Sale reviewed on</div>
                   <strong>{formatDate(offerData.timestamp)}</strong>
                 </Fragment>
               }
-              children={<span className="progress-circle checked" />}
+              children={<span />}
             />
           )}
           {offerDisputed && !offerRuling && (
             <Fragment>
               <Tooltip
                 placement="top"
+                triggerClass="progress-circle exclaimed"
                 content={
                   <Fragment>
                     <div>Dispute started on</div>
@@ -161,7 +167,7 @@ class PurchaseProgress extends Component {
                   </Fragment>
                 }
                 children={
-                  <span className="progress-circle exclaimed">
+                  <span >
                     {subdued ? null : '!'}
                   </span>
                 }
@@ -173,23 +179,25 @@ class PurchaseProgress extends Component {
             <Fragment>
               <Tooltip
                 placement="top"
+                triggerClass="progress-circle checked"
                 content={
                   <Fragment>
                     <div>Dispute started on</div>
                     <strong>{formatDate(offerDisputed.timestamp)}</strong>
                   </Fragment>
                 }
-                children={<span className="progress-circle checked" />}
+                children={<span />}
               />
               <Tooltip
                 placement="top"
+                triggerClass="progress-circle checked"
                 content={
                   <Fragment>
                     <div>Ruling made on</div>
                     <strong>{formatDate(offerRuling.timestamp)}</strong>
                   </Fragment>
                 }
-                children={<span className="progress-circle checked" />}
+                children={<span />}
               />
             </Fragment>
           )}

--- a/origin-dapp/src/components/tooltip.js
+++ b/origin-dapp/src/components/tooltip.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import TooltipBS from 'react-bootstrap/lib/Tooltip'
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger'
 

--- a/origin-dapp/src/components/tooltip.js
+++ b/origin-dapp/src/components/tooltip.js
@@ -11,13 +11,18 @@ class Tooltip extends Component {
   }
 
   render() {
-    const { trigger, placement, content, children, delay } = this.props
+    const { trigger, placement, content, children, delay, triggerClass } = this.props
     const overlay = <TooltipBS id={this.id}>{content}</TooltipBS>
     const overlayProps = { trigger, placement, overlay, delay }
 
     return (
       <OverlayTrigger {...overlayProps}>
-        <Fragment>{children}</Fragment>
+        <a
+          href="javascript:void(0);"
+          className={triggerClass}
+        >
+          {children}
+        </a>
       </OverlayTrigger>
     )
   }


### PR DESCRIPTION
### Description:
Fixes the tooltip behaviour in the Dapp (excluding the source code found under experimental folder):
 - tooltip on boost slider
 - tooltips on purchase progress slider

Seems that overlay trigger requires either a link or a button as an immediate child to work. Can't find any documentation on that though.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~[ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~
- ~[ ] Wrap any new text/strings for translation~
- ~[ ] Map any new environment variables with a default value in the Webpack config~
- ~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~

**Solves issue:** https://github.com/OriginProtocol/origin/issues/1188#event-2059225934