### PR TITLE
fixes #1392.  Added in missed import.

### DIFF
--- a/origin-js/src/ipfsInterface/schema-id.js
+++ b/origin-js/src/ipfsInterface/schema-id.js
@@ -1,3 +1,5 @@
+const { URL } = require('url')
+
 /*
   Utilities for manipulating schemaIds.
 


### PR DESCRIPTION
### Description:

Missing an import of `URL` in `origin-js/src/ipfsInterface/schema-id.js`.

That test I changed in PR #1383 is now failing on my local, but [passing in travis](https://travis-ci.org/OriginProtocol/origin/builds/488807474).  Not really sure what's going on there.  Maybe something to do with having a clean DB?  Reverting my change from that PR doesn't make it pass, either.

Ref: #1392

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
