### PR TITLE
Remove workaround for CORS from anywhere on bridge

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -20,24 +20,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-name: "ingress"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/limit-rps: "5"
-    {{- if ne .Release.Namespace "prod" }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "Access-Control-Allow-Origin: $http_origin";
-      more_set_headers "Access-Control-Allow-Credentials: true";
-
-      if ($request_method = 'OPTIONS') {
-          add_header 'Access-Control-Allow-Methods' 'GET,POST,PUT,DELETE,OPTIONS';
-          add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-          add_header 'Access-Control-Max-Age' 1728000;
-          add_header 'Content-Length' 0;
-          add_header 'Content-Type' 'text/plain charset=UTF-8';
-          return 204;
-      }
-    {{- else }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ template "dapp.host" . }}"
-    {{- end }}
 spec:
   tls:
     - secretName: {{ template "bridge.host" . }}


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- This hack was intended to allow CORS requests from any origin for the bridge for demo purposes, but it is causing too many problems right now

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
