### PR TITLE
fixes #1380 by temporarily pinning a core-js to a specific beta version.

### DIFF
--- a/origin-discovery/package.json
+++ b/origin-discovery/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "apollo-server-express": "^2.2.6",
+    "core-js": "3.0.0-beta.3",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "elasticsearch": "^15.2.0",


### PR DESCRIPTION
### Description:

`apollo-tooling` is running with a beta dep that has an evolving API.  Some imports changed on them and they didn't pin a specific version.  I'm not a huge fan of this PR, since a fix is on the way.  So **this is temporary and should be removed once it's fixed by our dependency**.  This does allow tests to run as expected, however, and it's unclear if this may cause issues in production.

#### References

https://github.com/apollographql/apollo-tooling/issues/962
https://github.com/apollographql/apollo-tooling/pull/961

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
