### PR TITLE
Messaging Requirement

### DIFF
--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -206,7 +206,10 @@ class ListingCreate extends Component {
         console.error(`Error fetching contract or IPFS info for listing: ${this.props.listingId}`)
         console.error(error)
       }
-    } else if (web3.currentProvider.isOrigin || !this.props.messagingEnabled) {
+    } else if (
+      web3.currentProvider.isOrigin ||
+      (this.props.messagingRequired && !this.props.messagingEnabled)
+    ) {
       if (!origin.contractService.walletLinker) {
         this.props.history.push('/')
       }
@@ -1800,6 +1803,7 @@ const mapStateToProps = ({ activation, app, config, exchangeRates, wallet }) => 
     exchangeRates,
     marketplacePublisher: config.marketplacePublisher,
     messagingEnabled: activation.messaging.enabled,
+    messagingRequired: app.messagingRequired,
     notificationsHardPermission: activation.notifications.permissions.hard,
     notificationsSoftPermission: activation.notifications.permissions.soft,
     pushNotificationsSupported: activation.notifications.pushEnabled,

--- a/origin-dapp/src/components/listing-detail.js
+++ b/origin-dapp/src/components/listing-detail.js
@@ -140,9 +140,9 @@ class ListingsDetail extends Component {
     if (
       !web3.currentProvider.isOrigin &&
       !origin.contractService.walletLinker &&
-      !this.props.messagingEnabled
+      (this.props.messagingRequired && !this.props.messagingEnabled)
     ) {
-       return
+      return
     }
 
     if ((!web3.currentProvider.isOrigin && this.props.wallet.address) || origin.contractService.walletLinker) {
@@ -1010,6 +1010,7 @@ class ListingsDetail extends Component {
 const mapStateToProps = ({ activation, app, profile, wallet }) => {
   return {
     messagingEnabled: activation.messaging.enabled,
+    messagingRequired: app.messagingRequired,
     notificationsHardPermission: activation.notifications.permissions.hard,
     notificationsSoftPermission: activation.notifications.permissions.soft,
     profile,

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -724,6 +724,7 @@ class Web3Provider extends Component {
 const mapStateToProps = ({ activation, app, wallet }) => {
   return {
     messagingInitialized: activation.messaging.initialized,
+    messagingRequired: app.messagingRequired,
     mobileDevice: app.mobileDevice,
     networkId: app.web3.networkId,
     wallet,

--- a/origin-dapp/src/reducers/App.js
+++ b/origin-dapp/src/reducers/App.js
@@ -4,6 +4,7 @@ const initialState = {
   betaModalDismissed: false,
   // a timestamp for when the messages dropdown was last closed
   messagingDismissed: null,
+  messagingRequired: process.env.MESSAGING_ACCOUNT,
   mobileDevice: null,
   // a list of ids that were present last time the notifications dropdown was closed
   notificationsDismissed: [],


### PR DESCRIPTION
This removes the requirement to run a server and enable messaging when there is not `MESSAGING_ACCOUNT` defined. As a result, [the instructions in the notifications server README](https://github.com/OriginProtocol/origin/tree/master/origin-notifications#the-not-as-easy-way) should now be sufficient.