### PR TITLE
Add instrumentation to injectListing

### DIFF
--- a/origin-discovery/src/apollo/injector.js
+++ b/origin-discovery/src/apollo/injector.js
@@ -110,7 +110,7 @@ async function injectListing(injectedListingInput, signature) {
   const ipfsHash = origin.marketplace.contractService.getIpfsHashFromBytes32(
     injectedListingInput.ipfsHash
   )
-  logger.info(`Loading listing data from IPFFS hash ${ipfsHash}`)
+  logger.info(`Loading listing data from IPFS hash ${ipfsHash}`)
   const listing = await origin.marketplace._listingFromData(undefined, injectedListingInput)
   logger.info(`Loaded listing data: ${listing}`)
 

--- a/origin-discovery/src/apollo/injector.js
+++ b/origin-discovery/src/apollo/injector.js
@@ -1,9 +1,11 @@
+const logger = require('./logger')
+
 const db = require('./db')
 require('dotenv').config()
 try {
   require('envkey')
 } catch (error) {
-  console.log('EnvKey not configured')
+  logger.error('EnvKey not configured')
 }
 
 const search = require('../lib/search.js')
@@ -52,8 +54,6 @@ process.argv.forEach(arg => {
 
 
 const config = {
-  // Verbose mode, includes dumping events on the console.
-  verbose: args['--verbose'] || (process.env.VERBOSE === 'true'),
   // ipfs url
   ipfsUrl: args['--ipfs-url'] || process.env.IPFS_URL || 'http://localhost:8080',
   // Origin-js configs
@@ -73,9 +73,8 @@ const origin = setupOriginJS(config, web3)
 async function updateSearch(listingId, listing) {
     if (config.elasticsearch) {
       const seller = await origin.users.get(listing.seller)
-      console.log(`Indexing listing in Elastic: id=${listingId}`)
+      logger.info(`Indexing listing in Elastic: id=${listingId}`)
       await search.Listing.index(listingId, seller.address, listing.ipfsHash, listing)
-      //await search.User.index(seller)
       return true
     }
 }
@@ -92,7 +91,6 @@ async function _verifyListing(listing, signature) {
     throw new Error('signature not encoded into ipfs blob')
   }
 
-  console.log('creator vs seller:', listing.creator, listing.seller)
   if (listing.creator != listing.seller)
   {
     throw new Error('Creator must be same as the seller!')
@@ -106,28 +104,32 @@ async function _verifyListing(listing, signature) {
 }
 
 async function injectListing(injectedListingInput, signature) {
-  //
-  // please very signature first
-  //
-  console.log('verifying:', injectedListingInput, ' against ', signature)
-  // schema ListingInput in graphql
+  // First, verify signature.
+  logger.info(`injectListing called. Input: ${injectedListingInput} Signature: ${signature}`)
+
+  const ipfsHash = origin.marketplace.contractService.getIpfsHashFromBytes32(
+    injectedListingInput.ipfsHash
+  )
+  logger.info(`Loading listing data from IPFFS hash ${ipfsHash}`)
   const listing = await origin.marketplace._listingFromData(undefined, injectedListingInput)
+  logger.info(`Loaded listing data: ${listing}`)
 
   // set the listing id for the current network
   const network = await origin.contractService.web3.eth.net.getId()
   const listingId = generateListingId({ version: 'A', network, uniqueId: listing.uniqueId })
-
   listing.id = listingId
+  logger.info(`Generated listing Id ${listingId}`)
 
+  logger.info('Verifying signature')
   await _verifyListing(listing, signature)
 
   const existingRow = await db.getListing(listingId)
-
   if (existingRow) {
     throw new Error('Row already created, update instead')
   }
-  const blockNumber = await origin.contractService.web3.eth.getBlockNumber()
 
+  logger.info(`Inserting listing ${listingId} in DB and Search index`)
+  const blockNumber = await origin.contractService.web3.eth.getBlockNumber()
   const listingData = {
     id: listingId,
     blockNumber,
@@ -137,7 +139,6 @@ async function injectListing(injectedListingInput, signature) {
     data: listing
   }
   const newListing = await db.createListing(listingData)
-  console.log('indexing:', listingId)
   await updateSearch(listingId, listing)
   return newListing
 }
@@ -148,8 +149,9 @@ async function updateListing(listingId, injectedListingInput, signature) {
   //
   // schema ListingInput in graphql
   //
-  console.log('verifying:', injectedListingInput, ' against ', signature)
+  logger.info(`Verifying ${injectedListingInput} against ${signature}`)
   const existingRow = await db.getListing(listingId)
+
   const listing = await origin.marketplace._listingFromData(listingId, injectedListingInput)
 
   if (((existingRow.updateVersion && Number(existingRow.updateVersion)) || 0) 

--- a/origin-discovery/src/apollo/logger.js
+++ b/origin-discovery/src/apollo/logger.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const Logger = require('logplease')
+
+Logger.setLogLevel(process.env.LOG_LEVEL || 'INFO')
+
+module.exports = Logger.create('discovery', { showTimestamp: false })


### PR DESCRIPTION
### Description:

This PR adds some instrumentation in the discovery server to troubleshoot why creation of no-gas listings in the services category fails.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
