### PR TITLE
Muti unit quantity field form validation

### DIFF
--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -748,12 +748,17 @@ class ListingCreate extends Component {
     const formData = formListing.formData
     const {
       unitsTotal,
-      unitsLockedInOffers
+      unitsPending,
+      unitsSold
     } = formData
 
-    const isMultiUnitListing = !!formData.unitsTotal && formData.unitsTotal > 1
-
     if (isEditMode) {
+      const unitsLockedInOffers = unitsPending + unitsSold
+      /* considers the case where a user would edit the quantity to 1 on a multi unit listing
+       * that already has offers for more than 1 unit.
+       */
+      const isMultiUnitListing = (!!formData.unitsTotal && formData.unitsTotal) > 1 || unitsLockedInOffers > 1
+
       // do not allow quantity to be edited below the value of units already in offers
       if (isMultiUnitListing && unitsTotal < unitsLockedInOffers) {
         errors.unitsTotal.addError(


### PR DESCRIPTION
### Description:
Fixes the following validation problems with multi unit listings: 
- fix a problem where quantity number could be set below the number of sold/pending units in offers
- fix a problem where quantity could be set to 1 and form validation would not treat a listing as multi unit and not do quantity checks. 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~[ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~
- ~[ ] Wrap any new text/strings for translation~
- ~[ ] Map any new environment variables with a default value in the Webpack config~
- ~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~
