### PR TITLE
Useful debug output for origin-js 

### DIFF
--- a/origin-js/scripts/helpers/contract-addresses.js
+++ b/origin-js/scripts/helpers/contract-addresses.js
@@ -1,0 +1,42 @@
+const { spawn } = require('child_process')
+
+/**
+ * Return a JS object of contract names and their deployed addresses
+ * @return {Object} JS object of {name: address}
+ */
+const truffleContractAddresses = () => {
+  return new Promise((resolve, reject) => {
+    const truffleOutRegex = /(\w+): (0x[A-Fa-f0-9]{40})/
+    const contracts = {}
+    const truffleNetworks = spawn(
+      'truffle',
+      ['networks'],
+      {
+        cwd: '../origin-contracts',
+        env: process.env
+      }
+    )
+    truffleNetworks.stdout.on('data', (data) => {
+      if (data) {
+        const dataArr = data.toString().split('\n')
+        dataArr.map(ln => {
+          ln = ln.trim()
+          const match = ln.match(truffleOutRegex)
+          if (match) {
+            contracts[match[1]] = match[2]
+          }
+        })
+      }
+    })
+    truffleNetworks.on('exit', code => {
+      if (code === 0) {
+        resolve(contracts)
+      } else {
+        reject(null)
+        reject()
+      }
+    })
+  })
+}
+
+module.exports = truffleContractAddresses

--- a/origin-js/scripts/helpers/debug-output.js
+++ b/origin-js/scripts/helpers/debug-output.js
@@ -1,0 +1,30 @@
+const pjson = require('../../package.json')
+const truffleContractAddresses = require('./contract-addresses')
+
+/**
+ * Output to console some details for debugging
+ */
+const debugHeader = async () => {
+    console.log('\n')
+    console.log('#################################################################')
+    console.log('## VERSIONS')
+    console.log('## --------------------------------------------------------------')
+    console.log(`## origin-js: ${pjson.version}`)
+    console.log('#################################################################')
+    console.log('## CONTRACTS')
+    console.log('## --------------------------------------------------------------')
+    const addresses = await truffleContractAddresses()
+    for (const key in addresses) {
+        console.log(`## ${key}: ${addresses[key]}`)
+    }
+    console.log('#################################################################')
+    console.log('## ENV')
+    console.log('## --------------------------------------------------------------')
+    for (const key in process.env) {
+        console.log(`## ${key}: ${process.env[key]}`)
+    }
+    console.log('#################################################################')
+    console.log('\n')
+}
+
+module.exports = debugHeader

--- a/origin-js/scripts/helpers/debug-output.js
+++ b/origin-js/scripts/helpers/debug-output.js
@@ -1,30 +1,53 @@
 const pjson = require('../../package.json')
+const Web3 = require('web3')
 const truffleContractAddresses = require('./contract-addresses')
+
+const EXPLICIT_ENV_WHITELIST = [
+  'NODE',
+  'DEBUG',
+  'LANG',
+  'NVM_DIR'
+]
+
+/**
+ * Check if an env var is whitelisted for debug output
+ * @param {string} The env var name
+ * @return {bool} If the var is whitelisted
+ */
+const isWhitelisted = (name) => {
+  if (name.startsWith('npm_') || EXPLICIT_ENV_WHITELIST.indexOf(name) > -1) {
+    return true
+  }
+  return false
+}
 
 /**
  * Output to console some details for debugging
  */
 const debugHeader = async () => {
-    console.log('\n')
-    console.log('#################################################################')
-    console.log('## VERSIONS')
-    console.log('## --------------------------------------------------------------')
-    console.log(`## origin-js: ${pjson.version}`)
-    console.log('#################################################################')
-    console.log('## CONTRACTS')
-    console.log('## --------------------------------------------------------------')
-    const addresses = await truffleContractAddresses()
-    for (const key in addresses) {
-        console.log(`## ${key}: ${addresses[key]}`)
+  console.log('\n')
+  console.log('#################################################################')
+  console.log('## VERSIONS')
+  console.log('## --------------------------------------------------------------')
+  console.log(`## origin-js: ${pjson.version}`)
+  console.log(`## node: ${process.env.npm_config_node_version}`)
+  console.log('#################################################################')
+  console.log('## CONTRACTS')
+  console.log('## --------------------------------------------------------------')
+  const addresses = await truffleContractAddresses()
+  for (const key in addresses) {
+    console.log(`## ${key}: ${Web3.utils.toChecksumAddress(addresses[key])}`)
+  }
+  console.log('#################################################################')
+  console.log('## ENV')
+  console.log('## --------------------------------------------------------------')
+  for (const key in process.env) {
+    if (isWhitelisted(key)) {
+      console.log(`## ${key}: ${process.env[key]}`)
     }
-    console.log('#################################################################')
-    console.log('## ENV')
-    console.log('## --------------------------------------------------------------')
-    for (const key in process.env) {
-        console.log(`## ${key}: ${process.env[key]}`)
-    }
-    console.log('#################################################################')
-    console.log('\n')
+  }
+  console.log('#################################################################')
+  console.log('\n')
 }
 
 module.exports = debugHeader

--- a/origin-js/scripts/serve.js
+++ b/origin-js/scripts/serve.js
@@ -2,6 +2,7 @@ const chalk = require('chalk')
 const startGanache = require('./helpers/start-ganache')
 const deployContracts = require('./helpers/deploy-contracts')
 const startIpfs = require('./helpers/start-ipfs')
+const debugOutput = require('./helpers/debug-output')
 
 const args = process.argv.slice(2)
 const noGanache = args.length && args[0] === 'no-ganache'
@@ -15,6 +16,8 @@ const start = async () => {
   await deployContracts()
   console.log(chalk`\n{bold.hex('#6e3bea') ⬢  Starting Local IPFS }\n`)
   await startIpfs()
+
+  await debugOutput()
 }
 
 start()


### PR DESCRIPTION
### Description:

This PR adds some helpful debug output when running `origin-js` with `npm start` as requested in #1379.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
