### PR TITLE
Fix crash on depolyed wallet when trying to purchase/sell

### DIFF
--- a/origin-mobile/ios/OriginCatcher/Info.plist
+++ b/origin-mobile/ios/OriginCatcher/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>19</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/origin-mobile/src/OriginWallet.js
+++ b/origin-mobile/src/OriginWallet.js
@@ -454,7 +454,7 @@ class OriginWallet {
       const meta = await this.extractMetaFromCall(transaction.call) || {}
       const cost = this.extractTransactionCost(transaction.call)
       const gas_cost = this.extractTransactionGasCost(transaction.call)
-      const ogn_cost = meta && meta.originTokenValue
+      const ogn_cost = this.extractOgnCost(meta)
       const listing = this.extractListing(meta)
       const to = this.extractTo(transaction.call)
       const transaction_type = this.extractTransactionActionType(meta)
@@ -474,6 +474,11 @@ class OriginWallet {
     }
     //this is the bare event
     return event_data
+  }
+
+  extractOgnCost(meta)
+  {
+    return (meta && meta.originTokenValue && web3.utils.toBN(meta.originTokenValue)) || web3.utils.toBN("0")
   }
 
   async extractMetaFromCall({net_id, params:{txn_object}}) {
@@ -519,12 +524,12 @@ class OriginWallet {
 
   extractTransactionCost({params:{txn_object}}){
     // might want to format this some how
-    return (txn_object && txn_object.value && web3.utils.toBN(txn_object.value)) || 0
+    return (txn_object && txn_object.value && web3.utils.toBN(txn_object.value)) || web3.utils.toBN("0")
   }
 
   extractTransactionGasCost({params}){
     // might want to format this some how
-    return params && params.txn_object && (web3.utils.toBN(params.txn_object.gas) * web3.utils.toBN(params.txn_object.gasPrice))
+    return params && params.txn_object && (web3.utils.toBN(params.txn_object.gas).mul(web3.utils.toBN(params.txn_object.gasPrice)))
   }
 
  

--- a/origin-mobile/src/components/transaction-item.js
+++ b/origin-mobile/src/components/transaction-item.js
@@ -127,7 +127,7 @@ class TransactionItem extends Component {
                 </View>
                 <View style={styles.price}>
                   <Image source={require(`${IMAGES_PATH}eth-icon.png`)} style={styles.currencyIcon} />
-                  <Text style={styles.amount}>{Number(web3.utils.fromWei(totalEth)).toFixed(5)}</Text>
+                  <Text style={styles.amount}>{Number(web3.utils.fromWei(totalEth.toString())).toFixed(5)}</Text>
                   <Text style={styles.abbreviation}>ETH</Text>
                 </View>
               </View>

--- a/origin-mobile/src/components/transaction-modal.js
+++ b/origin-mobile/src/components/transaction-modal.js
@@ -13,6 +13,7 @@ export default class TransactionModal extends Component {
     const name = item.listing && item.listing.title
     const pictures = item.listing && item.listing.media && item.listing.media.map( m => m.url)
     const meta = item.meta
+    console.log("modal balance:", balance, " type:", typeof balance)
     const hasSufficientFunds = !cost || web3.utils.toBN(balance).gt(web3.utils.toBN(cost))
     const counterpartyAddress = (item.listing && item.listing.seller) || item.to
 

--- a/origin-mobile/src/screens/transaction.js
+++ b/origin-mobile/src/screens/transaction.js
@@ -110,9 +110,9 @@ class TransactionScreen extends Component {
     const innerWidth = width - DETAIL_PADDING * 2
     const fromUser = users.find(({ address }) => address === wallet.address) || {}
     const toUser = users.find(({ address }) => address === counterpartyAddress) || {}
-    const priceInETH = Number(web3.utils.fromWei(web3.utils.toBN(cost))).toFixed(5)
+    const priceInETH = Number(web3.utils.fromWei(web3.utils.toBN(cost).toString())).toFixed(5)
     const fiatPrice = getFiatPrice(priceInETH)
-    const gasCostInETH = Number(web3.utils.fromWei(web3.utils.toBN(gas_cost))).toFixed(5)
+    const gasCostInETH = Number(web3.utils.fromWei(web3.utils.toBN(gas_cost).toString())).toFixed(5)
     const fiatGasCost = getFiatPrice(gasCostInETH)
 
     return (

--- a/origin-mobile/src/screens/wallet-funding.js
+++ b/origin-mobile/src/screens/wallet-funding.js
@@ -35,7 +35,7 @@ class WalletFundingScreen extends Component {
     const { currency, item } = navigation.state.params
     const balance = web3.utils.fromWei(balances[currency], 'ether')
     const fundsRequired = web3.utils.toBN(item.cost).add(web3.utils.toBN(item.gas_cost))
-    const readableRequired = web3.utils.fromWei(fundsRequired)
+    const readableRequired = web3.utils.fromWei(fundsRequired.toString())
     const { height } = Dimensions.get('window')
     const smallScreen = height < 812
 


### PR DESCRIPTION
…ance object so fromWei crashes have to convert to string.

First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

-  For some reason web3.utils.toBN was not creating a BN object(it was an s object) and so toWei/fromWei would crash. Using string as default parameter for now.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
