### PR TITLE
Fix modal

### DIFF
--- a/origin-dapp/src/pages/profile/ConfirmReset.js
+++ b/origin-dapp/src/pages/profile/ConfirmReset.js
@@ -40,7 +40,7 @@ class ConfirmReset extends Component {
             />
           </button>
         </div>
-        <a data-modal="publish" onClick={handleToggle}>
+        <a data-modal="reset" onClick={handleToggle}>
           <FormattedMessage
             id={'ConfirmReset.oopsNoWait'}
             defaultMessage={'Not now...'}


### PR DESCRIPTION

### Description:

Fix bug in identity modal where it was using the publish modal's name when cancelling it, causing some undesired side effect.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
