### PR TITLE
Sparrow dom/dapp2 docker attempt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ COPY ./experimental/origin-validator/package*.json ./experimental/origin-validat
 COPY ./experimental/origin-messaging-client/package*.json ./experimental/origin-messaging-client/
 COPY ./experimental/origin-eventsource/package*.json ./experimental/origin-eventsource/
 COPY ./experimental/origin-services/package*.json ./experimental/origin-services/
+COPY ./experimental/origin-admin/package*.json ./experimental/origin-admin/
+COPY ./experimental/origin-dapp2/package*.json ./experimental/origin-dapp2/
 
 # Complete contracts source needs to be available so that `truffle compile contracts`
 # which is calleed by the prepare script can succeed
@@ -42,6 +44,8 @@ COPY ./experimental/origin-validator ./experimental/origin-validator
 COPY ./experimental/origin-eventsource ./experimental/origin-eventsource
 COPY ./experimental/origin-messaging-client ./experimental/origin-messaging-client
 COPY ./experimental/origin-services ./experimental/origin-services
+COPY ./experimental/origin-admin ./experimental/origin-admin
+COPY ./experimental/origin-dapp2 ./experimental/origin-dapp2
 COPY ./origin-growth ./origin-growth
 COPY ./origin-ipfs-proxy ./origin-ipfs-proxy
 COPY ./origin-js ./origin-js

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY ./origin-messaging/package*.json ./origin-messaging/
 COPY ./origin-notifications/package*.json ./origin-notifications/
 COPY ./origin-tests/package*.json ./origin-tests/
 COPY ./origin-growth/package*.json ./origin-growth/
-COPY ./experimental/origin-graphql/package*.json ./origin-graphql
+COPY ./experimental/origin-graphql/package*.json ./experimental/origin-graphql
 
 # Complete contracts source needs to be available so that `truffle compile contracts`
 # which is calleed by the prepare script can succeed
@@ -31,7 +31,7 @@ RUN npm install --unsafe-perm
 # Copy all the source files for the packages
 COPY ./origin-dapp ./origin-dapp
 COPY ./origin-discovery ./origin-discovery
-COPY ./experimental/origin-graphql ./origin-graphql
+COPY ./experimental/origin-graphql ./experimental/origin-graphql
 COPY ./origin-growth ./origin-growth
 COPY ./origin-ipfs-proxy ./origin-ipfs-proxy
 COPY ./origin-js ./origin-js

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,12 @@ COPY ./origin-messaging/package*.json ./origin-messaging/
 COPY ./origin-notifications/package*.json ./origin-notifications/
 COPY ./origin-tests/package*.json ./origin-tests/
 COPY ./origin-growth/package*.json ./origin-growth/
-COPY ./experimental/origin-graphql/package*.json ./experimental/origin-graphql
+COPY ./experimental/origin-graphql/package*.json ./experimental/origin-graphql/
+COPY ./experimental/origin-ipfs/package*.json ./experimental/origin-ipfs/
+COPY ./experimental/origin-validator/package*.json ./experimental/origin-validator/
+COPY ./experimental/origin-messaging-client/package*.json ./experimental/origin-messaging-client/
+COPY ./experimental/origin-eventsource/package*.json ./experimental/origin-eventsource/
+COPY ./experimental/origin-services/package*.json ./experimental/origin-services/
 
 # Complete contracts source needs to be available so that `truffle compile contracts`
 # which is calleed by the prepare script can succeed
@@ -32,6 +37,11 @@ RUN npm install --unsafe-perm
 COPY ./origin-dapp ./origin-dapp
 COPY ./origin-discovery ./origin-discovery
 COPY ./experimental/origin-graphql ./experimental/origin-graphql
+COPY ./experimental/origin-ipfs ./experimental/origin-ipfs
+COPY ./experimental/origin-validator ./experimental/origin-validator
+COPY ./experimental/origin-eventsource ./experimental/origin-eventsource
+COPY ./experimental/origin-messaging-client ./experimental/origin-messaging-client
+COPY ./experimental/origin-services ./experimental/origin-services
 COPY ./origin-growth ./origin-growth
 COPY ./origin-ipfs-proxy ./origin-ipfs-proxy
 COPY ./origin-js ./origin-js

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,6 @@ COPY ./origin-messaging/package*.json ./origin-messaging/
 COPY ./origin-notifications/package*.json ./origin-notifications/
 COPY ./origin-tests/package*.json ./origin-tests/
 COPY ./origin-growth/package*.json ./origin-growth/
-COPY ./experimental/origin-graphql/package*.json ./experimental/origin-graphql/
-COPY ./experimental/origin-ipfs/package*.json ./experimental/origin-ipfs/
-COPY ./experimental/origin-validator/package*.json ./experimental/origin-validator/
-COPY ./experimental/origin-messaging-client/package*.json ./experimental/origin-messaging-client/
-COPY ./experimental/origin-eventsource/package*.json ./experimental/origin-eventsource/
-COPY ./experimental/origin-services/package*.json ./experimental/origin-services/
 
 # Complete contracts source needs to be available so that `truffle compile contracts`
 # which is calleed by the prepare script can succeed
@@ -36,12 +30,6 @@ RUN npm install --unsafe-perm
 # Copy all the source files for the packages
 COPY ./origin-dapp ./origin-dapp
 COPY ./origin-discovery ./origin-discovery
-COPY ./experimental/origin-graphql ./experimental/origin-graphql
-COPY ./experimental/origin-ipfs ./experimental/origin-ipfs
-COPY ./experimental/origin-validator ./experimental/origin-validator
-COPY ./experimental/origin-eventsource ./experimental/origin-eventsource
-COPY ./experimental/origin-messaging-client ./experimental/origin-messaging-client
-COPY ./experimental/origin-services ./experimental/origin-services
 COPY ./origin-growth ./origin-growth
 COPY ./origin-ipfs-proxy ./origin-ipfs-proxy
 COPY ./origin-js ./origin-js

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY ./origin-messaging/package*.json ./origin-messaging/
 COPY ./origin-notifications/package*.json ./origin-notifications/
 COPY ./origin-tests/package*.json ./origin-tests/
 COPY ./origin-growth/package*.json ./origin-growth/
+COPY ./experimental/origin-graphql/package*.json ./origin-graphql
 
 # Complete contracts source needs to be available so that `truffle compile contracts`
 # which is calleed by the prepare script can succeed
@@ -30,6 +31,7 @@ RUN npm install --unsafe-perm
 # Copy all the source files for the packages
 COPY ./origin-dapp ./origin-dapp
 COPY ./origin-discovery ./origin-discovery
+COPY ./experimental/origin-graphql ./origin-graphql
 COPY ./origin-growth ./origin-growth
 COPY ./origin-ipfs-proxy ./origin-ipfs-proxy
 COPY ./origin-js ./origin-js

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -25,6 +25,8 @@ COPY ./experimental/origin-validator/package*.json ./experimental/origin-validat
 COPY ./experimental/origin-messaging-client/package*.json ./experimental/origin-messaging-client/
 COPY ./experimental/origin-eventsource/package*.json ./experimental/origin-eventsource/
 COPY ./experimental/origin-services/package*.json ./experimental/origin-services/
+COPY ./experimental/origin-admin/package*.json ./experimental/origin-admin/
+COPY ./experimental/origin-dapp2/package*.json ./experimental/origin-dapp2/
 
 # Complete contracts source needs to be available so that `truffle compile contracts`
 # which is calleed by the prepare script can succeed
@@ -42,6 +44,8 @@ COPY ./experimental/origin-validator ./experimental/origin-validator
 COPY ./experimental/origin-eventsource ./experimental/origin-eventsource
 COPY ./experimental/origin-messaging-client ./experimental/origin-messaging-client
 COPY ./experimental/origin-services ./experimental/origin-services
+COPY ./experimental/origin-admin ./experimental/origin-admin
+COPY ./experimental/origin-dapp2 ./experimental/origin-dapp2
 COPY ./origin-growth ./origin-growth
 COPY ./origin-ipfs-proxy ./origin-ipfs-proxy
 COPY ./origin-js ./origin-js

--- a/docker-compose.experimental.yaml
+++ b/docker-compose.experimental.yaml
@@ -3,7 +3,10 @@ version: "3"
 services:
   origin-dapp2:
     container_name: origin-dapp2
-    image: origin
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    image: origin-depp2
     volumes:
       # Include origin-contracts build files so the DApp has access to the
       # address of the contracts on the local blockchain

--- a/docker-compose.experimental.yaml
+++ b/docker-compose.experimental.yaml
@@ -11,7 +11,6 @@ services:
       - ./experimental:/app/experimental
     ports:
       - "3000:3000"
-    # npm run start --prefix experimental/origin-dapp2
     command:
       >
-      sleep infinity
+      npm run start --prefix experimental/origin-dapp2

--- a/docker-compose.experimental.yaml
+++ b/docker-compose.experimental.yaml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+  origin-dapp2:
+    container_name: origin-dapp2
+    image: origin
+    volumes:
+      # Include origin-contracts build files so the DApp has access to the
+      # address of the contracts on the local blockchain
+      - ./origin-contracts/build:/app/origin-contracts/build
+      - ./experimental:/app/experimental
+    ports:
+      - "3000:3000"
+    # npm run start --prefix experimental/origin-dapp2
+    command:
+      >
+      sleep infinity

--- a/docker-compose.experimental.yaml
+++ b/docker-compose.experimental.yaml
@@ -12,6 +12,7 @@ services:
       # address of the contracts on the local blockchain
       - ./origin-contracts/build:/app/origin-contracts/build
       - ./experimental:/app/experimental
+      - ./package.json:/app/package.json
     ports:
       - "3000:3000"
     command:

--- a/origin-growth/package.json
+++ b/origin-growth/package.json
@@ -20,6 +20,7 @@
     "graphql": "^0.13.2",
     "graphql-type-json": "^0.2.1",
     "http": "0.0.0",
+    "origin-graphql": "^0.1.0",
     "origin": "^0.8.6",
     "per-env": "^1.0.2",
     "pg": "^7.7.1",

--- a/origin-growth/src/apollo/schema.js
+++ b/origin-growth/src/apollo/schema.js
@@ -1,5 +1,5 @@
 const { gql } = require('apollo-server-express')
-const schema = require('../../../experimental/origin-graphql/src/typeDefs/Growth')
+const schema = require('origin-graphql/src/typeDefs/Growth')
 const typeDefs = gql`${schema}`
 
 module.exports = typeDefs


### PR DESCRIPTION
Make a separate docker-image for development purposes so there is no overhead on Travis and dapp2 can be run from docker. 

** build image with: ** 
```
docker-compose -f docker-compose.experimental.yaml build --no-cache origin-dapp2
```

** up containers with: **
```
docker-compose -f docker-compose.experimental.yaml up
```
