### PR TITLE
Enable performance mode by default for origin-box

### DIFF
--- a/development/envfiles/origin-dapp.env
+++ b/development/envfiles/origin-dapp.env
@@ -49,4 +49,4 @@ BLOCK_EPOCH=0
 BLOCK_ATTESTATION_V1=0
 
 # If true, use discovery server for fetching listing/offer data.
-ENABLE_PERFORMANCE_MODE=false
+ENABLE_PERFORMANCE_MODE=true


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- I find myself always enabling performance mode in origin-box so we should make it enabled by default

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
