### PR TITLE
Implement prettier and run for origin-ipfs-proxy

### DIFF
--- a/origin-ipfs-proxy/load.js
+++ b/origin-ipfs-proxy/load.js
@@ -8,20 +8,25 @@ const logger = require('./src/logger')
 
 const imageHash = 'QmcJwbSPxVgpLsnN3ESAeZ7FRSapYKa27pWFhY9orsZat7'
 const ipfsFactory = ipfsdCtl.create({
-  type: 'js',
+  type: 'js'
 })
 require('./src/app')
 
 async function spawnIpfs() {
   return new Promise((resolve, reject) => {
-    ipfsFactory.spawn({
-      disposable: true,
-      defaultAddrs: true
-    }, (err, node) => {
-      if (err) { reject(err) }
-      node.api.util.addFromFs('./fixtures/sample_1mb.jpg')
-      resolve(node)
-    })
+    ipfsFactory.spawn(
+      {
+        disposable: true,
+        defaultAddrs: true
+      },
+      (err, node) => {
+        if (err) {
+          reject(err)
+        }
+        node.api.util.addFromFs('./fixtures/sample_1mb.jpg')
+        resolve(node)
+      }
+    )
   })
 }
 
@@ -30,20 +35,23 @@ async function loadTest(url, requests = []) {
   let autocannonInstance
 
   return new Promise((resolve, reject) => {
-    autocannonInstance = autocannon({
-      url: url,
-      connections: 10,
-      pipelining: 1,
-      duration: 30,
-      requests: requests
-    }, (err, res) => {
-      if (err) {
-        logger.error(err)
-        reject(err)
+    autocannonInstance = autocannon(
+      {
+        url: url,
+        connections: 10,
+        pipelining: 1,
+        duration: 30,
+        requests: requests
+      },
+      (err, res) => {
+        if (err) {
+          logger.error(err)
+          reject(err)
+        }
+        ipfsNode.stop()
+        resolve(res)
       }
-      ipfsNode.stop()
-      resolve(res)
-    })
+    )
 
     autocannon.track(autocannonInstance, {
       renderLatencyTable: true

--- a/origin-ipfs-proxy/package.json
+++ b/origin-ipfs-proxy/package.json
@@ -4,7 +4,9 @@
   "description": "A proxy that validates Origin content being uploaded and downloaded from Origin's IPFS servers",
   "main": "app.js",
   "scripts": {
-    "lint": "eslint '**/*.js'",
+    "lint": "eslint '**/*.js' && npm run prettier:check",
+    "prettier": "prettier --write *.js \"src/**/*.js\"",
+    "prettier:check": "prettier -c *.js \"src/**/*.js\"",
     "start": "per-env",
     "start:development": "nodemon src/app.js",
     "start:production": "node src/app.js",
@@ -43,5 +45,9 @@
     "nodemon": "^1.18.7",
     "supertest": "^3.3.0",
     "webrtcsupport": "^2.2.0"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
   }
 }

--- a/origin-ipfs-proxy/src/config.js
+++ b/origin-ipfs-proxy/src/config.js
@@ -1,6 +1,6 @@
 module.exports = Object.freeze({
-  'IPFS_API_URL': process.env.IPFS_API_URL || 'http://127.0.0.1:5002',
-  'IPFS_GATEWAY_URL': process.env.IPFS_GATEWAY_URL || 'http://127.0.0.1:9090',
-  'IPFS_PROXY_PORT': process.env.IPFS_PROXY_PORT || 9999,
-  'IPFS_PROXY_ADDRESS': process.env.IPFS_PROXY_ADDRESS || '0.0.0.0'
+  IPFS_API_URL: process.env.IPFS_API_URL || 'http://127.0.0.1:5002',
+  IPFS_GATEWAY_URL: process.env.IPFS_GATEWAY_URL || 'http://127.0.0.1:9090',
+  IPFS_PROXY_PORT: process.env.IPFS_PROXY_PORT || 9999,
+  IPFS_PROXY_ADDRESS: process.env.IPFS_PROXY_ADDRESS || '0.0.0.0'
 })

--- a/origin-ipfs-proxy/test.js
+++ b/origin-ipfs-proxy/test.js
@@ -24,28 +24,31 @@ describe('upload', () => {
   let ipfsFactory
   let ipfsd
 
-  before((done) => {
+  before(done => {
     server = require('./src/app')
     ipfsFactory = ipfsdCtl.create({
-      type: 'js',
+      type: 'js'
     })
 
-    ipfsFactory.spawn({
-      disposable: true,
-      defaultAddrs: true
-    }, (err, node) => {
-      expect(err).to.be.null
-      ipfsd = node
-      done()
-    })
+    ipfsFactory.spawn(
+      {
+        disposable: true,
+        defaultAddrs: true
+      },
+      (err, node) => {
+        expect(err).to.be.null
+        ipfsd = node
+        done()
+      }
+    )
   })
 
-  after((done) => {
+  after(done => {
     server.close()
     ipfsd.stop(done)
   })
 
-  it('should prevent uploads larger than size limit', (done) => {
+  it('should prevent uploads larger than size limit', done => {
     const image = './fixtures/sample_5mb.jpg'
     request(server)
       .post('/api/v0/add')
@@ -53,7 +56,7 @@ describe('upload', () => {
       .expect(413, done)
   })
 
-  it('should prevent uploads larger then size with fake content length', (done) => {
+  it('should prevent uploads larger then size with fake content length', done => {
     const image = './fixtures/sample_5mb.jpg'
     request(server)
       .post('/api/v0/add')
@@ -62,7 +65,7 @@ describe('upload', () => {
       .expect(413, done)
   })
 
-  it('should allow gif uploads', (done) => {
+  it('should allow gif uploads', done => {
     const image = './fixtures/sample.gif'
     request(server)
       .post('/api/v0/add')
@@ -70,7 +73,7 @@ describe('upload', () => {
       .expect(200, done)
   })
 
-  it('should allow file uploads with query string', (done) => {
+  it('should allow file uploads with query string', done => {
     const image = './fixtures/sample.gif'
     request(server)
       .post('/api/v0/add?stream-channels=true')
@@ -78,7 +81,7 @@ describe('upload', () => {
       .expect(200, done)
   })
 
-  it('should allow png uploads', (done) => {
+  it('should allow png uploads', done => {
     const image = './fixtures/sample.png'
     request(server)
       .post('/api/v0/add')
@@ -86,7 +89,7 @@ describe('upload', () => {
       .expect(200, done)
   })
 
-  it('should allow jpg uploads', (done) => {
+  it('should allow jpg uploads', done => {
     const image = './fixtures/sample_1mb.jpg'
     request(server)
       .post('/api/v0/add')
@@ -94,15 +97,15 @@ describe('upload', () => {
       .expect(200, done)
   })
 
-  it('should allow ico uploads', (done) => {
-   const image = './fixtures/sample.ico'
+  it('should allow ico uploads', done => {
+    const image = './fixtures/sample.ico'
     request(server)
       .post('/api/v0/add')
       .attach('image', image)
       .expect(200, done)
   })
 
-  it('should allow json uploads', (done) => {
+  it('should allow json uploads', done => {
     const json = './fixtures/sample.json'
     request(server)
       .post('/api/v0/add')
@@ -110,7 +113,7 @@ describe('upload', () => {
       .expect(200, done)
   })
 
-  it('should prevent svg uploads', (done) => {
+  it('should prevent svg uploads', done => {
     const image = './fixtures/sample.svg'
     request(server)
       .post('/api/v0/add')
@@ -118,7 +121,7 @@ describe('upload', () => {
       .expect(415, done)
   })
 
-  it('should prevent html uploads', (done) => {
+  it('should prevent html uploads', done => {
     const html = './fixtures/sample.html'
     request(server)
       .post('/api/v0/add')
@@ -126,30 +129,34 @@ describe('upload', () => {
       .expect(415, done)
   })
 
-  it('should deflate the content', (done) => {
+  it('should deflate the content', done => {
     const image = './fixtures/sample_1mb.jpg'
 
     request(server)
       .post('/api/v0/add')
       .attach('image', image)
       .set('Accept-Encoding', 'deflate')
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(200)
-        expect(JSON.parse(response.text)['Hash']).to.equal(ipfsHashes['sample_1mb.jpg'])
+        expect(JSON.parse(response.text)['Hash']).to.equal(
+          ipfsHashes['sample_1mb.jpg']
+        )
         done()
       })
   })
 
-  it('should gzip the content', (done) => {
+  it('should gzip the content', done => {
     const image = './fixtures/sample_1mb.jpg'
 
     request(server)
       .post('/api/v0/add')
       .attach('image', image)
       .set('Accept-Encoding', 'gzip')
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(200)
-        expect(JSON.parse(response.text)['Hash']).to.equal(ipfsHashes['sample_1mb.jpg'])
+        expect(JSON.parse(response.text)['Hash']).to.equal(
+          ipfsHashes['sample_1mb.jpg']
+        )
         done()
       })
   })
@@ -160,43 +167,46 @@ describe('download', () => {
   let ipfsFactory
   let ipfsd
 
-  before((done) => {
+  before(done => {
     server = require('./src/app')
 
     ipfsFactory = ipfsdCtl.create({
-      type: 'js',
+      type: 'js'
     })
 
-    ipfsFactory.spawn({
-      disposable: true,
-      defaultAddrs: true
-    }, (err, node) => {
-      expect(err).to.be.null
-      ipfsd = node
-      Promise.all([
-        ipfsd.api.addFromFs('./fixtures/sample_1mb.jpg'),
-        ipfsd.api.addFromFs('./fixtures/sample_5mb.jpg'),
-        ipfsd.api.addFromFs('./fixtures/sample.gif'),
-        ipfsd.api.addFromFs('./fixtures/sample.ico'),
-        ipfsd.api.addFromFs('./fixtures/sample.json'),
-        ipfsd.api.addFromFs('./fixtures/sample.png'),
-        ipfsd.api.addFromFs('./fixtures/sample.html')
-      ]).then(() => {
-        done()
-      })
-    })
+    ipfsFactory.spawn(
+      {
+        disposable: true,
+        defaultAddrs: true
+      },
+      (err, node) => {
+        expect(err).to.be.null
+        ipfsd = node
+        Promise.all([
+          ipfsd.api.addFromFs('./fixtures/sample_1mb.jpg'),
+          ipfsd.api.addFromFs('./fixtures/sample_5mb.jpg'),
+          ipfsd.api.addFromFs('./fixtures/sample.gif'),
+          ipfsd.api.addFromFs('./fixtures/sample.ico'),
+          ipfsd.api.addFromFs('./fixtures/sample.json'),
+          ipfsd.api.addFromFs('./fixtures/sample.png'),
+          ipfsd.api.addFromFs('./fixtures/sample.html')
+        ]).then(() => {
+          done()
+        })
+      }
+    )
   })
 
-  after((done) => {
+  after(done => {
     server.close()
     ipfsd.stop(done)
   })
 
-  it('should allow gif downloads', (done) => {
+  it('should allow gif downloads', done => {
     const fileBuffer = fs.readFileSync('./fixtures/sample.gif')
     request(server)
       .get(`/ipfs/${ipfsHashes['sample.gif']}`)
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(200)
         expect(response.headers['content-type']).to.equal('image/gif')
         expect(Buffer.compare(fileBuffer, response.body)).to.equal(0)
@@ -204,11 +214,11 @@ describe('download', () => {
       })
   })
 
-  it('should allow png downloads', (done) => {
+  it('should allow png downloads', done => {
     const fileBuffer = fs.readFileSync('./fixtures/sample.png')
     request(server)
       .get(`/ipfs/${ipfsHashes['sample.png']}`)
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(200)
         expect(response.headers['content-type']).to.equal('image/png')
         expect(Buffer.compare(fileBuffer, response.body)).to.equal(0)
@@ -216,12 +226,12 @@ describe('download', () => {
       })
   })
 
-  it('should allow jpg downloads', (done) => {
+  it('should allow jpg downloads', done => {
     const fileBuffer = fs.readFileSync('./fixtures/sample_1mb.jpg')
 
     request(server)
       .get(`/ipfs/${ipfsHashes['sample_1mb.jpg']}`)
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(200)
         expect(response.headers['content-type']).to.equal('image/jpeg')
         expect(Buffer.compare(fileBuffer, response.body)).to.equal(0)
@@ -229,21 +239,21 @@ describe('download', () => {
       })
   })
 
-  it('should allow json downloads', (done) => {
+  it('should allow json downloads', done => {
     const fileBuffer = fs.readFileSync('./fixtures/sample.json')
     request(server)
       .get(`/ipfs/${ipfsHashes['sample.json']}`)
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(200)
         expect(response.text).to.equal(fileBuffer.toString())
         done()
       })
   })
 
-  it('should prevent html downloads', (done) => {
+  it('should prevent html downloads', done => {
     request(server)
       .get(`/ipfs/${ipfsHashes['sample.html']}`)
-      .then((response) => {
+      .then(response => {
         expect(response.status).to.equal(415)
         done()
       })


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Title says it all

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
