### PR TITLE
[Search] Disable indexing of jCal fields

### DIFF
--- a/origin-discovery/src/lib/search.js
+++ b/origin-discovery/src/lib/search.js
@@ -58,6 +58,17 @@ class Listing {
     const gettersToIndex = ['unitsPending', 'unitsSold', 'unitsRemaining', 'commissionRemaining', 'boostCommission']
     gettersToIndex.forEach(getter => listingToIndex[getter] = listing[getter])
 
+    // jCal fields are very dynamic and cause issues with ElasticSearch dynamic mappings.
+    // Disabling indexing of those fields for now until we need to support search by availability.
+    delete listingToIndex.ipfs
+    delete listingToIndex.availability
+    if (listingToIndex.offers) {
+      listingToIndex.offers.forEach(offer => {
+        delete offer.ipfs
+        delete offer.timeSlots
+      })
+    }
+
     await client.index({
       index: LISTINGS_INDEX,
       id: listingId,


### PR DESCRIPTION
### Description:

The new listing.availability and offer.timeSlots fields use a complex jCal type.
This is causing issues with ElasticSearch dynamic mappings functionality.
Here is the scenario:
 - First doc of the corpus with an availability field gets indexed, Elastic decides on a mapping.
 - 2nd doc comes, it has an availability field but the structure is different -> Elastic fails indexing that document since the mapping has changed.

Since for now we do not need to support searching by availability we can simply disable indexing of those fields.

In terms of longer term solution, dynamic mapping is pretty dangerous and we should probably turn it off in favor of defining explicit mappings ourselves.


### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
