### PR TITLE
Update dapp hostnames for dev and staging

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/_helpers.tpl
+++ b/deployment/kubernetes/charts/origin/templates/_helpers.tpl
@@ -35,7 +35,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 
 {{- define "dapp.host" -}}
 {{- if ne .Release.Namespace "prod" -}}
-{{- printf "demo.%s.originprotocol.com" .Release.Namespace -}}
+{{- printf "dapp.%s.originprotocol.com" .Release.Namespace -}}
 {{- else -}}
 {{- printf "dapp.originprotocol.com" -}}
 {{- end -}}


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Changes dev and staging from `demo.<env>.originprotocol.com` to `dapp.<env>.originprotocol.com`

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
