### PR TITLE
Fix problems with dapp2 running in docker

### DIFF
--- a/Dockerfile-experimental
+++ b/Dockerfile-experimental
@@ -18,6 +18,7 @@ COPY ./origin-messaging/package*.json ./origin-messaging/
 COPY ./origin-notifications/package*.json ./origin-notifications/
 COPY ./origin-tests/package*.json ./origin-tests/
 COPY ./origin-growth/package*.json ./origin-growth/
+COPY ./origin-token/package*.json ./origin-token/
 COPY ./experimental/origin-dapp2/package*.json ./experimental/origin-dapp2/
 COPY ./experimental/origin-graphql/package*.json ./experimental/origin-graphql/
 COPY ./experimental/origin-ipfs/package*.json ./experimental/origin-ipfs/

--- a/docker-compose.experimental.yml
+++ b/docker-compose.experimental.yml
@@ -55,19 +55,19 @@ services:
       - ./origin-growth/:/app/origin-growth/
       - ./origin-token/:/app/origin-token/
     # Exclude all node_modules
-      - /app/experimental/origin-dapp2/node_modules
-      - /app/experimental/origin-services/node_modules
-      - /app/experimental/origin-graphql/node_modules
-      - /app/experimental/origin-eventsource/node_modules
-      - /app/experimental/origin-ipfs/node_modules
-      - /app/experimental/origin-messaging-client/node_modules
-      - /app/experimental/origin-validator/node_modules
-      - /origin-discovery/node_modules
-      - /origin-ipfs-proxy/node_modules
-      - /origin-messaging/node_modules
-      - /origin-notifications/node_modules
-      - /origin-growth/node_modules
-      - /origin-token/node_modules
+      - /app/experimental/origin-dapp2/node_modules/
+      - /app/experimental/origin-services/node_modules/
+      - /app/experimental/origin-graphql/node_modules/
+      - /app/experimental/origin-eventsource/node_modules/
+      - /app/experimental/origin-ipfs/node_modules/
+      - /app/experimental/origin-messaging-client/node_modules/
+      - /app/experimental/origin-validator/node_modules/
+      - /app/origin-discovery/node_modules/
+      - /app/origin-ipfs-proxy/node_modules/
+      - /app/origin-messaging/node_modules/
+      - /app/origin-notifications/node_modules/
+      - /app/origin-growth/node_modules/
+      - /app/origin-token/node_modules/
       # IPFS data
       - ipfs:/app/ipfs
     ports:


### PR DESCRIPTION
### Description:
This solves 2 problems: 
- added `origin-token` folder in image creation step, otherwise a clean install produced this errors:  `Can not find origin-token@0.1.0`
- corrected `node_modules` folder omissions. In my case the host machine `node_modules` have been mapped to the docker containers producing unexpected results. 