### PR TITLE
[draft] Additional GraphQL mutation testing + gas used table

### DIFF
--- a/experimental/origin-admin/src/queries/Mutations.js
+++ b/experimental/origin-admin/src/queries/Mutations.js
@@ -244,8 +244,8 @@ export const AcceptOfferMutation = gql`
 `
 
 export const AddFundsMutation = gql`
-  mutation AddFunds($offerID: String!, $amount: String!, $from: String) {
-    addFunds(offerID: $offerID, amount: $amount, from: $from) {
+  mutation AddFunds($offerID: String!, $value: String!, $from: String) {
+    addFunds(offerID: $offerID, value: $value, from: $from) {
       id
     }
   }
@@ -254,10 +254,10 @@ export const AddFundsMutation = gql`
 export const UpdateRefundMutation = gql`
   mutation UpdateRefundMutation(
     $offerID: String!
-    $amount: String!
+    $value: String!
     $from: String
   ) {
-    updateRefund(offerID: $offerID, amount: $amount, from: $from) {
+    updateRefund(offerID: $offerID, value: $value, from: $from) {
       id
     }
   }

--- a/experimental/origin-graphql/src/mutations/_gasCost.js
+++ b/experimental/origin-graphql/src/mutations/_gasCost.js
@@ -10,7 +10,7 @@ export default {
   withdrawListing: 29367,
   addFunds: 200000, // GraphQL test with ETH at 33,312. ERC20 offers make external function call.
   updateRefund: 200000, // Needs real value. Needs GraphQL tests.
-  disputeOffer: 60000, // Contract test at 32164. Needs GraphQL tests.
+  disputeOffer: 40000,
   executeRuling: 200000, // Needs real value. Needs GraphQL tests.
   addData: 28690, // Contract test. Uses offer addData, since amount is larger.
 

--- a/experimental/origin-graphql/src/mutations/_gasCost.js
+++ b/experimental/origin-graphql/src/mutations/_gasCost.js
@@ -8,7 +8,7 @@ export default {
   finalizeOffer: 128219,
   withdrawOffer: 41321,
   withdrawListing: 29367,
-  addFunds: 200000, // Needs real value. Needs GraphQL tests.
+  addFunds: 200000, // GraphQL test with ETH at 33,312. ERC20 offers make external function call.
   updateRefund: 200000, // Needs real value. Needs GraphQL tests.
   disputeOffer: 60000, // Contract test at 32164. Needs GraphQL tests.
   executeRuling: 200000, // Needs real value. Needs GraphQL tests.

--- a/experimental/origin-graphql/src/mutations/_txHelper.js
+++ b/experimental/origin-graphql/src/mutations/_txHelper.js
@@ -72,6 +72,7 @@ export default function txHelper({
           transactionUpdated: {
             id: receipt.transactionHash,
             status: 'receipt',
+            gasUsed: receipt.gasUsed,
             mutation
           }
         })

--- a/experimental/origin-graphql/src/mutations/marketplace/addFunds.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/addFunds.js
@@ -12,11 +12,11 @@ async function addFunds(_, data) {
 
   // TODO: Finish support for ERC20 offers
   // Currently assumes value is priced in ETH
-  const value = contracts.web3.utils.toWei(data.value, 'ether')
+  const amount = contracts.web3.utils.toWei(data.amount, 'ether')
 
   const tx = contracts.marketplaceExec.methods
-    .addFunds(listingId, offerId, ipfsHash, value)
-    .send({ gas: cost.addFunds, from, value: value })
+    .addFunds(listingId, offerId, ipfsHash, amount)
+    .send({ gas: cost.addFunds, from, value: amount })
 
   return txHelper({ tx, from, mutation: 'addFunds' })
 }

--- a/experimental/origin-graphql/src/mutations/marketplace/addFunds.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/addFunds.js
@@ -9,10 +9,11 @@ async function addFunds(_, data) {
   await checkMetaMask(data.from)
   const ipfsHash = await post(contracts.ipfsRPC, data)
   const { listingId, offerId } = parseId(data.offerID)
+  const value = contracts.web3.utils.toWei(data.value, 'ether')
 
   const tx = contracts.marketplaceExec.methods
-    .addFunds(listingId, offerId, ipfsHash, data.amount)
-    .send({ gas: cost.addFunds, from, value: data.amount })
+    .addFunds(listingId, offerId, ipfsHash, value)
+    .send({ gas: cost.addFunds, from, value: value })
 
   return txHelper({ tx, from, mutation: 'addFunds' })
 }

--- a/experimental/origin-graphql/src/mutations/marketplace/addFunds.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/addFunds.js
@@ -9,6 +9,9 @@ async function addFunds(_, data) {
   await checkMetaMask(data.from)
   const ipfsHash = await post(contracts.ipfsRPC, data)
   const { listingId, offerId } = parseId(data.offerID)
+
+  // TODO: Finish support for ERC20 offers
+  // Currently assumes value is priced in ETH
   const value = contracts.web3.utils.toWei(data.value, 'ether')
 
   const tx = contracts.marketplaceExec.methods

--- a/experimental/origin-graphql/src/mutations/marketplace/executeRuling.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/executeRuling.js
@@ -9,16 +9,31 @@ async function executeRuling(_, data) {
   await checkMetaMask(from)
   const ipfsHash = await post(contracts.ipfsRPC, data)
   const { listingId, offerId } = parseId(data.offerID)
+
   let ruling = 0,
-    refund = '0'
-  if (data.ruling === 'partial-refund') {
-    refund = data.refund
+    refundStr = '0'
+  if (data.ruling === 'pay-seller') {
+    ruling = 0
+  } else if (data.ruling === 'partial-refund') {
+    ruling = 0
+    refundStr = data.refund
   } else if (data.ruling === 'refund-buyer') {
     ruling = 1
-    refund = data.refund
+  } else {
+    throw new Error(
+      'ruling must be one of "pay-seller", "partial-refund", or "refund-buyer"'
+    )
   }
+  // TODO: Finish support for ERC20 offers
+  // Currently assumes refund is priced in ETH
+  const refund = contracts.web3.utils.toWei(refundStr, 'ether')
+
   if (data.commission === 'pay') {
     ruling += 2
+  } else if (data.commission === 'refund') {
+    // no change needed
+  } else {
+    throw new Error('commission must be either "pay", or "refund"')
   }
 
   const tx = contracts.marketplaceExec.methods

--- a/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
@@ -37,6 +37,12 @@ async function makeOffer(_, data) {
     ipfsData.commission.amount,
     'ether'
   )
+
+  // TODO: Finish support for ERC20 offers
+  // Currently assumes value is priced in ETH
+  if (data.currency != ZeroAddress) {
+    throw new Error('ERC20 offers not currently supported')
+  }
   const value = contracts.web3.utils.toWei(data.value, 'ether')
   const arbitrator = data.arbitrator || contracts.config.arbitrator
 

--- a/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/makeOffer.js
@@ -39,11 +39,11 @@ async function makeOffer(_, data) {
   )
 
   // TODO: Finish support for ERC20 offers
-  // Currently assumes value is priced in ETH
+  // Currently assumes amount is priced in ETH
   if (data.currency != ZeroAddress) {
     throw new Error('ERC20 offers not currently supported')
   }
-  const value = contracts.web3.utils.toWei(data.value, 'ether')
+  const amount = contracts.web3.utils.toWei(data.amount, 'ether')
   const arbitrator = data.arbitrator || contracts.config.arbitrator
 
   const { listingId } = parseId(data.listingID)
@@ -53,7 +53,7 @@ async function makeOffer(_, data) {
     ipfsData.finalizes,
     affiliate,
     commission,
-    value,
+    amount,
     data.currency || ZeroAddress,
     arbitrator
   ]
@@ -65,7 +65,7 @@ async function makeOffer(_, data) {
   const tx = marketplace.methods.makeOffer(...args).send({
     gas: cost.makeOffer,
     from: buyer,
-    value
+    value: amount
   })
   return txHelper({ tx, from: buyer, mutation: 'makeOffer' })
 }
@@ -106,7 +106,7 @@ async function toIpfsData(data) {
     listingType: 'unit',
     unitsPurchased: Number.parseInt(data.quantity),
     totalPrice: {
-      amount: data.value,
+      amount: data.amount,
       currency: 'ETH'
     },
     commission,

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -77,7 +77,7 @@ module.exports = `
       listingID: ID!
       finalizes: Int
       commission: String
-      value: String
+      amount: String
       currency: String
       from: String
       withdraw: String
@@ -114,7 +114,7 @@ module.exports = `
     withdrawOffer(offerID: ID!, from: String): Transaction
     finalizeOffer(offerID: ID!, from: String, rating: Int, review: String): Transaction
     disputeOffer(offerID: ID!, data: String!, from: String): Transaction
-    addFunds(offerID: ID!, value: String!, from: String): Transaction
+    addFunds(offerID: ID!, amount: String!, from: String): Transaction
     updateRefund(offerID: ID!, amount: String!, from: String): Transaction
   }
 
@@ -281,7 +281,7 @@ module.exports = `
     history: [OfferHistory]
 
     # On-Chain
-    value: String
+    amount: String
     commission: String
     refund: String
     currency: String

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -104,7 +104,7 @@ module.exports = `
     acceptOffer(offerID: ID!, from: String): Transaction
     withdrawOffer(offerID: ID!, from: String): Transaction
     finalizeOffer(offerID: ID!, from: String, rating: Int, review: String): Transaction
-    disputeOffer(offerID: ID!, from: String): Transaction
+    disputeOffer(offerID: ID!, data: String!, from: String): Transaction
     addFunds(offerID: ID!, value: String!, from: String): Transaction
     updateRefund(offerID: ID!, amount: String!, from: String): Transaction
   }

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -105,7 +105,7 @@ module.exports = `
     withdrawOffer(offerID: ID!, from: String): Transaction
     finalizeOffer(offerID: ID!, from: String, rating: Int, review: String): Transaction
     disputeOffer(offerID: ID!, from: String): Transaction
-    addFunds(offerID: ID!, amount: String!, from: String): Transaction
+    addFunds(offerID: ID!, value: String!, from: String): Transaction
     updateRefund(offerID: ID!, amount: String!, from: String): Transaction
   }
 

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -91,7 +91,16 @@ module.exports = `
 
     executeRuling(
       offerID: ID!
+      # ruling may be one of:
+      # 
+      # - refund-buyer: Buyer gets all value in the offer
+      # - pay-seller: Seller gets all value in the offer
+      # - partial-refund: Buyer the refund value, Seller gets all remaining value
       ruling: String!
+      # commission may be one of:
+      # 
+      # - pay: Affiliate receives commission tokens, if any
+      # - refund: Seller refunded commission tokens, if any
       commission: String!
       message: String
       refund: String

--- a/experimental/origin-graphql/test/_gasTable.js
+++ b/experimental/origin-graphql/test/_gasTable.js
@@ -1,32 +1,32 @@
 import pubsub from '../src/utils/pubsub'
 
 let subscriptionId = undefined
-let used = {}
+const used = {}
 
 export async function trackGas(){
     subscriptionId = await pubsub.subscribe('TRANSACTION_UPDATED', data => {
         try{
-            if(data.transactionUpdated == undefined){
+            if(data.transactionUpdated == undefined) {
                 return
             }
-            if(data.transactionUpdated.status != "receipt"){
+            if(data.transactionUpdated.status != 'receipt'){
                 return
             }
-            const {mutation, gasUsed} = data.transactionUpdated
+            const { mutation, gasUsed } = data.transactionUpdated
             used[mutation] = used[mutation] ? used[mutation] : []
             used[mutation].push(gasUsed)
-        } catch (e){
-
+        } catch (e) {
+            // Do nothing
         }
     })
 }
 
 export function showGasTable() {
     pubsub.unsubscribe(subscriptionId)
-    console.log("")
-    console.log("--------------------------------------------------")
-    console.log("Gas used (max, min)")
-    console.log("--------------------------------------------------")
+    console.log('')
+    console.log('--------------------------------------------------')
+    console.log('Gas used (max, min)')
+    console.log('--------------------------------------------------')
     const keys = Object.keys(used).sort()
     keys.forEach(key => {
         const values = used[key].sort((a,b) => a - b)
@@ -36,7 +36,7 @@ export function showGasTable() {
             key.padEnd(18),
             max.toLocaleString().padStart(10),
             min.toLocaleString().padStart(10)
-        ].join("\t"))
+        ].join('\t'))
     })
 }
 

--- a/experimental/origin-graphql/test/_gasTable.js
+++ b/experimental/origin-graphql/test/_gasTable.js
@@ -1,0 +1,42 @@
+import pubsub from '../src/utils/pubsub'
+
+let subscriptionId = undefined
+let used = {}
+
+export async function trackGas(){
+    subscriptionId = await pubsub.subscribe('TRANSACTION_UPDATED', data => {
+        try{
+            if(data.transactionUpdated == undefined){
+                return
+            }
+            if(data.transactionUpdated.status != "receipt"){
+                return
+            }
+            const {mutation, gasUsed} = data.transactionUpdated
+            used[mutation] = used[mutation] ? used[mutation] : []
+            used[mutation].push(gasUsed)
+        } catch (e){
+
+        }
+    })
+}
+
+export function showGasTable() {
+    pubsub.unsubscribe(subscriptionId)
+    console.log("")
+    console.log("--------------------------------------------------")
+    console.log("Gas used (max, min)")
+    console.log("--------------------------------------------------")
+    const keys = Object.keys(used).sort()
+    keys.forEach(key => {
+        const values = used[key].sort((a,b) => a - b)
+        const min = values[0]
+        const max = values[values.length-1]
+        console.log([
+            key.padEnd(18),
+            max.toLocaleString().padStart(10),
+            min.toLocaleString().padStart(10)
+        ].join("\t"))
+    })
+}
+

--- a/experimental/origin-graphql/test/_helpers.js
+++ b/experimental/origin-graphql/test/_helpers.js
@@ -59,7 +59,7 @@ export async function getOffer(listingId, offerIdx, checkValid) {
 
   const offers = get(res, 'data.marketplace.listing.allOffers')
     .filter(o => o.id === offerId)
-  assert.strictEqual(offers.length, 1)
+  assert.strictEqual(offers.length, 1, 'offer not found on listing')
   const offer = offers[0]
   assert.ok(offer)
   assert.strictEqual(offer.id, offerId)

--- a/experimental/origin-graphql/test/_mutations.js
+++ b/experimental/origin-graphql/test/_mutations.js
@@ -160,6 +160,14 @@ const AddData = gql`
   }
 `
 
+const AddFunds = gql`
+  mutation AddFunds($offerID: String!, $value: String!, $from: String) {
+    addFunds(offerID: $offerID, value: $value, from: $from) {
+      id
+    }
+  }
+`
+
 const UpdateTokenAllowance = gql`
   mutation UpdateTokenAllowance(
     $token: String!
@@ -194,6 +202,7 @@ export default {
   AcceptOffer,
   FinalizeOffer,
   AddData,
+  AddFunds,
   UpdateTokenAllowance,
   TransferToken,
   AddAffiliate,

--- a/experimental/origin-graphql/test/_mutations.js
+++ b/experimental/origin-graphql/test/_mutations.js
@@ -168,6 +168,14 @@ const AddFunds = gql`
   }
 `
 
+const DisputeOffer = gql`
+  mutation DisputeOffer($offerID: String!, $data: String!, $from: String) {
+    disputeOffer(offerID: $offerID, data: $data, from: $from) {
+      id
+    }
+  }
+`
+
 const UpdateTokenAllowance = gql`
   mutation UpdateTokenAllowance(
     $token: String!
@@ -203,6 +211,7 @@ export default {
   FinalizeOffer,
   AddData,
   AddFunds,
+  DisputeOffer,
   UpdateTokenAllowance,
   TransferToken,
   AddAffiliate,

--- a/experimental/origin-graphql/test/_mutations.js
+++ b/experimental/origin-graphql/test/_mutations.js
@@ -176,6 +176,28 @@ const DisputeOffer = gql`
   }
 `
 
+const ExecuteRuling = gql`
+  mutation ExecuteRuling(
+    $offerID: ID!,
+    $ruling: String!,
+    $commission: String!,
+    $message: String,
+    $refund: String,
+    $from: String
+  ) {
+    executeRuling(
+      offerID: $offerID,
+      ruling: $ruling,
+      commission: $commission,
+      message: $message,
+      refund: $refund,
+      from: $from
+    ) {
+      id
+    }
+  }
+`
+
 const UpdateTokenAllowance = gql`
   mutation UpdateTokenAllowance(
     $token: String!
@@ -212,6 +234,7 @@ export default {
   AddData,
   AddFunds,
   DisputeOffer,
+  ExecuteRuling,
   UpdateTokenAllowance,
   TransferToken,
   AddAffiliate,

--- a/experimental/origin-graphql/test/_mutations.js
+++ b/experimental/origin-graphql/test/_mutations.js
@@ -102,7 +102,7 @@ const MakeOffer = gql`
     $finalizes: Int
     $affiliate: String
     $commission: String
-    $value: String
+    $amount: String
     $currency: String
     $arbitrator: String
     $data: MakeOfferInput
@@ -115,7 +115,7 @@ const MakeOffer = gql`
       finalizes: $finalizes
       affiliate: $affiliate
       commission: $commission
-      value: $value
+      amount: $amount
       currency: $currency
       arbitrator: $arbitrator
       data: $data
@@ -161,8 +161,8 @@ const AddData = gql`
 `
 
 const AddFunds = gql`
-  mutation AddFunds($offerID: String!, $value: String!, $from: String) {
-    addFunds(offerID: $offerID, value: $value, from: $from) {
+  mutation AddFunds($offerID: String!, $amount: String!, $from: String) {
+    addFunds(offerID: $offerID, amount: $amount, from: $from) {
       id
     }
   }

--- a/experimental/origin-graphql/test/index.js
+++ b/experimental/origin-graphql/test/index.js
@@ -205,6 +205,20 @@ describe('Marketplace', function() {
       assert(events.OfferAccepted)
     })
 
+    it('should add funds to an offer', async function() {
+      const offer = await getOffer('999-0-0', 1, false)
+      const events = await mutate(
+        mutations.AddFunds,
+        {
+          offerID: '999-0-0-1',
+          from: Buyer,
+          value: '0.015',
+        },
+        true
+      )
+      assert(events.OfferFundsAdded)
+    })
+
     it('should finalize an offer', async function() {
       const events = await mutate(
         mutations.FinalizeOffer,

--- a/experimental/origin-graphql/test/index.js
+++ b/experimental/origin-graphql/test/index.js
@@ -7,6 +7,7 @@ import contracts, { setNetwork } from '../src/contracts'
 import { getOffer, mutate } from './_helpers'
 import queries from './_queries'
 import mutations from './_mutations'
+import {trackGas, showGasTable} from './_gasTable'
 
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
 
@@ -16,9 +17,14 @@ describe('Marketplace', function() {
 
   before(async function() {
     setNetwork('test')
+    trackGas()
     const res = await client.query({ query: queries.GetNodeAccounts })
     const nodeAccounts = get(res, 'data.web3.nodeAccounts').map(a => a.id)
     ;[Admin, Seller, Buyer, Arbitrator, Affiliate] = nodeAccounts
+  })
+
+  after(async function(){
+    showGasTable()
   })
 
   it('should deploy the token contract', async function() {

--- a/experimental/origin-graphql/test/index.js
+++ b/experimental/origin-graphql/test/index.js
@@ -7,7 +7,7 @@ import contracts, { setNetwork } from '../src/contracts'
 import { getOffer, mutate } from './_helpers'
 import queries from './_queries'
 import mutations from './_mutations'
-import {trackGas, showGasTable} from './_gasTable'
+import { trackGas, showGasTable } from './_gasTable'
 
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
 
@@ -206,7 +206,6 @@ describe('Marketplace', function() {
     })
 
     it('should add funds to an offer', async function() {
-      const offer = await getOffer('999-0-0', 1, false)
       const events = await mutate(
         mutations.AddFunds,
         {

--- a/experimental/origin-graphql/test/index.js
+++ b/experimental/origin-graphql/test/index.js
@@ -143,7 +143,7 @@ describe('Marketplace', function() {
           from: Buyer,
           finalizes: 123,
           affiliate: ZeroAddress,
-          value: '0.005',
+          amount: '0.005',
           currency: ZeroAddress,
           arbitrator: Arbitrator,
           quantity: 1
@@ -170,7 +170,7 @@ describe('Marketplace', function() {
           from: Buyer,
           finalizes: 123,
           affiliate: ZeroAddress,
-          value: '0.01',
+          amount: '0.01',
           currency: ZeroAddress,
           arbitrator: Arbitrator,
           quantity: 1
@@ -211,7 +211,7 @@ describe('Marketplace', function() {
         {
           offerID: '999-0-0-1',
           from: Buyer,
-          value: '0.015',
+          amount: '0.015',
         },
         true
       )
@@ -328,7 +328,7 @@ describe('Marketplace', function() {
           from: Buyer,
           finalizes: 123,
           affiliate: Affiliate,
-          value: '0.1',
+          amount: '0.1',
           currency: ZeroAddress,
           arbitrator: Arbitrator,
           quantity: 1
@@ -404,7 +404,7 @@ describe('Marketplace', function() {
           from: Buyer,
           finalizes: 123,
           affiliate: Affiliate,
-          value: '0.01',
+          amount: '0.01',
           currency: ZeroAddress,
           arbitrator: Arbitrator,
           quantity: 1
@@ -426,7 +426,7 @@ describe('Marketplace', function() {
           from: Buyer,
           finalizes: 123,
           affiliate: Affiliate,
-          value: '0.01',
+          amount: '0.01',
           currency: ZeroAddress,
           arbitrator: Arbitrator,
           quantity: 1
@@ -476,7 +476,7 @@ describe('Marketplace', function() {
           from: Buyer,
           finalizes: 123,
           affiliate: Affiliate,
-          value: '0.02',
+          amount: '0.02',
           currency: ZeroAddress,
           arbitrator: Arbitrator,
           quantity: 2
@@ -666,7 +666,7 @@ describe('Marketplace', function() {
             from: Buyer,
             finalizes: 123,
             affiliate: Affiliate,
-            value: '0.05',
+            amount: '0.05',
             currency: ZeroAddress,
             arbitrator: Arbitrator,
             quantity: 5
@@ -760,7 +760,7 @@ describe('Marketplace', function() {
         from: Buyer,
         finalizes: 123,
         affiliate: ZeroAddress,
-        value: '0.01',
+        amount: '0.01',
         currency: ZeroAddress,
         arbitrator: Arbitrator,
         quantity: 1


### PR DESCRIPTION
- Add test for addFunds mutation
- Add test for disputeOffer mutation
- Throw error in makeOffer if an ERC20 currency is used, since the method does not currently support it
- Add table of gas prices as used in GraphQL mutation tests
- Change addFunds "amount" field to "value" and use ETH, to match the name and behavior of all other offer mutations.