### PR TITLE
Disable IPFS preloading for messaging IPFS

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/bridge.ingress.yaml
@@ -22,14 +22,14 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: "5"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($request_method = 'GET') {
-          more_set_headers 'Access-Control-Allow-Origin: $http_origin";
+          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
           more_set_headers 'Access-Control-Allow-Credentials: true';
           more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS';
           more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
       }
 
       if ($request_method = 'OPTIONS') {
-          more_set_headers 'Access-Control-Allow-Origin: $http_origin";
+          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
 
           # Cookie support
           more_set_headers 'Access-Control-Allow-Credentials: true';
@@ -45,7 +45,7 @@ metadata:
       }
 
       if ($request_method = 'POST') {
-          more_set_headers 'Access-Control-Allow-Origin: $http_origin";
+          more_set_headers 'Access-Control-Allow-Origin: $http_origin';
           more_set_headers 'Access-Control-Allow-Credentials: true';
           more_set_headers 'Access-Control-Allow-Methods: GET, POST, OPTIONS';
           more_set_headers 'Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';

--- a/origin-dapp/src/services/origin.js
+++ b/origin-dapp/src/services/origin.js
@@ -67,6 +67,9 @@ const ipfsCreator = repo_key => {
       Addresses: {
        //Swarm: ['/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star']
       }
+    },
+    preload: {
+      enabled: false
     }
   }
 


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- The js-ipfs team added this functionality where whenever you load something from IPFS it sends an additional request to a preload node to prompt those nodes to try and retrieve those hashes. The IPFS server in the browser for messaging triggers thousands of these requests and we see a lot of failed requests so I think we should disable this preloading for now.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
