### PR TITLE
GraphQL single-unit w/ commission tests

### DIFF
--- a/experimental/origin-eventsource/src/index.js
+++ b/experimental/origin-eventsource/src/index.js
@@ -127,10 +127,9 @@ class OriginEventSource {
     const type = 'unit'
     let commissionPerUnit = '0', commission = '0'
     if (type === 'unit') {
-      const commissionPerUnitOgn =
-        (data.commissionPerUnit && data.commissionPerUnit.amount)
-        || (data.commission && data.commission.amount)
-        || '0'
+      const commissionPerUnitOgn = data.unitsTotal === 1
+        ? (data.commission && data.commission.amount) || '0'
+        : (data.commissionPerUnit && data.commissionPerUnit.amount) || '0'
       commissionPerUnit = this.web3.utils.toWei(commissionPerUnitOgn, 'ether')
 
       const commissionOgn = (data.commission && data.commission.amount) || '0'

--- a/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
@@ -79,22 +79,16 @@ async function toIpfsData(data) {
   let commission = { currency: 'OGN', amount: '0' }
   if (data.commission) {
     // Passed in commission takes precedence
-    commission = {
-      currency: 'OGN',
-      amount: web3.utils.fromWei(data.commission, 'ether')
-    }
+    commission.amount = web3.utils.fromWei(data.commission, 'ether')
   } else if (listing.commissionPerUnit) {
     // Default commission to min(depositAvailable, commissionPerUnit)
     const amount = web3.utils.toBN(listing.commissionPerUnit)
       .mul(web3.utils.toBN(data.quantity))
     const depositAvailable = web3.utils.toBN(listing.depositAvailable)
-    const commissionAmount = amount.lt(depositAvailable)
-      ? amount
-      : depositAvailable
-    commission = {
-      amount: web3.utils.fromWei(commissionAmount, 'ether'),
-      currency: 'OGN'
-    }
+    const commissionWei = amount.lt(depositAvailable)
+      ? amount.toString()
+      : depositAvailable.toString()
+    commission.amount = web3.utils.fromWei(commissionWei, 'ether')
   }
 
   const ipfsData = {

--- a/experimental/origin-graphql/test/_queries.js
+++ b/experimental/origin-graphql/test/_queries.js
@@ -59,8 +59,41 @@ query GetListing($id: String!) {
   marketplace {
     listing(id: $id) {
       id
+      status
+      totalEvents
+      seller {
+        id
+      }
+      arbitrator {
+        id
+      }
+      deposit
+      depositAvailable
+      createdEvent {
+        timestamp
+      }
+
+      category
+      categoryStr
+      subCategory
+      title
+      description
+      currencyId
+      unitsTotal
       unitsAvailable
       unitsSold
+      featured
+      hidden
+      price {
+        amount
+        currency
+      }
+      media {
+        url
+        contentType
+      }
+      commission
+      commissionPerUnit
     }
   }
 }


### PR DESCRIPTION
Single-unit w/ commission tests + more listing field validation in tests

Also put in a fix to use listingIpfs.commission for single-unit listings
and listingIpfs.commissionPerUnit for multi-unit listings. This is
needed for compatibility with existing IPFS schema.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
