### PR TITLE
Pin web3 in creator to beta 34

### DIFF
--- a/origin-dapp-creator-client/package.json
+++ b/origin-dapp-creator-client/package.json
@@ -59,7 +59,7 @@
     "superagent": "^4.0.0",
     "terser": "3.14.1",
     "terser-webpack-plugin": "^1.1.0",
-    "web3": "^1.0.0-beta.37",
+    "web3": "1.0.0-beta.34",
     "webpack": "^4.27.0",
     "webpack-cli": "^3.1.2"
   },

--- a/origin-dapp-creator-server/package.json
+++ b/origin-dapp-creator-server/package.json
@@ -41,7 +41,7 @@
     "logplease": "^1.2.15",
     "per-env": "^1.0.2",
     "raven": "^2.6.4",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.0.0-beta.34"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- The `^` modifier is dangerous with web3 😞
- Web3 published beta 42 which is broken

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything~~
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
