### PR TITLE
Pass provider URL to web3

### DIFF
--- a/origin-dapp-creator-server/src/middleware.js
+++ b/origin-dapp-creator-server/src/middleware.js
@@ -5,7 +5,7 @@ import { getConfigFromIpfs } from './lib/ipfs'
 import logger from './logger'
 
 const Web3 = require('web3')
-const web3 = new Web3()
+const web3 = new Web3(process.env.PROVIDER_URL)
 
 export async function validateSubdomain (req, res, next) {
   const { address, config } = req.body


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Web3 beta 38 got released and it requires you to pass a provider

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
