### PR TITLE
origin-admin commission handling

### DIFF
--- a/experimental/origin-admin/src/pages/accounts/_populate.js
+++ b/experimental/origin-admin/src/pages/accounts/_populate.js
@@ -204,7 +204,8 @@ export default async function populate(NodeAccount, gqlClient) {
           subCategory: listing.subCategory,
           media: listing.media,
           unitsTotal: listing.unitsTotal,
-          commissionPerUnit
+          commissionPerUnit,
+          commission: listing.commission ? listing.commission.amount : '0'
         }
       }
     })).data.createListing.id

--- a/experimental/origin-admin/src/pages/listings/Listing.js
+++ b/experimental/origin-admin/src/pages/listings/Listing.js
@@ -188,10 +188,6 @@ class Listing extends Component {
           />
           {`. Deposit managed by `}
           <Identity account={listing.arbitrator} />
-          <span style={{ marginLeft: 10 }}>
-            {currency({ amount: listing.depositAvailable, currency: 'OGN' })}/
-            {currency({ amount: listing.deposit, currency: 'OGN' })}
-          </span>
         </span>
         {this.renderActions(sellerPresent, listing)}
         {listing.status === 'withdrawn' ? (
@@ -201,6 +197,16 @@ class Listing extends Component {
             Active
           </Tag>
         )}
+        <br />
+        <span style={{ marginRight: 10 }}>
+          Commission:{' '}
+          {currency({ amount: listing.depositAvailable, currency: 'OGN' })}/
+          {currency({ amount: listing.commission, currency: 'OGN' })}
+        </span>
+        <span>
+          Per-unit commission:{' '}
+          {currency({ amount: listing.commissionPerUnit, currency: 'OGN' })}
+        </span>
       </div>
     )
   }

--- a/experimental/origin-admin/src/pages/marketplace/_Offers.js
+++ b/experimental/origin-admin/src/pages/marketplace/_Offers.js
@@ -346,7 +346,11 @@ function price(offer, field = 'value') {
 
 function status(offer) {
   if (!offer.valid) {
-    return <Tag icon="cross">Invalid</Tag>
+    return (
+      <Tooltip content={offer.validationError}>
+        <Tag icon="cross">Invalid</Tag>
+      </Tooltip>
+    )
   }
 
   if (offer.status === 0) {

--- a/experimental/origin-admin/src/pages/marketplace/mutations/CreateListing.js
+++ b/experimental/origin-admin/src/pages/marketplace/mutations/CreateListing.js
@@ -13,7 +13,8 @@ import {
   HTMLSelect,
   Slider,
   Checkbox,
-  TextArea
+  TextArea,
+  Tag
 } from '@blueprintjs/core'
 
 import rnd from 'utils/rnd'
@@ -50,6 +51,9 @@ class CreateListing extends Component {
       const media = props.listing.media || []
       const category = props.listing.category || 'schema.forSale'
       const subCategory = get(Categories[category], `0.0`, '')
+      const commissionPerUnit = props.listing.commissionPerUnit
+        ? web3.utils.fromWei(props.listing.commissionPerUnit, 'ether')
+        : '0'
 
       this.state = {
         title: props.listing.title || '',
@@ -63,7 +67,8 @@ class CreateListing extends Component {
         autoApprove: true,
         media,
         initialMedia: media,
-        unitsTotal: props.listing.unitsTotal
+        unitsTotal: props.listing.unitsTotal,
+        commissionPerUnit
       }
     } else {
       this.state = {
@@ -79,7 +84,8 @@ class CreateListing extends Component {
         autoApprove: true,
         media: [],
         initialMedia: [],
-        unitsTotal: 1
+        unitsTotal: 1,
+        commissionPerUnit: 5
       }
     }
   }
@@ -240,6 +246,14 @@ class CreateListing extends Component {
                     />
                   </FormGroup>
                 </div>
+                <div style={{ flex: 1 }}>
+                  <FormGroup label="Com/Unit">
+                    <InputGroup
+                      {...input('commissionPerUnit')}
+                      rightElement={<Tag minimal={true}>OGN</Tag>}
+                      />
+                  </FormGroup>
+                </div>
               </div>
               {!isCreate ? null : (
                 <div style={{ display: 'flex' }}>
@@ -307,7 +321,9 @@ class CreateListing extends Component {
       description: egListing.description,
       media: egListing.media,
       initialMedia: egListing.media,
-      unitsTotal: egListing.unitsTotal
+      unitsTotal: egListing.unitsTotal,
+      commission: egListing.commission || '2',
+      commissionPerUnit: egListing.commissionPerUnit || '2'
     })
   }
 
@@ -345,7 +361,9 @@ class CreateListing extends Component {
           category: this.state.category,
           subCategory: this.state.subCategory,
           media: this.state.media.map(m => pick(m, 'contentType', 'url')),
-          unitsTotal: Number(this.state.unitsTotal)
+          unitsTotal: Number(this.state.unitsTotal),
+          commission: String(this.state.deposit) || '0',
+          commissionPerUnit: String(this.state.commissionPerUnit) || '0'
         }
       }
     }

--- a/experimental/origin-admin/src/pages/marketplace/mutations/MakeOffer.js
+++ b/experimental/origin-admin/src/pages/marketplace/mutations/MakeOffer.js
@@ -34,7 +34,7 @@ class MakeOffer extends Component {
     this.state = {
       finalizes: new Date(+new Date() + 1000 * 60 * 60 * 24 * 3),
       affiliate: affiliate ? affiliate.id : ZeroAddress,
-      commission: '2',
+      commission: '5',
       value: '0.1',
       quantity: 1,
       currency: ZeroAddress,
@@ -175,12 +175,15 @@ class MakeOffer extends Component {
 
   getVars() {
     const { affiliate } = this.state
+    const commission = affiliate === ZeroAddress
+      ? '0'
+      : web3.utils.toWei(this.state.commission, 'ether')
     const variables = {
       listingID: String(this.props.listing.id),
       from: this.state.from,
       finalizes: Math.floor(Number(this.state.finalizes) / 1000),
       affiliate,
-      commission: affiliate === ZeroAddress ? '0' : this.state.commission,
+      commission,
       value: this.state.value,
       currency: ZeroAddress,
       arbitrator: this.state.arbitrator,


### PR DESCRIPTION
* Show validation error when hovering over offer status "Invalid"
* Populate commissions for demo listings
* Handle commissions in origin-admin  …
  - Show commissions info on each listing page
  - Specify commission & per-unit commission for create & edit commissions
  - Handle commissions when creating new listing based on example listings

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
