### PR TITLE
Allow signing and sending transaction for off browser processes

### DIFF
--- a/origin-js/src/services/contract-service.js
+++ b/origin-js/src/services/contract-service.js
@@ -457,9 +457,7 @@ class ContractService {
     }
     // set gas
     //opts.gas = "5000000"
-    console.log("estiamting gas...")
     opts.gas = (opts.gas || (await method.estimateGas(opts))) + additionalGas
-    console.log("estiamted gas...", opts.gas)
     const transactionReceipt = await new Promise((resolve, reject) => {
       if (!opts.from && this.isActiveWalletLinker() && !this.walletLinker.linked) {
         opts.from = this.walletPlaceholderAccount()

--- a/origin-linking/src/logic/hot.js
+++ b/origin-linking/src/logic/hot.js
@@ -10,6 +10,7 @@ class Hot {
     // grab the version that allows for behalf submits
     this.marketplace_adapter = origin.marketplace.resolver.adapters['A']
     this.account = web3.eth.accounts.wallet.add(HOT_WALLET_PK)
+    origin.contractService.transactionSigner = this.account.signTransaction
   }
 
   async submitMarketplace(cmd, params) {


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- Infura doesn't support signing or sending transactions for accounts that it doesn't have private keys for, this sends a raw transaction instead.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
