### PR TITLE
Fix spelling of 'affiliate' in Config query

### DIFF
--- a/experimental/origin-dapp2/src/queries/Config.js
+++ b/experimental/origin-dapp2/src/queries/Config.js
@@ -4,7 +4,7 @@ export default gql`
   query Config {
     config
     configObj {
-      affilliate
+      affiliate
       arbitrator
       discovery
       bridge

--- a/experimental/origin-graphql/src/contracts.js
+++ b/experimental/origin-graphql/src/contracts.js
@@ -328,8 +328,7 @@ export function setMarketplace(address, epoch) {
   context.eventSource = new EventSource({
     marketplaceContract: context.marketplace,
     ipfsGateway: context.ipfsGateway,
-    web3: context.web3,
-    arbitrator: context.config.arbitrator
+    web3: context.web3
   })
   context.marketplaceExec = context.marketplace
 

--- a/experimental/origin-graphql/src/typeDefs/Web3.js
+++ b/experimental/origin-graphql/src/typeDefs/Web3.js
@@ -30,7 +30,7 @@ export default `
   }
 
   type Config {
-    affilliate: String
+    affiliate: String
     arbitrator: String
     discovery: String
     bridge: String


### PR DESCRIPTION
This fixes the "affiliate" field in dapp2's dapp-info page, where it's
currently blank.

Also removed an unused parameter to the OriginEventSource constructor.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
