### PR TITLE
set VA marketplace to the multisig account

### DIFF
--- a/origin-contracts/migrations/17_transfer_vA_ownership_for_mainnet.js
+++ b/origin-contracts/migrations/17_transfer_vA_ownership_for_mainnet.js
@@ -1,0 +1,31 @@
+const VA_Marketplace = artifacts.require('./VA_Marketplace.sol')
+
+// TODO: extract these addresses into a common file that can be imported from
+// the various places that require these addresses
+const marketplaceMultiSig = '0x8a1a4f77f9f0eb35fb9930696038be6220986c1b'
+
+module.exports = function(deployer, network) {
+  return deployer.then(() => {
+    if (network === 'mainnet' || process.env['SIMULATE_MAINNET']) {
+      return transferVAMarketplaceToMultiSig()
+    }
+  })
+}
+
+async function transferVAMarketplaceToMultiSig() {
+  const accounts = await new Promise((resolve, reject) => {
+    web3.eth.getAccounts((error, result) => {
+      if (error) {
+        reject(error)
+      }
+      resolve(result)
+    })
+  })
+  const owner = accounts[0]
+
+  // Transfer marketplace contract to multi-sig wallet.
+  const marketplace = await VA_Marketplace.deployed()
+  await marketplace.transferOwnership(marketplaceMultiSig, { from: owner })
+  console.log(`marketplace contract owner set to ${marketplaceMultiSig}`)
+}
+


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Please explain the changes you made here:

- migration to set the multisig owner.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
