### PR TITLE
Prettier implementation and run on origin-messaging

### DIFF
--- a/origin-messaging/.eslintrc.js
+++ b/origin-messaging/.eslintrc.js
@@ -2,7 +2,7 @@ const baseConfig = require('../.eslintrc.js')
 
 module.exports = {
   ...baseConfig,
-  'globals': {
-    'web3': true,
+  globals: {
+    web3: true
   }
 }

--- a/origin-messaging/package.json
+++ b/origin-messaging/package.json
@@ -9,11 +9,13 @@
   "scripts": {
     "build": "per-env",
     "build:production": "babel src/* -d dist --presets @babel/env",
+    "lint": "eslint . && npm run prettier:check",
+    "prettier": "prettier --write *.js \"src/**/*.js\"",
+    "prettier:check": "prettier -c *.js \"src/**/*.js\"",
+    "prestart:production": "npm run build",
     "start": "per-env",
     "start:development": "nodemon --exec 'babel-node' src/index.js --presets @babel/env",
-    "prestart:production": "npm run build",
     "start:production": "node dist/index.js",
-    "lint": "eslint '**/*.js'",
     "test": "echo \"Warning: no tests specified\""
   },
   "repository": {
@@ -47,5 +49,9 @@
     "@babel/node": "^7.2.0",
     "eslint": "^5.9.0",
     "nodemon": "^1.18.7"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
   }
 }

--- a/origin-messaging/src/config.js
+++ b/origin-messaging/src/config.js
@@ -13,8 +13,9 @@ module.exports = Object.freeze({
   IPFS_ADDRESS: process.env.IPFS_ADDRESS || null,
   IPFS_PORT: process.env.IPFS_PORT || '5001',
 
-  IPFS_MAX_CONNECTIONS: process.env.IPFS_MAX_CONNECTIONS ?
-    Number(process.env.IPFS_MAX_CONNECTIONS) : 16384,
+  IPFS_MAX_CONNECTIONS: process.env.IPFS_MAX_CONNECTIONS
+    ? Number(process.env.IPFS_MAX_CONNECTIONS)
+    : 16384,
   IPFS_REPO_PATH: process.env.IPFS_REPO_PATH || './ipfs',
   IPFS_WS_ADDRESS: process.env.IPFS_WS_ADDRESS || '/ip4/0.0.0.0/tcp/9012/ws',
 
@@ -24,5 +25,5 @@ module.exports = Object.freeze({
   ORBIT_DB_PATH: process.env.ORBIT_DB_PATH || './odb',
 
   RPC_SERVER: process.env.RPC_SERVER,
-  SNAPSHOT_BATCH_SIZE: process.env.SNAPSHOT_BATCH_SIZE || 150,
+  SNAPSHOT_BATCH_SIZE: process.env.SNAPSHOT_BATCH_SIZE || 150
 })

--- a/origin-messaging/src/exchange-heads.js
+++ b/origin-messaging/src/exchange-heads.js
@@ -4,9 +4,18 @@ import logger from './logger'
 
 const Channel = require('ipfs-pubsub-1on1')
 
-const getHeadsForDatabase = store => (store && store._oplog) ? store._oplog.heads : []
+const getHeadsForDatabase = store =>
+  store && store._oplog ? store._oplog.heads : []
 
-const exchangeHeads = async (ipfs, address, peer, getStore, getDirectConnection, onMessage, onChannelCreated) => {
+const exchangeHeads = async (
+  ipfs,
+  address,
+  peer,
+  getStore,
+  getDirectConnection,
+  onMessage,
+  onChannelCreated
+) => {
   const _handleMessage = message => {
     const msg = JSON.parse(message.data)
     const { address, heads } = msg

--- a/origin-messaging/src/index.js
+++ b/origin-messaging/src/index.js
@@ -30,12 +30,12 @@ function sleep(ms) {
 async function startRoom(roomDb, roomId, storeType, writers, shareFunc) {
   let key = roomId
   if (writers.length != 1 || writers[0] != '*') {
-    key = roomId + '-' +  writers.join('-')
+    key = roomId + '-' + writers.join('-')
   }
 
   logger.debug(`Checking key: ${key}`)
 
-  if(!messagingRoomsMap[key]) {
+  if (!messagingRoomsMap[key]) {
     messagingRoomsMap[key] = 'pending'
     const room = await roomDb[storeType](roomId, { write: writers })
 
@@ -63,16 +63,17 @@ function handleGlobalRegistryWrite(convInitDb, payload) {
   if (payload.op == 'PUT') {
     const ethAddress = payload.key
     logger.debug(`Started conversation for: ${ethAddress}`)
-    startRoom(convInitDb, config.CONV_INIT_PREFIX + ethAddress, 'kvstore', ['*'])
+    startRoom(convInitDb, config.CONV_INIT_PREFIX + ethAddress, 'kvstore', [
+      '*'
+    ])
   }
 }
 
-function rebroadcastOnReplicate(DB, db){
+function rebroadcastOnReplicate(DB, db) {
   db.events.on('replicated', (address, length, from) => {
     // rebroadcast
-    DB._pubsub.publish(db.id,  db._oplog.heads)
-    if (from != 'fromSnapshot')
-    {
+    DB._pubsub.publish(db.id, db._oplog.heads)
+    if (from != 'fromSnapshot') {
       snapshotDB(db)
     }
   })
@@ -136,8 +137,7 @@ async function loadSnapshotDB(db) {
       await saveToIpfs(db._ipfs, entry)
     }
     */
-    if (snapshotData.values.length < snapshotBatchSize)
-    {
+    if (snapshotData.values.length < snapshotBatchSize) {
       const log = new Log(
         db._ipfs,
         snapshotData.id,
@@ -150,8 +150,7 @@ async function loadSnapshotDB(db) {
       await db._oplog.join(log)
     } else {
       const values = snapshotData.values
-      while(values.length)
-      {
+      while (values.length) {
         const push_values = values.splice(0, snapshotBatchSize)
         const log = new Log(
           db._ipfs,
@@ -167,7 +166,12 @@ async function loadSnapshotDB(db) {
       }
     }
     await db._updateIndex()
-    db.events.emit('replicated', db.address.toString(), undefined, 'fromSnapshot')
+    db.events.emit(
+      'replicated',
+      db.address.toString(),
+      undefined,
+      'fromSnapshot'
+    )
   }
   db.__snapshot_loaded = true
   db.events.emit('ready', db.address.toString(), db._oplog.heads)
@@ -180,7 +184,8 @@ async function startSnapshotDB(db) {
 async function _onPeerConnected(address, peer) {
   const getStore = address => this.stores[address]
   const getDirectConnection = peer => this._directConnections[peer]
-  const onChannelCreated = channel => this._directConnections[channel._receiverID] = channel
+  const onChannelCreated = channel =>
+    (this._directConnections[channel._receiverID] = channel)
   const onMessage = (address, heads) => this._onMessage(address, heads)
 
   await exchangeHeads(
@@ -205,20 +210,24 @@ const initRESTApp = db => {
   // limit request to one per minute
   const rateLimiterOptions = {
     points: 1,
-    duration: 60,
+    duration: 60
   }
   const rateLimiter = new RateLimiterMemory(rateLimiterOptions)
 
   // should be tightened up for security
   app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*')
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept'
+    )
 
     next()
   })
 
   app.all((req, res, next) => {
-    rateLimiter.consume(req.connection.remoteAddress)
+    rateLimiter
+      .consume(req.connection.remoteAddress)
       .then(() => {
         next()
       })
@@ -228,8 +237,9 @@ const initRESTApp = db => {
   })
 
   app.get('/', async (req, res) => {
-    const markup = '<h1>Origin Messaging</h1>' +
-                 '<h2><a href="https://medium.com/originprotocol/introducing-origin-messaging-decentralized-secure-and-auditable-13c16fe0f13e">Learn More</a></h2>'
+    const markup =
+      '<h1>Origin Messaging</h1>' +
+      '<h2><a href="https://medium.com/originprotocol/introducing-origin-messaging-decentralized-secure-and-auditable-13c16fe0f13e">Learn More</a></h2>'
 
     res.send(markup)
   })
@@ -265,14 +275,12 @@ const initRESTApp = db => {
   })
 }
 
-const startOrbitDbServer = async (ipfs) => {
+const startOrbitDbServer = async ipfs => {
   // Remap the peer connected to ours which will wait before exchanging heads
   // with the same peer
-  const orbitGlobal = new OrbitDB(
-    ipfs,
-    config.ORBIT_DB_PATH,
-    { keystore: new InsertOnlyKeystore() }
-  )
+  const orbitGlobal = new OrbitDB(ipfs, config.ORBIT_DB_PATH, {
+    keystore: new InsertOnlyKeystore()
+  })
 
   orbitGlobal._onPeerConnected = _onPeerConnected
 
@@ -285,9 +293,9 @@ const startOrbitDbServer = async (ipfs) => {
     }
   )
 
-  const globalRegistry = await orbitGlobal.kvstore(
-    config.GLOBAL_KEYS, { write: ['*'] }
-  )
+  const globalRegistry = await orbitGlobal.kvstore(config.GLOBAL_KEYS, {
+    write: ['*']
+  })
   rebroadcastOnReplicate(orbitGlobal, globalRegistry)
   orbitGlobal.keystore.registerSignVerify(
     config.CONV_INIT_PREFIX,
@@ -300,7 +308,9 @@ const startOrbitDbServer = async (ipfs) => {
     }
   )
   orbitGlobal.keystore.registerSignVerify(
-    config.CONV, undefined, verifyMessageSignature(globalRegistry, orbitGlobal)
+    config.CONV,
+    undefined,
+    verifyMessageSignature(globalRegistry, orbitGlobal)
   )
   logger.debug(`Orbit registry started...: ${globalRegistry.id}`)
 
@@ -321,14 +331,18 @@ const main = async () => {
     const ipfs = IPFSApi(config.IPFS_ADDRESS, config.IPFS_PORT)
     const ipfsId = ipfs.id()
 
-    await ipfsId.then((peer) => {
-      logger.info(`Connected to IPFS server: ${peer.id}`)
-      startOrbitDbServer(ipfs)
-    }).catch((error) => {
-      logger.error(`Connection error ${config.IPFS_ADDRESS}:${config.IPFS_PORT}`)
-      logger.error(error)
-      setTimeout(main, 5000)
-    })
+    await ipfsId
+      .then(peer => {
+        logger.info(`Connected to IPFS server: ${peer.id}`)
+        startOrbitDbServer(ipfs)
+      })
+      .catch(error => {
+        logger.error(
+          `Connection error ${config.IPFS_ADDRESS}:${config.IPFS_PORT}`
+        )
+        logger.error(error)
+        setTimeout(main, 5000)
+      })
   } else {
     // Create our own IPFS server
     logger.debug(`Creating IPFS server`)
@@ -336,17 +350,17 @@ const main = async () => {
     const ipfs = new IPFS({
       repo: config.IPFS_REPO_PATH,
       EXPERIMENTAL: {
-        pubsub: true,
+        pubsub: true
       },
       config: {
         Bootstrap: [],
         Addresses: {
-         Swarm: [config.IPFS_WS_ADDRESS]
+          Swarm: [config.IPFS_WS_ADDRESS]
         }
       }
     })
 
-    ipfs.on('error', (e) => console.error(e))
+    ipfs.on('error', e => console.error(e))
     ipfs.on('ready', async () => {
       ipfs.setMaxListeners(config.IPFS_MAX_CONNECTIONS)
       startOrbitDbServer(ipfs)

--- a/origin-messaging/src/insert-only-keystore.js
+++ b/origin-messaging/src/insert-only-keystore.js
@@ -11,7 +11,7 @@ class InsertOnlyKeystore {
 
   getSignVerify(id) {
     const parts = id.split('/')
-    const end = parts[parts.length-1]
+    const end = parts[parts.length - 1]
 
     const obj = this._signVerifyRegistry[end]
     if (obj) return obj
@@ -51,7 +51,7 @@ class InsertOnlyKeystore {
       if (obj && obj.verifyFunc) {
         if (message.payload.op == 'PUT' || message.payload.op == 'ADD') {
           //verify all for now
-          if(obj.verifyFunc(signature, key, message, data)) {
+          if (obj.verifyFunc(signature, key, message, data)) {
             if (obj.postFunc) {
               obj.postFunc(message)
             }
@@ -59,7 +59,7 @@ class InsertOnlyKeystore {
           }
         }
       }
-    } catch(error) {
+    } catch (error) {
       console.log(error)
     }
 

--- a/origin-messaging/src/logger.js
+++ b/origin-messaging/src/logger.js
@@ -2,4 +2,6 @@
 
 const Logger = require('logplease')
 Logger.setLogLevel('DEBUG')
-module.exports = Logger.create('origin-messaging', { color: Logger.Colors.Yellow })
+module.exports = Logger.create('origin-messaging', {
+  color: Logger.Colors.Yellow
+})

--- a/origin-messaging/src/verify.js
+++ b/origin-messaging/src/verify.js
@@ -28,17 +28,26 @@ function verifyConversationSignature(keysMap) {
   }
 }
 
-function verifyConversers(conversee, keysMap){
+function verifyConversers(conversee, keysMap) {
   return (o, contentObject) => {
-    const checkString = joinConversationKey(conversee, o.parentSub) +
-      contentObject.ts.toString()
-    const verifyAddress = web3.eth.accounts.recover(checkString, contentObject.sig)
+    const checkString =
+      joinConversationKey(conversee, o.parentSub) + contentObject.ts.toString()
+    const verifyAddress = web3.eth.accounts.recover(
+      checkString,
+      contentObject.sig
+    )
     const parentKey = keysMap.get(o.parentSub)
     const converseeKey = keysMap.get(conversee)
 
-    if ((parentKey && verifyAddress == parentKey.address) ||
-        (converseeKey && verifyAddress == keysMap.get(conversee).address)) {
-      logger.debug(`Verified conv init for ${conversee}, Signature: ${contentObject.sign}, Signed with: ${verifyAddress}`)
+    if (
+      (parentKey && verifyAddress == parentKey.address) ||
+      (converseeKey && verifyAddress == keysMap.get(conversee).address)
+    ) {
+      logger.debug(
+        `Verified conv init for ${conversee}, Signature: ${
+          contentObject.sign
+        }, Signed with: ${verifyAddress}`
+      )
       return true
     }
     return false
@@ -47,7 +56,9 @@ function verifyConversers(conversee, keysMap){
 
 function verifyMessageSignature(keysMap, orbitGlobal) {
   return (signature, key, message, buffer) => {
-    logger.debug(`Verify message: ${message.id}, Key: ${key}, Signature: ${signature}`)
+    logger.debug(
+      `Verify message: ${message.id}, Key: ${key}, Signature: ${signature}`
+    )
 
     const verifyAddress = web3.eth.accounts.recover(
       buffer.toString('utf8'),
@@ -56,15 +67,20 @@ function verifyMessageSignature(keysMap, orbitGlobal) {
     const entry = keysMap.get(key)
 
     const db_store = orbitGlobal.stores[message.id]
-    if (config.LINKING_NOTIFY_ENDPOINT &&
+    if (
+      config.LINKING_NOTIFY_ENDPOINT &&
       db_store &&
       db_store.__snapshot_loaded &&
       db_store.access.write.includes(key)
     ) {
       const value = message.payload.value
       if (value.length && value[0].emsg) {
-        const receivers = db_store.access.write.filter(address => address != key).
-          reduce((acc, i) => {acc[i] = { newMessage: true }; return acc}, {})
+        const receivers = db_store.access.write
+          .filter(address => address != key)
+          .reduce((acc, i) => {
+            acc[i] = { newMessage: true }
+            return acc
+          }, {})
 
         fetch(config.LINKING_NOTIFY_ENDPOINT, {
           method: 'POST',
@@ -72,7 +88,10 @@ function verifyMessageSignature(keysMap, orbitGlobal) {
             Accept: 'application/json',
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify({ receivers, token: config.LINKING_NOTIFY_TOKEN })
+          body: JSON.stringify({
+            receivers,
+            token: config.LINKING_NOTIFY_TOKEN
+          })
         })
       }
     }
@@ -91,10 +110,13 @@ function verifyRegistrySignature(signature, key, message) {
     const extractedAddress = '0x' + web3.utils.sha3(value.pub_key).substr(-40)
 
     if (extractedAddress == value.address.toLowerCase()) {
-
       const verifyPhAddress = web3.eth.accounts.recover(value.ph, value.phs)
       if (verifyPhAddress == value.address) {
-        logger.debug(`Key verified: ${value.msg}, Signature: ${signature}, Signed with, ${verifyAddress}`)
+        logger.debug(
+          `Key verified: ${
+            value.msg
+          }, Signature: ${signature}, Signed with, ${verifyAddress}`
+        )
         return true
       }
     }


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Implement and run prettier for `origin-messaging`

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~