### PR TITLE
add originalForm state (check if changes happen on editing listing)

### DIFF
--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -590,12 +590,12 @@ class ListingCreate extends Component {
     localFormData.pictures = picURIsOnly(formData.pictures)
     //currently comming with domain before actual schema and validating schema.const when next step
     localFormData.dappSchemaId = formData.dappSchemaId
-    this.setState({
+    this.setState((prevState) => ({
       formListing: {
-        ...this.state.formListing,
+        ...prevState.formListing,
         formData: localFormData
       }
-    })
+    }))
   }
 
   checkOgnBalance() {

--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -182,10 +182,10 @@ class ListingCreate extends Component {
             }
           },
           selectedSchemaId: listing.dappSchemaId,
-          dappSchemaId : listing.dappSchemaId,
+          dappSchemaId: listing.dappSchemaId,
           selectedBoostAmount: listing.boostValue,
           isEditMode: true
-        };
+        }
         if (listing.pictures.length) {
           const pictures = await getDataURIsFromImgURLs(listing.pictures)
           localState.formListing = {
@@ -195,16 +195,16 @@ class ListingCreate extends Component {
             }
           }
         }
-        await this.setState(localState);
+        await this.setState(localState)
         this.handleCategorySelection(listing.category)
         this.renderDetailsForm(listing.schema)
         this.setState(prevState => ({
-          formOriginalData : {
+          formOriginalData: {
             ...prevState.formListing.formData,
-            dappSchemaId : prevState.dappSchemaId.substring(prevState.dappSchemaId.lastIndexOf('/')+1)
+            dappSchemaId: prevState.dappSchemaId.substring(prevState.dappSchemaId.lastIndexOf('/')+1)
           },
           step: this.STEP.DETAILS
-        }));
+        }))
       } catch (error) {
         console.error(`Error fetching contract or IPFS info for listing: ${this.props.listingId}`)
         console.error(error)
@@ -548,7 +548,7 @@ class ListingCreate extends Component {
       const deepCompare = (val, compare, parentNode = true) => {
         // if current property is an array of same size, convert array to Object(JSON);
         if (Array.isArray(val)) {
-          if (val.length !== compare.length) return false;
+          if (val.length !== compare.length) return false
           const localValue1 = { ...val }
           const localValue2 = { ...compare }
           return deepCompare(localValue1, localValue2, false)
@@ -560,15 +560,15 @@ class ListingCreate extends Component {
           const valKeys = Object.keys(val)
           let isEqual = true
           for (let i = 0; i < valKeys.length; i++) {
-            const key = valKeys[i];
+            const key = valKeys[i]
             if (!deepCompare(val[key], compare[key], false)) {
               isEqual = false
               // if it is parentNode ( we might want to store only tree's parentNode to ensure we can retrieve that later on review session)
               if (parentNode) {
                 changes.push({
                   keyName: key,
-                  currentValue : val[key],
-                  originValue : compare[key]
+                  currentValue: val[key],
+                  originValue: compare[key]
                 })
               }
             }
@@ -581,9 +581,9 @@ class ListingCreate extends Component {
       }
 
       if (!deepCompare(localFormData, formOriginalData)) {
-        this.setState({ originalForm : false })
+        this.setState({ originalForm: false })
       }
-      else this.setState({ originalForm : true })
+      else this.setState({ originalForm: true })
     }
     // console.log('STATE ON FORM DATA CHANGE', this.state)
      console.log('CHANGES', changes)


### PR DESCRIPTION
add deepCompare() algo to formDataChange
change state to work local>setState instead of directly setState
set done button to be disabled whenever the form is original
This only works after #1331 commits get merged.

First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

As mentioned on #1237 , this deepCompare is also saving what changed on 'property' level.


### Checklist:

- [  x ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
