### PR TITLE
Multi-unit for GraphQL

### DIFF
--- a/experimental/origin-admin/src/pages/listings/Listing.js
+++ b/experimental/origin-admin/src/pages/listings/Listing.js
@@ -173,9 +173,10 @@ class Listing extends Component {
       a => listing.seller && a.id === listing.seller.id
     )
     const units = listing.unitsTotal <= 1 ? '' : `${listing.unitsTotal} items `
+    const available = ` (${listing.unitsAvailable} available) `
     return (
       <div style={{ marginBottom: 10 }}>
-        {`${units}${listing.categoryStr} by `}
+        {`${units}${available}${listing.categoryStr} by `}
         <Identity account={listing.seller} />
         <span style={{ marginRight: 10 }}>
           {` for `}
@@ -186,6 +187,8 @@ class Listing extends Component {
           {`. Deposit managed by `}
           <Identity account={listing.arbitrator} />
           <span style={{ marginLeft: 10 }}>
+            {currency({ amount: listing.depositAvailable, currency: 'OGN' })}
+            /
             {currency({ amount: listing.deposit, currency: 'OGN' })}
           </span>
         </span>

--- a/experimental/origin-admin/src/pages/marketplace/_Offers.js
+++ b/experimental/origin-admin/src/pages/marketplace/_Offers.js
@@ -29,6 +29,7 @@ const Offers = ({ listing, offers, accounts }) => {
           <th>ID</th>
           <th>Status</th>
           <th>Offer</th>
+          <th>Qty</th>
           <th>Refund</th>
           <th>Buyer</th>
           <th>Commission</th>
@@ -160,6 +161,7 @@ class OfferRow extends Component {
         <td>{offer.offerId}</td>
         <td>{status(offer)}</td>
         <td>{price(offer)}</td>
+        <td>{offer.quantity}</td>
         <td>{price(offer, 'refund')}</td>
         <td>
           <AccountButton account={offer.buyer} />

--- a/experimental/origin-admin/src/pages/marketplace/mutations/MakeOffer.js
+++ b/experimental/origin-admin/src/pages/marketplace/mutations/MakeOffer.js
@@ -36,6 +36,7 @@ class MakeOffer extends Component {
       affiliate: affiliate ? affiliate.id : ZeroAddress,
       commission: '2',
       value: '0.1',
+      quantity: 1,
       currency: ZeroAddress,
       arbitrator: arbitrator ? arbitrator.id : '',
       from: buyer ? buyer.id : ''
@@ -78,6 +79,11 @@ class MakeOffer extends Component {
                       rightElement={<Tag minimal={true}>ETH</Tag>}
                     />
                   </FormGroup>
+                </div>
+                <div style={{ flex: 1, marginRight: 20 }} >
+                      <FormGroup label="Quantity">
+                      <InputGroup {...input('quantity')} />
+                      </FormGroup>
                 </div>
                 <div style={{ flex: 1, marginRight: 20 }}>
                   <FormGroup label="Finalizes">
@@ -177,7 +183,8 @@ class MakeOffer extends Component {
       commission: affiliate === ZeroAddress ? '0' : this.state.commission,
       value: this.state.value,
       currency: ZeroAddress,
-      arbitrator: this.state.arbitrator
+      arbitrator: this.state.arbitrator,
+      quantity: Number(this.state.quantity)
     }
     if (this.props.offer) {
       variables.withdraw = String(this.props.offer.id)

--- a/experimental/origin-admin/src/queries/Fragments.js
+++ b/experimental/origin-admin/src/queries/Fragments.js
@@ -31,6 +31,7 @@ export default {
           id
         }
         deposit
+        depositAvailable
         createdEvent {
           timestamp
         }
@@ -41,6 +42,8 @@ export default {
         description
         currencyId
         unitsTotal
+        unitsAvailable
+        unitsSold
         featured
         hidden
         price {
@@ -66,6 +69,7 @@ export default {
         commission
         status
         finalizes
+        quantity
         arbitrator {
           id
         }

--- a/experimental/origin-admin/src/queries/Mutations.js
+++ b/experimental/origin-admin/src/queries/Mutations.js
@@ -201,6 +201,7 @@ export const MakeOfferMutation = gql`
     $data: MakeOfferInput
     $from: String
     $withdraw: String
+    $quantity: Int
   ) {
     makeOffer(
       listingID: $listingID
@@ -213,6 +214,7 @@ export const MakeOfferMutation = gql`
       data: $data
       from: $from
       withdraw: $withdraw
+      quantity: $quantity
     ) {
       id
     }

--- a/experimental/origin-dapp2/src/mutations.js
+++ b/experimental/origin-dapp2/src/mutations.js
@@ -192,6 +192,7 @@ export const MakeOfferMutation = gql`
     $data: MakeOfferInput
     $from: String
     $withdraw: String
+    $quantity: Int
   ) {
     makeOffer(
       listingID: $listingID
@@ -204,6 +205,7 @@ export const MakeOfferMutation = gql`
       data: $data
       from: $from
       withdraw: $withdraw
+      quantity: $quantity
     ) {
       id
     }

--- a/experimental/origin-dapp2/src/mutations/MakeOffer.js
+++ b/experimental/origin-dapp2/src/mutations/MakeOffer.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag'
 
 export default gql`
-  mutation MakeOffer($listingID: String!, $value: String!, $from: String!) {
-    makeOffer(listingID: $listingID, value: $value, from: $from) {
+  mutation MakeOffer($listingID: String!, $value: String!, $from: String!, $quantity: Int!) {
+    makeOffer(listingID: $listingID, value: $value, from: $from, quantity: $quantity) {
       id
     }
   }

--- a/experimental/origin-dapp2/src/pages/listing/ListingDetail.js
+++ b/experimental/origin-dapp2/src/pages/listing/ListingDetail.js
@@ -71,7 +71,7 @@ class ListingDetail extends Component {
                   />
                 </>
               ) : (
-                <Buy listing={listing} from={from} value={amount} />
+                <Buy listing={listing} from={from} value={amount} quantity={quantity} />
               )}
             </div>
             <h5 className="mt-3">About the Seller</h5>

--- a/experimental/origin-dapp2/src/pages/listing/mutations/Buy.js
+++ b/experimental/origin-dapp2/src/pages/listing/mutations/Buy.js
@@ -239,8 +239,13 @@ class Buy extends Component {
     }
     if (!data || !data.web3) return
 
-    const { listing, from, value } = this.props
-    const variables = { listingID: listing.id, value, from }
+    const { listing, from, value, quantity } = this.props
+    const variables = {
+      listingID: listing.id,
+      value,
+      from,
+      quantity: Number(quantity)
+    }
 
     const eth = Number(get(data, 'web3.metaMaskAccount.balance.eth', 0))
     if (!data.web3.metaMaskAccount) {

--- a/experimental/origin-dapp2/src/queries/Fragments.js
+++ b/experimental/origin-dapp2/src/queries/Fragments.js
@@ -31,6 +31,7 @@ export default {
           id
         }
         deposit
+        depositAvailable
         createdEvent {
           timestamp
         }
@@ -42,6 +43,8 @@ export default {
         description
         currencyId
         unitsTotal
+        unitsAvailable
+        unitsSold
         featured
         hidden
         price {

--- a/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
@@ -12,7 +12,7 @@ async function makeOffer(_, data) {
     schemaId: 'https://schema.originprotocol.com/offer_1.0.0.json',
     listingId: data.listingID,
     listingType: 'unit',
-    unitsPurchased: 1,
+    unitsPurchased: Number.parseInt(data.quantity),
     totalPrice: {
       amount: data.value,
       currency: 'ETH'
@@ -30,16 +30,16 @@ async function makeOffer(_, data) {
   const buyer = data.from
   const marketplace = contracts.marketplaceExec
 
-  const affilaiteWhitelistDisabled = await marketplace.methods
+  const affiliateWhitelistDisabled = await marketplace.methods
     .allowedAffiliates(marketplace.options.address)
     .call()
 
-  if (!affilaiteWhitelistDisabled) {
-    const affilaiteAllowed = await marketplace.methods
+  if (!affiliateWhitelistDisabled) {
+    const affiliateAllowed = await marketplace.methods
       .allowedAffiliates(data.affiliate)
       .call()
 
-    if (!affilaiteAllowed) {
+    if (!affiliateAllowed) {
       throw new Error('Affiliate not on whitelist')
     }
   }

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -40,6 +40,7 @@ export default `
       arbitrator: String
       from: String
       withdraw: String
+      quantity: Int
     ): Transaction
 
     executeRuling(
@@ -175,6 +176,9 @@ export default `
     status: String
     hidden: Boolean
     featured: Boolean
+    unitsAvailable: Int
+    unitsSold: Int
+    depositAvailable: String
 
     # IPFS
     title: String
@@ -215,6 +219,7 @@ export default `
     arbitrator: Account
     finalizes: Int
     status: Int
+    quantity: Int
 
     # Computed
     withdrawnBy: Account


### PR DESCRIPTION
* Addition of `unitsAvailable`, `unitsSold`, and `depositAvailable`
* New `quantity` field for `MakeOffer` mutation
* Purchasing multiple units in `origin-admin` and `origin-dapp2`

There are no tests or validation yet. Validation can go in its own PR.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [x] Wrap any new text/strings for translation
- [x] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
