### PR TITLE
Don't overzealously check for price in indexer

### DIFF
--- a/origin-discovery/src/listener/rules.js
+++ b/origin-discovery/src/listener/rules.js
@@ -231,12 +231,6 @@ async function handleLog (log, rule, contractVersion, context) {
     throw new Error(`ListingId mismatch: ${ipfsListingId} !== ${log.decoded.listingID}`)
   }
 
-  // TODO: This kind of verification logic should live in origin.js
-  if (listing.ipfs.data.price === undefined) {
-    console.log(`ERROR: listing ${listingId} has no price. Skipping indexing.`)
-    return
-  }
-
   // On listing or offer event, index the listing.
   // Notes:
   //  - Reason for also re-indexing on offer event is that the listing data includes


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Fractional listings don't have a price field.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
