### PR TITLE
Pointless Web3 Connection Check

### DIFF
--- a/origin-dapp/translations/all-messages.json
+++ b/origin-dapp/translations/all-messages.json
@@ -561,7 +561,6 @@
   "web3-provider.coinbase": "Coinbase Wallet",
   "web3-provider.trust": "Trust Wallet",
   "web3-provider.intentRequiresSignIn": "In order to {web3Intent}, you must sign in to {currentProvider}.",
-  "web3-provider.connecting": "Connecting to network...",
   "web3-provider.shouldBeOnRinkeby": "{currentProvider} should be set to {supportedNetworkName}.",
   "web3-provider.currentlyOnNetwork": "It is currently on {currentNetworkName}.",
   "web3-provider.redirectMessage": "If you are looking for {label}, visit {url}.",

--- a/origin-dapp/translations/messages/src/components/web3-provider.json
+++ b/origin-dapp/translations/messages/src/components/web3-provider.json
@@ -32,10 +32,6 @@
     "defaultMessage": "In order to {web3Intent}, you must sign in to {currentProvider}."
   },
   {
-    "id": "web3-provider.connecting",
-    "defaultMessage": "Connecting to network..."
-  },
-  {
     "id": "web3-provider.shouldBeOnRinkeby",
     "defaultMessage": "{currentProvider} should be set to {supportedNetworkName}."
   },


### PR DESCRIPTION
It seems that there is no merit in checking for a web3 "connection".

- [Trust Wallet provider](https://github.com/TrustWallet/trust-web3-provider/blob/f5bc6f0b19818accbc93eeed61e2931ab4d4db95/src/index.js#L21-L23)
- [MetaMask provider](https://github.com/MetaMask/metamask-inpage-provider/blob/dcfd9245ee4fd687e1e91fa4a9ba23b8a72dd3db/index.js#L111-L113)
- [Web3.js Deprecation](https://github.com/ethereum/web3.js/issues/440#issuecomment-321517072)
- [Web3.js 1.0 docs](https://web3js.readthedocs.io/en/1.0/search.html?q=isconnected&check_keywords=yes&area=default)

It also suffers from [some underlying problem in the Cyton Android wallet](https://github.com/cryptape/cyton-android/issues/294). We've had problems with it in the past when dealing with IMToken's wallet, which did not support `connected` or `isConnected`. And it is likely the cause of a current problem for Zoidcoin, which originally forked a version of Trust Wallet that probably suffered from [a similar issue](https://github.com/OriginProtocol/origin/issues/439).

Finally, it is no longer (or never was?) used in [react-web3](https://github.com/coopermaruyama/react-web3), which was the inspiration for our current web3-provider component.

Either we have a web3 provider and a network id or not. 🗑 