### PR TITLE
Use existing mnemonic for origin-services

### DIFF
--- a/experimental/origin-services/index.js
+++ b/experimental/origin-services/index.js
@@ -32,7 +32,7 @@ const startGanache = (opts = {}) =>
       default_balance_ether: 100,
       db_path: `${__dirname}/data/db`,
       network_id: 999,
-      seed: 123
+      mnemonic: 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
       // blockTime: 3
     }
     if (opts.inMemory) {
@@ -45,11 +45,12 @@ const startGanache = (opts = {}) =>
       }
     }
     const server = Ganache.server(ganacheOpts)
-    server.listen(8545, err => {
+    const port = 8545
+    server.listen(port, err => {
       if (err) {
         return reject(err)
       }
-      console.log('Ganache listening.')
+      console.log(`Ganache listening on port ${port}.`)
       resolve(server)
     })
   })


### PR DESCRIPTION
This change makes the ganache instance launched by origin-services use
the same mnemonic that's used by origin-js's ganache instance. This
makes switching between the two code bases much easier.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
