### PR TITLE
Natasha/Unblock ui when getting-started is triggered.

### DIFF
--- a/origin-dapp/src/components/onboarding-modal/index.js
+++ b/origin-dapp/src/components/onboarding-modal/index.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
+import { unblock } from 'actions/Onboarding'
 
 import {
   updateSteps,
@@ -100,10 +101,11 @@ class OnboardingModal extends Component {
 
   userProgress() {
     const {
-      onboarding: { progress, learnMore, stepsCompleted, splitPanel },
+      onboarding: { blocked, progress, learnMore, stepsCompleted, splitPanel },
       toggleLearnMore,
       toggleSplitPanel,
-      wallet: { ognBalance }
+      wallet: { ognBalance },
+      unblock
     } = this.props
     const { dismissed, gettingStarted, listings = [] } = this.state
 
@@ -122,6 +124,7 @@ class OnboardingModal extends Component {
       !splitPanel && toggleSplitPanel(true)
     } else if (!progress && !dismissed) {
       !learnMore && toggleLearnMore(true)
+      blocked && unblock()
     }
   }
 
@@ -214,7 +217,8 @@ const mapDispatchToProps = dispatch => ({
   toggleLearnMore: show => dispatch(toggleLearnMore(show)),
   updateSteps: ({ incompleteStep }) =>
     dispatch(updateSteps({ incompleteStep })),
-  selectStep: ({ selectedStep }) => dispatch(selectStep({ selectedStep }))
+  selectStep: ({ selectedStep }) => dispatch(selectStep({ selectedStep })),
+  unblock: () => dispatch(unblock())
 })
 
 export default withRouter(


### PR DESCRIPTION
### Description:
[Issue #1091](https://github.com/OriginProtocol/origin/issues/1091#issuecomment-451296288)
- Stop the getting started modal from blocking the UI

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything


### Manual Testing:
- Change metamask to Mainnet & dismiss Beta Modal. You should be able to scroll etc