### PR TITLE
Do not set cors response headers twice on staging

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -26,8 +26,6 @@ metadata:
       more_set_headers "Access-Control-Allow-Credentials: true";
 
       if ($request_method = 'OPTIONS') {
-          add_header 'Access-Control-Allow-Origin' "$http_origin";
-          add_header 'Access-Control-Allow-Credentials' 'true';
           add_header 'Access-Control-Allow-Methods' 'GET,POST,PUT,DELETE,OPTIONS';
           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
           add_header 'Access-Control-Max-Age' 1728000;


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)
### Description:

On staging, the Access-Control-Allow-Origin and Access-Control-Allow-Credentials headers were set twice on the response, causing Chrome browser to fail the request.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
