### PR TITLE
Container updates for origin-growth dependency in origin-discovery

### DIFF
--- a/deployment/dockerfiles/event-listener
+++ b/deployment/dockerfiles/event-listener
@@ -17,6 +17,13 @@ COPY lerna.json ./
 COPY ./origin-js ./origin-js
 COPY ./origin-contracts ./origin-contracts
 COPY ./origin-discovery ./origin-discovery
+COPY ./origin-growth ./origin-growth
+COPY ./experimental/origin-eventsource ./experimental/origin-eventsource
+COPY ./experimental/origin-graphql ./experimental/origin-graphql
+COPY ./experimental/origin-ipfs ./experimental/origin-ipfs
+COPY ./experimental/origin-messaging-client ./experimental/origin-messaging-client
+COPY ./experimental/origin-services ./experimental/origin-services
+COPY ./experimental/origin-validator ./experimental/origin-validator
 COPY ./scripts ./scripts
 
 RUN npm install --unsafe-perm

--- a/deployment/dockerfiles/origin-discovery
+++ b/deployment/dockerfiles/origin-discovery
@@ -12,6 +12,13 @@ COPY lerna.json ./
 COPY ./origin-js ./origin-js
 COPY ./origin-contracts ./origin-contracts
 COPY ./origin-discovery ./origin-discovery
+COPY ./origin-growth ./origin-growth
+COPY ./experimental/origin-eventsource ./experimental/origin-eventsource
+COPY ./experimental/origin-graphql ./experimental/origin-graphql
+COPY ./experimental/origin-ipfs ./experimental/origin-ipfs
+COPY ./experimental/origin-messaging-client ./experimental/origin-messaging-client
+COPY ./experimental/origin-services ./experimental/origin-services
+COPY ./experimental/origin-validator ./experimental/origin-validator
 COPY ./scripts ./scripts
 
 RUN npm install --unsafe-perm

--- a/origin-dapp-creator-client/package.json
+++ b/origin-dapp-creator-client/package.json
@@ -59,7 +59,7 @@
     "superagent": "^4.0.0",
     "terser": "3.14.1",
     "terser-webpack-plugin": "^1.1.0",
-    "web3": "^1.0.0-beta.37",
+    "web3": "1.0.0-beta.34",
     "webpack": "^4.27.0",
     "webpack-cli": "^3.1.2"
   },

--- a/origin-dapp-creator-server/package.json
+++ b/origin-dapp-creator-server/package.json
@@ -41,7 +41,7 @@
     "logplease": "^1.2.15",
     "per-env": "^1.0.2",
     "raven": "^2.6.4",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.0.0-beta.34"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/origin-dapp-creator-server/package.json
+++ b/origin-dapp-creator-server/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "build": "per-env",
     "build:production": "babel -d dist --presets @babel/env src",
-    "lint": "eslint '**/*.js' && npm run prettier:check",
-    "prettier": "prettier --write *.js \"src/**/*.js\"",
-    "prettier:check": "prettier -c *.js \"src/**/*.js\"",
+    "lint": "eslint \"src/**/*.js\" && npm run prettier:check",
+    "prettier": "prettier --write \"src/**/*.js\"",
+    "prettier:check": "prettier -c \"src/**/*.js\"",
     "start": "per-env",
     "start:development": "nodemon --exec 'babel-node' -r src/env.js src/app.js --presets @babel/env",
     "prestart:production": "npm run build",


### PR DESCRIPTION
- `origin-discovery` now depends on `origin-growth` so a bunch of new packages need to be added to the discovery based deployment containers
- Added a path fix to `origin-dapp-creator-server` eslint rule so it doesn't pick up the `dist` directory

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
