### PR TITLE
New type for unitsTotal since it can go negative

### DIFF
--- a/origin-contracts/sig_schema/Listing.json
+++ b/origin-contracts/sig_schema/Listing.json
@@ -5,7 +5,7 @@
   { "name" : "commision", "type" : "Money" },
   { "name" : "category", "type" : "string" },
   { "name" : "type", "type" : "string" },
-  { "name" : "unitsTotal", "type" : "uint256" },
+  { "name" : "unitsTotal", "type" : "int256" },
   { "name" : "createDate", "type" : "string" },
   { "name" : "deposit", "type": "string" },
   { "name" : "depositManager", "type": "address" },

--- a/origin-dapp/src/components/listing-create.js
+++ b/origin-dapp/src/components/listing-create.js
@@ -224,7 +224,7 @@ class ListingCreate extends Component {
       }
     } else if (
       web3.currentProvider.isOrigin ||
-      (this.props.messagingRequired && !this.props.messagingEnabled && !origin.contractService.walletLinker.linked)
+      (this.props.messagingRequired && !this.props.messagingEnabled && !(origin.contractService.walletLinker && origin.contractService.walletLinker.linked))
     ) {
       if (!origin.contractService.walletLinker) {
         this.props.history.push('/')


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- Made an assumption that unitsTotal can be uint, apparently not the case.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
