### PR TITLE
Offer validation for GraphQL

### DIFF
--- a/experimental/origin-admin/src/pages/listings/Listing.js
+++ b/experimental/origin-admin/src/pages/listings/Listing.js
@@ -112,7 +112,7 @@ class Listing extends Component {
                             <Offers
                               listing={listing}
                               listingId={listingId}
-                              offers={listing.offers}
+                              offers={listing.allOffers}
                             />
 
                             <Button

--- a/experimental/origin-admin/src/pages/marketplace/_Offers.js
+++ b/experimental/origin-admin/src/pages/marketplace/_Offers.js
@@ -345,6 +345,10 @@ function price(offer, field = 'value') {
 }
 
 function status(offer) {
+  if (!offer.valid) {
+    return <Tag icon="cross">Invalid</Tag>
+  }
+
   if (offer.status === 0) {
     if (offer.withdrawnBy && offer.withdrawnBy.id !== offer.buyer.id) {
       return <Tag icon="cross">Declined</Tag>

--- a/experimental/origin-admin/src/queries/Fragments.js
+++ b/experimental/origin-admin/src/queries/Fragments.js
@@ -70,6 +70,8 @@ export default {
         status
         finalizes
         quantity
+        valid
+        validationError
         arbitrator {
           id
         }

--- a/experimental/origin-admin/src/queries/Listing.js
+++ b/experimental/origin-admin/src/queries/Listing.js
@@ -21,7 +21,7 @@ export default gql`
             listingID
           }
         }
-        offers {
+        allOffers {
           ...basicOfferFields
         }
       }

--- a/experimental/origin-eventsource/src/index.js
+++ b/experimental/origin-eventsource/src/index.js
@@ -4,6 +4,7 @@ const get = ipfs.get
 // import { get } from 'origin-ipfs'
 const startCase = require('lodash/startCase')
 const pick = require('lodash/pick')
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 class OriginEventSource {
   constructor({ ipfsGateway, marketplaceContract }) {
@@ -37,19 +38,6 @@ class OriginEventSource {
       blockNumber
     )
 
-    // Retrieve the IPFS data for all offers
-    const offerCreationData = {}
-    await Promise.all(
-      events.map(async e => {
-        if (e.event === 'OfferCreated') {
-          const data = await get(this.ipfsGateway, e.returnValues.ipfsHash)
-          offerCreationData[e.returnValues.offerID] = data
-        }
-      })
-    )
-
-    let unitsSold = 0
-    let depositAvailable = web3.utils.toBN(listing.deposit)
     events.forEach(e => {
       if (e.event === 'ListingCreated') {
         ipfsHash = e.returnValues.ipfsHash
@@ -60,29 +48,6 @@ class OriginEventSource {
       }
       if (e.event === 'ListingWithdrawn') {
         status = 'withdrawn'
-      }
-
-      const offerId = e.returnValues.offerID
-      const offer = offerId && offerCreationData[offerId]
-      const offerCommission = offer &&
-        web3.utils.toBN(web3.utils.toWei(offer.commission.amount, 'ether'))
-      if (e.event === 'OfferCreated') {
-        const unitsPurchased = offer && offer.unitsPurchased
-        if (unitsPurchased) {
-          unitsSold += unitsPurchased
-        }
-        if (offerCommission) {
-          depositAvailable = depositAvailable.sub(offerCommission)
-        }
-      }
-      if (e.event === 'OfferWithdrawn') {
-        const unitsPurchased = offer && offer.unitsPurchased
-        if (unitsPurchased) {
-          unitsSold -= unitsPurchased
-        }
-        if (offerCommission) {
-          depositAvailable = depositAvailable.add(offerCommission)
-        }
       }
       if (e.event === 'OfferFinalized') {
         status = 'sold'
@@ -104,7 +69,8 @@ class OriginEventSource {
         'category',
         'subCategory',
         'media',
-        'unitsTotal'
+        'unitsTotal',
+        'commissionPerUnit'
       )
     } catch (e) {
       return null
@@ -120,15 +86,11 @@ class OriginEventSource {
       }))
     }
 
-    const unitsAvailable = data.unitsTotal >= unitsSold
-      ? data.unitsTotal - unitsSold
-      : 0
-    console.log()
-    return {
+    const type = 'unit'
+    return this.withOffers(listingId, {
       id: `999-1-${listingId}${blockNumber ? `-${blockNumber}` : ''}`,
       ipfs: ipfsHash ? { id: ipfsHash } : null,
       deposit: listing.deposit,
-      depositAvailable: depositAvailable.toString(),
       arbitrator: listing.depositManager
         ? { id: listing.depositManager }
         : null,
@@ -136,13 +98,57 @@ class OriginEventSource {
       contract: this.contract,
       status,
       events,
-      unitsSold,
-      unitsAvailable,
+      type,
+      multiUnit: type === 'unit' && data.unitsTotal > 1,
+      commissionPerUnit: listing.commissionPerUnit,
       ...data
+    })
+  }
+
+  // Returns a listing with offers and any fields that are computed from the
+  // offers.
+  async withOffers(listingId, listing) {
+    const totalOffers = await this.contract.methods
+      .totalOffers(listingId).call()
+
+    const allOffers = []
+    for (const id of Array.from({ length: totalOffers }, (_, i) => i)) {
+      allOffers.push(await this._getOffer(listing, listingId, id))
     }
+
+    // Compute fields from valid offers.
+    let depositAvailable = web3.utils.toBN(listing.deposit)
+    let unitsAvailable = listing.unitsTotal
+    if (listing.type === 'unit') {
+      allOffers.forEach(offer => {
+        if (!offer.valid || offer.statusStr === 'Withdrawn') {
+          // No need to do anything here.
+        } else if (offer.quantity > unitsAvailable) {
+          offer.valid = false
+          offer.validationError = 'units purchased exceeds available'
+        } else {
+          unitsAvailable -= offer.quantity
+          if (offer.commission) {
+            const offerCommission = web3.utils.toBN(offer.commission)
+            depositAvailable = depositAvailable.sub(offerCommission)
+          }
+          // TODO: validate offer commission when dapp2 passes that in
+        }
+      })
+    }
+    return Object.assign({}, listing, {
+      allOffers,
+      unitsAvailable,
+      unitsSold: listing.unitsTotal - unitsAvailable,
+      depositAvailable: depositAvailable.toString()
+    })
   }
 
   async getOffer(listingId, offerId) {
+    return this._getOffer(await this.getListing(listingId), listingId, offerId)
+  }
+
+  async _getOffer(listing, listingId, offerId) {
     let blockNumber, status, ipfsHash, lastEvent, withdrawnBy, createdBlock
     const events = await this.contract.eventCache.offers(listingId, Number(offerId))
 
@@ -186,7 +192,7 @@ class OriginEventSource {
 
     const offerObj = {
       id: `999-1-${listingId}-${offerId}`,
-      listingId: String(listingId),
+      listingId: String(listing.id),
       offerId: String(offerId),
       createdBlock,
       status,
@@ -205,7 +211,72 @@ class OriginEventSource {
     }
     offerObj.statusStr = offerStatus(offerObj)
 
+    try {
+      await this.validateOffer(offerObj, listing)
+      offerObj.valid = true
+      offerObj.validationError = null
+    } catch(e) {
+      offerObj.valid = false
+      offerObj.validationError = e.message
+    }
+
     return offerObj
+  }
+
+  // Validates an offer, throwing an error if an issue is found.
+  async validateOffer(offer, listing) {
+    if (offer.status != 1 /* pending */) {
+      return
+    }
+
+    // TODO: make this better by getting the listing price currency address
+    if (listing.price.currency === 'ETH' && offer.currency !== ZERO_ADDRESS) {
+      throw new Error('Invalid offer: currency does not match listing')
+    }
+
+    // TODO: uncomment when we create new listings, including demo listings,
+    //  with affiliates and arbitrators
+    /*
+    const offerArbitrator = offer.arbitrator
+      && offer.arbitrator.id
+      && offer.arbitrator.id.toLowerCase()
+    const listingArbitrator = listing.arbitrator
+      && listing.arbitrator.id
+      && listing.arbitrator.id.toLowerCase()
+    if (offerArbitrator !== listingArbitrator) {
+      throw new Error(
+        `Arbitrator: offer ${offerArbitrator} !== listing ${listingArbitrator}`
+      )
+    }
+
+    const offerAffiliate = offer.affiliate
+      && offer.affiliate.id
+      && offer.affiliate.id.toLowerCase()
+    const listingAffiliate = listing.affiliate
+      && listing.affiliate.id
+      && listing.affiliate.id.toLowerCase()
+    if (offerAffiliate !== listingAffiliate) {
+      throw new Error(
+        `Affiliate: offer ${offerAffiliate} !== listing ${listingAffiliate}`
+      )
+    }
+    */
+
+    if (listing.type !== 'unit') {
+      // TODO: validate fractional offers
+      return
+    }
+
+    // Compare offer value with listing price. This assumes listing currency
+    // has 18 decimal places like ETH.
+    const listingPriceWei = web3.utils.toBN(
+      web3.utils.toWei(listing.price.amount, 'ether')
+    )
+    const expectedValue = listingPriceWei.mul(web3.utils.toBN(offer.quantity))
+    const offerValue = web3.utils.toBN(offer.value)
+    if (expectedValue.gt(offerValue)) {
+      throw new Error('Invalid offer: insufficient offer amount for listing')
+    }
   }
 
   async getReview(listingId, offerId, party, ipfsHash) {

--- a/experimental/origin-graphql/src/resolvers/Listing.js
+++ b/experimental/origin-graphql/src/resolvers/Listing.js
@@ -19,21 +19,8 @@ export default {
     const { listingId, offerId } = parseId(args.id)
     return contracts.eventSource.getOffer(listingId, offerId)
   },
-  offers: async listing => {
-    if (!listing.contract) {
-      return null
-    }
-    const { listingId } = parseId(listing.id)
-    const totalOffers = await listing.contract.methods
-      .totalOffers(listingId)
-      .call()
-
-    const offers = []
-    for (const id of Array.from({ length: Number(totalOffers) }, (v, i) => i)) {
-      offers.push(await contracts.eventSource.getOffer(listingId, id))
-    }
-    return offers
-  },
+  offers: async listing =>
+    listing.allOffers.filter(o => o.valid),
   createdEvent: async listing => {
     const { listingId } = parseId(listing.id)
     const events = await listing.contract.eventCache.listings(

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -166,6 +166,7 @@ export default `
 
     # Connections
     offers: [Offer]
+    allOffers: [Offer]
     offer(id: ID!): Offer
     totalOffers: Int
     events: [Event]
@@ -179,6 +180,8 @@ export default `
     unitsAvailable: Int
     unitsSold: Int
     depositAvailable: String
+    type: String
+    multiUnit: Boolean
 
     # IPFS
     title: String
@@ -224,6 +227,8 @@ export default `
     # Computed
     withdrawnBy: Account
     statusStr: String
+    valid: Boolean
+    validationError: String
   }
 
   input NewListingInput {


### PR DESCRIPTION
Implements offer validation in the event sourcing layer for GraphQL.
This change introduces a new `Listing` field called `allOffers`, which
contains all offers regardless of validity.

The existing `offers` field now contains just valid offers.

Additionally, each `Offer` now contains the `valid` and
`validationError` fields.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`]~~(https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
