### PR TITLE
Messaging Account Detection

### DIFF
--- a/origin-dapp/src/actions/Activation.js
+++ b/origin-dapp/src/actions/Activation.js
@@ -5,6 +5,8 @@ import { createSubscription } from 'utils/notifications'
 
 import origin from '../services/origin'
 
+const MESSAGING_URL = process.env.MESSAGING_URL
+
 export const ActivationConstants = keyMirror(
   {
     MESSAGING_ENABLED: null,
@@ -16,6 +18,22 @@ export const ActivationConstants = keyMirror(
   },
   'ACTIVATION'
 )
+
+export function detectMessagingEnabled(account) {
+  return async function(dispatch) {
+    try {
+      const response = await fetch(`${MESSAGING_URL}/accounts/${account}`)
+      const enabled = response.status === 200
+
+      dispatch({
+        type: ActivationConstants.MESSAGING_ENABLED,
+        enabled
+      })
+    } catch (error) {
+      console.error(error)
+    }
+  }
+}
 
 export function handleNotificationsSubscription(role, props = {}) {
   return async function(dispatch) {

--- a/origin-dapp/src/components/onboarding.js
+++ b/origin-dapp/src/components/onboarding.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router'
 import queryString from 'query-string'
 
 import {
+  detectMessagingEnabled,
   enableMessaging,
   handleNotificationsSubscription,
   setMessagingEnabled,
@@ -90,6 +91,7 @@ class Onboarding extends Component {
     })
 
     // detect existing messaging account
+    // (potentially redundant if detectMessagingEnabled already returned true)
     origin.messaging.events.on('ready', accountKey => {
       this.props.setMessagingEnabled(!!accountKey)
     })
@@ -131,6 +133,12 @@ class Onboarding extends Component {
       messagingInitialized,
       wallet
     } = this.props
+
+    // on account change
+    if (wallet.address && wallet.address !== prevProps.wallet.address) {
+      // cheat and detect activation from central server
+      this.props.detectMessagingEnabled(wallet.address)
+    }
 
     if (wallet.address && !this.notificationsInterval) {
       // Poll for notifications every 60 seconds.
@@ -381,6 +389,7 @@ const mapStateToProps = ({ activation, app, messages, wallet }) => ({
 
 const mapDispatchToProps = dispatch => ({
   addMessage: obj => dispatch(addMessage(obj)),
+  detectMessagingEnabled: addr => dispatch(detectMessagingEnabled(addr)),
   enableMessaging: () => dispatch(enableMessaging()),
   fetchNotifications: () => dispatch(fetchNotifications()),
   fetchUser: addr => dispatch(fetchUser(addr)),

--- a/origin-dapp/webpack.config.js
+++ b/origin-dapp/webpack.config.js
@@ -36,6 +36,7 @@ const env = {
   IPFS_SWARM: 'None',
   MESSAGING_ACCOUNT: null,
   MESSAGING_NAMESPACE: null,
+  MESSAGING_URL: null,
   MAINNET_DAPP_BASEURL: 'https://dapp.originprotocol.com',
   NOTIFICATIONS_KEY: null,
   NOTIFICATIONS_URL: 'https://notifications.originprotocol.com',

--- a/origin-messaging/src/index.js
+++ b/origin-messaging/src/index.js
@@ -176,6 +176,14 @@ const initRESTApp = db => {
   }
   const rateLimiter = new RateLimiterMemory(rateLimiterOptions)
 
+  // should be tightened up for security
+  app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+
+    next()
+  })
+
   app.all((req, res, next) => {
     rateLimiter.consume(req.connection.remoteAddress)
       .then(() => {


### PR DESCRIPTION
This solves an issue of the "messaging requirement" modal persisting while Orbit is being synced. Now we will start by querying the central server for whether or not the account is in the global registry. We will still listen for it to be enabled later once everything is synced.