### PR TITLE
fix a problem with fractional listings not showing in elasticsearch

### DIFF
--- a/origin-js/src/ipfsInterface/adapters/listing/v1-listing-adapter.js
+++ b/origin-js/src/ipfsInterface/adapters/listing/v1-listing-adapter.js
@@ -89,6 +89,9 @@ export default class ListingAdapterV1 extends AdapterBase {
       listing.slots = ipfsData.slots
       listing.slotLength = ipfsData.slotLength
       listing.slotLengthUnit = ipfsData.slotLengthUnit
+      listing.commission = ipfsData.commission
+        ? new Money(ipfsData.commission)
+        : null
     } else {
       throw new Error(`Unexpected listing type: ${listing.type}`)
     }


### PR DESCRIPTION
### Description:
Fix a problem where fractional listings were missing `commission` property when decoded from IPFS. 