### PR TITLE
Fix `npm run install:mobile`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci --progress --hoist \"**\" --ignore origin-mobile",
-    "bootstrap:mobile": "lerna bootstrap --progress --scope origin-linking --scope origin-mobile --scope origin --scope origin-contracts --scope origin-dapp --scope origin-messaging --scope origin-discovery --scope origin-notifications",
+    "bootstrap:mobile": "lerna bootstrap --progress",
     "build": "lerna run build",
     "clean": "git clean -fdX .",
     "start": "lerna run start --stream --parallel --scope origin --scope origin-dapp",


### PR DESCRIPTION
origin-growth was made a dependency of origin-discovery, which is needed
for install:mobile. origin-growth depends on origin-graphql, which has a
lot of transitive dependencies, so it's easier to just install all
packages when running `install:mobile`.

cc @micahalcorn @crazybuster 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
