### PR TITLE
Update mobile to support new Identity

### DIFF
--- a/origin-js/src/contractInterface/users/resolver.js
+++ b/origin-js/src/contractInterface/users/resolver.js
@@ -42,4 +42,12 @@ export default class UsersResolver {
       return new UserObject({ address, version: null })
     }
   }
+
+  /**
+   * Origin-mobile hack that allows to update the config after the UsersResolver
+   * object has already been created.
+   */
+  function updateConfig({ attestationAccount }) {
+    this.adapters['001'].issuerAddress = attestationAccount
+  }
 }

--- a/origin-js/src/contractInterface/users/resolver.js
+++ b/origin-js/src/contractInterface/users/resolver.js
@@ -44,10 +44,10 @@ export default class UsersResolver {
   }
 
   /**
-   * Origin-mobile hack that allows to update the config after the UsersResolver
+   * Origin-mobile specific. Hack to update the config after the UsersResolver
    * object has already been created.
    */
-  function updateConfig({ attestationAccount }) {
+  updateConfig({ attestationAccount }) {
     this.adapters['001'].issuerAddress = attestationAccount
   }
 }

--- a/origin-linking/src/linker-routes.js
+++ b/origin-linking/src/linker-routes.js
@@ -46,7 +46,8 @@ router.get("/server-info", (req, res) => {
     messagingUrl,
     profileUrl,
     rootUrl,
-    sellingUrl
+    sellingUrl,
+    attestationAccount
   } = linker.getServerInfo()
   res.send({
     provider_url:providerUrl,
@@ -56,7 +57,8 @@ router.get("/server-info", (req, res) => {
     messaging_url:messagingUrl,
     profile_url:profileUrl,
     root_url:rootUrl,
-    selling_url:sellingUrl
+    selling_url:sellingUrl,
+    attestation_account:attestationAccount
   })
 })
 

--- a/origin-linking/src/logic/linker.js
+++ b/origin-linking/src/logic/linker.js
@@ -12,6 +12,7 @@ const MESSAGING_URL = process.env.MESSAGING_URL
 const PROFILE_URL = process.env.PROFILE_URL
 const ROOT_URL = process.env.ROOT_URL
 const SELLING_URL = process.env.SELLING_URL
+const ATTESTATION_ACCOUNT = process.env.ATTESTATION_ACCOUNT
 const CODE_EXPIRATION_TIME_MINUTES = 60
 const CODE_SIZE = 16
 
@@ -252,6 +253,7 @@ class Linker {
       profileUrl:PROFILE_URL,
       rootUrl:ROOT_URL,
       sellingUrl:SELLING_URL
+      attestationAccount:ATTESTATION_ACCOUNT,
     }
   }
 

--- a/origin-mobile/src/OriginWallet.js
+++ b/origin-mobile/src/OriginWallet.js
@@ -1059,7 +1059,8 @@ class OriginWallet {
         messaging_url,
         profile_url,
         root_url,
-        selling_url
+        selling_url,
+        attestation_account,
       } = await this.doFetch(this.API_WALLET_SERVER_INFO, 'GET')
       const newProviderUrl = localfy(provider_url)
       console.log("Set network to:", newProviderUrl, contract_addresses)
@@ -1079,7 +1080,9 @@ class OriginWallet {
       origin.contractService.updateContractAddresses(contract_addresses)
       origin.ipfsService.gateway = localfy(ipfs_gateway)
       origin.ipfsService.api = localfy(ipfs_api)
-      
+      // Update the users config.
+      origin.users.resolver.updateConfig({ attestation_account })
+
       await this.setNetId()
       if (this.state.ethAddress)
       {


### PR DESCRIPTION
### Description:
With the new Identity system to be rolled out soon, Origin-js needs to be passed a new variable called attestationAccount, otherwise origin.users.get(address) will fail verifying attestations for new identities.

This PR passes that variable to origin-mobile via the server-info route from origin-linking.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
