### PR TITLE
Correctly handle line breaks in descriptions.

### DIFF
--- a/experimental/origin-admin/src/pages/listings/Listing.js
+++ b/experimental/origin-admin/src/pages/listings/Listing.js
@@ -81,7 +81,7 @@ class Listing extends Component {
                   {!media.length && !listing.description ? null : (
                     <div style={{ maxWidth: 300, margin: '20px 20px 0 0' }}>
                       {!media.length ? null : <Gallery pics={media} />}
-                      <div className="mt-2">{listing.description}</div>
+                      <div className="mt-2" style={{"white-space":"pre-wrap"}}>{listing.description}</div>
                     </div>
                   )}
                   <div>

--- a/experimental/origin-admin/src/pages/listings/Listing.js
+++ b/experimental/origin-admin/src/pages/listings/Listing.js
@@ -81,7 +81,7 @@ class Listing extends Component {
                   {!media.length && !listing.description ? null : (
                     <div style={{ maxWidth: 300, margin: '20px 20px 0 0' }}>
                       {!media.length ? null : <Gallery pics={media} />}
-                      <div className="mt-2" style={{"white-space":"pre-wrap"}}>{listing.description}</div>
+                      <div className="mt-2" style={{ 'white-space': 'pre-wrap' }}>{listing.description}</div>
                     </div>
                   )}
                   <div>

--- a/experimental/origin-dapp2/src/pages/listing/ListingDetail.js
+++ b/experimental/origin-dapp2/src/pages/listing/ListingDetail.js
@@ -119,6 +119,7 @@ require('react-styl')(`
 
     .description
       margin-top: 2rem
+      white-space: pre-wrap
 
     .listing-buy
       padding: 1.5rem


### PR DESCRIPTION
Correct line break handling for listing description for both dapp2 and origin-admin.

![image](https://user-images.githubusercontent.com/837/51274839-38347580-199e-11e9-972c-7c5e6f9c7644.png)
