### PR TITLE
Pin terser to 3.14.1

### DIFF
--- a/origin-dapp-creator-client/package.json
+++ b/origin-dapp-creator-client/package.json
@@ -54,6 +54,7 @@
     "rework": "^1.0.1",
     "style-loader": "0.23.1",
     "superagent": "^4.0.0",
+    "terser": "3.14.1",
     "terser-webpack-plugin": "^1.1.0",
     "web3": "^1.0.0-beta.37",
     "webpack": "^4.27.0",

--- a/origin-dapp/package.json
+++ b/origin-dapp/package.json
@@ -64,6 +64,7 @@
     "serve": "^10.1.1",
     "store": "^2.0.12",
     "style-loader": "0.23.1",
+    "terser": "3.14.1",
     "web3": "1.0.0-beta.34",
     "webpack": "^4.27.0",
     "webpack-cli": "^3.1.2"

--- a/origin-js/package.json
+++ b/origin-js/package.json
@@ -79,6 +79,7 @@
     "mocha": "^5.2.0",
     "mocha-loader": "^2.0.0",
     "sinon": "^7.1.1",
+    "terser": "3.14.1",
     "web3-provider-engine": "^14.1.0",
     "webpack": "^4.27.0"
   },


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Webpack now uses Terser for minification, Terser released a broken package which causes these errors for builds:

`TypeError: Cannot read property 'minify' of undefined`

- Pinned terser to the version prior to the broken one
- Ref https://github.com/terser-js/terser/issues/251

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
