### PR TITLE
Store marketplacePublisher correctly

### DIFF
--- a/origin-dapp-creator-client/src/pages/App.js
+++ b/origin-dapp-creator-client/src/pages/App.js
@@ -21,7 +21,8 @@ class App extends React.Component {
 
     this.state = {
       config: store.get('creator-config', {
-        ...baseConfig
+        ...baseConfig,
+        marketplacePublisher: web3.eth.accounts[0]
       })
     }
 


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- Forgot to store the marketplacePublisher ethereum address in the config 😞 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
