### PR TITLE
Pin redis chart to a specific version

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -22,14 +22,14 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: "5"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($request_method = 'GET') {
-          more_set_headers 'Access-Control-Allow-Origin: $http_origin";
+          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
           more_set_headers 'Access-Control-Allow-Credentials: true';
           more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS';
           more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
       }
 
       if ($request_method = 'OPTIONS') {
-          more_set_headers 'Access-Control-Allow-Origin: $http_origin";
+          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
 
           # Cookie support
           more_set_headers 'Access-Control-Allow-Credentials: true';
@@ -45,7 +45,7 @@ metadata:
       }
 
       if ($request_method = 'POST') {
-          more_set_headers 'Access-Control-Allow-Origin: $http_origin";
+          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
           more_set_headers 'Access-Control-Allow-Credentials: true';
           more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS';
           more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';

--- a/deployment/kubernetes/helmfile/origin.yaml
+++ b/deployment/kubernetes/helmfile/origin.yaml
@@ -29,6 +29,8 @@ releases:
   - name: {{ requiredEnv "NAMESPACE" }}-redis
     namespace: {{ requiredEnv "NAMESPACE" }}
     chart: stable/redis
+    # https://github.com/helm/charts/issues/10733
+    version: 5.2.0
     values:
       - ../values/origin/redis/values-{{ requiredEnv "NAMESPACE" }}.yaml
 

--- a/deployment/kubernetes/values/origin/redis/values-dev.yaml
+++ b/deployment/kubernetes/values/origin/redis/values-dev.yaml
@@ -1,3 +1,4 @@
+usePassword: false
 metrics:
   enabled: true
   serviceMonitor:

--- a/deployment/kubernetes/values/origin/redis/values-prod.yaml
+++ b/deployment/kubernetes/values/origin/redis/values-prod.yaml
@@ -1,3 +1,4 @@
+usePassword: false
 metrics:
   enabled: true
   serviceMonitor:

--- a/deployment/kubernetes/values/origin/redis/values-staging.yaml
+++ b/deployment/kubernetes/values/origin/redis/values-staging.yaml
@@ -1,3 +1,4 @@
+usePassword: false
 metrics:
   enabled: true
   serviceMonitor:


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Bug in newer version of redis chart (>5.3.0) with metrics container https://github.com/helm/charts/issues/10733
- Disable password generation for redis

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
