### PR TITLE
Enable cors on messaging API server

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/messaging-api.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/messaging-api.ingress.yaml
@@ -17,6 +17,26 @@ metadata:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- if ne .Release.Namespace "prod" }}
+    ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Access-Control-Allow-Origin: $http_origin";
+      more_set_headers "Access-Control-Allow-Credentials: true";
+
+      if ($request_method = 'OPTIONS') {
+          add_header 'Access-Control-Allow-Origin' "$http_origin";
+          add_header 'Access-Control-Allow-Credentials' 'true';
+          add_header 'Access-Control-Allow-Methods' 'GET,POST,PUT,DELETE,OPTIONS';
+          add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+          add_header 'Access-Control-Max-Age' 1728000;
+          add_header 'Content-Length' 0;
+          add_header 'Content-Type' 'text/plain charset=UTF-8';
+          return 204;
+      }
+    {{- else }}
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ template "dapp.host" . }}"
+    {{- end }}
 spec:
   tls:
     - secretName: {{ template "messaging-api.host" . }}


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Enable CORS on the messaging api server from anywhere on dev and staging and from the dapp on production in support of #1223 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
