### PR TITLE
Add blog post link to identity upgrade modal

### DIFF
--- a/origin-dapp/src/pages/profile/ConfirmReset.js
+++ b/origin-dapp/src/pages/profile/ConfirmReset.js
@@ -32,7 +32,7 @@ class ConfirmReset extends Component {
             }
           />
           &nbsp;
-          <a href="https://medium.com/originprotocol/origin-id-v2-eca7c4e85a70" target="_blank">
+          <a href="https://medium.com/originprotocol/origin-id-v2-eca7c4e85a70" target="_blank" rel="noopener noreferrer">
             <FormattedMessage
               id={'ConfirmReset.learnMore'}
               defaultMessage={'Learn More.'}

--- a/origin-dapp/src/pages/profile/ConfirmReset.js
+++ b/origin-dapp/src/pages/profile/ConfirmReset.js
@@ -28,7 +28,7 @@ class ConfirmReset extends Component {
           <FormattedMessage
             id={'ConfirmReset.afterResetNotice'}
             defaultMessage={
-              'OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Your existing account verifications will be removed.'
+              'OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Any previous attestations will need to be reverified.'
             }
           />
           &nbsp;

--- a/origin-dapp/src/pages/profile/ConfirmReset.js
+++ b/origin-dapp/src/pages/profile/ConfirmReset.js
@@ -31,6 +31,13 @@ class ConfirmReset extends Component {
               'OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Your existing account verifications will be removed.'
             }
           />
+          &nbsp;
+          <a href="https://medium.com/originprotocol/origin-id-v2-eca7c4e85a70" target="_blank">
+            <FormattedMessage
+              id={'ConfirmReset.learnMore'}
+              defaultMessage={'Learn More.'}
+            />
+          </a>
         </p>
         <div className="button-container">
           <button type="submit" className="btn btn-clear" onClick={onConfirm}>

--- a/origin-dapp/translations/all-messages.json
+++ b/origin-dapp/translations/all-messages.json
@@ -830,7 +830,7 @@
   "ConfirmPublish.letsDoIt": "Let's do it!",
   "ConfirmPublish.oopsNoWait": "Oops, no wait...",
   "ConfirmReset.resetIdentity": "Upgrade Your Identity",
-  "ConfirmReset.afterResetNotice": "OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Your existing account verifications will be removed.",
+  "ConfirmReset.afterResetNotice": "OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Any previous attestations will need to be reverified.",
   "ConfirmReset.learnMore": "Learn More.",
   "ConfirmReset.letsDoIt": "Let's do it!",
   "ConfirmReset.oopsNoWait": "Not now...",

--- a/origin-dapp/translations/all-messages.json
+++ b/origin-dapp/translations/all-messages.json
@@ -831,6 +831,7 @@
   "ConfirmPublish.oopsNoWait": "Oops, no wait...",
   "ConfirmReset.resetIdentity": "Upgrade Your Identity",
   "ConfirmReset.afterResetNotice": "OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Your existing account verifications will be removed.",
+  "ConfirmReset.learnMore": "Learn More.",
   "ConfirmReset.letsDoIt": "Let's do it!",
   "ConfirmReset.oopsNoWait": "Not now...",
   "ConfirmUpload.waitNotice": "Wait! You haven’t published yet.",

--- a/origin-dapp/translations/messages/src/pages/profile/ConfirmReset.json
+++ b/origin-dapp/translations/messages/src/pages/profile/ConfirmReset.json
@@ -8,6 +8,10 @@
     "defaultMessage": "OriginID has been updated to make profiles significantly cheaper to publish. We recommend verifying each of your accounts and publishing your profile again. Your existing account verifications will be removed."
   },
   {
+    "id": "ConfirmReset.learnMore",
+    "defaultMessage": "Learn More."
+  },
+  {
     "id": "ConfirmReset.letsDoIt",
     "defaultMessage": "Let's do it!"
   },


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:
Adds a "Learn More" link that points to medium blog post about new identity.

![screen shot 2019-01-22 at 10 58 25 am](https://user-images.githubusercontent.com/945910/51558849-52a29f00-1e35-11e9-89a2-11f98732c841.png)


### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [X] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
