### PR TITLE
Show table of gas usage in Origin GraphQL tests.

### DIFF
--- a/experimental/origin-graphql/src/mutations/_txHelper.js
+++ b/experimental/origin-graphql/src/mutations/_txHelper.js
@@ -72,6 +72,7 @@ export default function txHelper({
           transactionUpdated: {
             id: receipt.transactionHash,
             status: 'receipt',
+            gasUsed: receipt.gasUsed,
             mutation
           }
         })

--- a/experimental/origin-graphql/test/_gasTable.js
+++ b/experimental/origin-graphql/test/_gasTable.js
@@ -1,0 +1,42 @@
+import pubsub from '../src/utils/pubsub'
+
+let subscriptionId = undefined
+const used = {}
+
+export async function trackGas(){
+  subscriptionId = await pubsub.subscribe('TRANSACTION_UPDATED', data => {
+    try{
+      if(data.transactionUpdated == undefined) {
+        return
+      }
+      if(data.transactionUpdated.status != 'receipt'){
+        return
+      }
+      const { mutation, gasUsed } = data.transactionUpdated
+      used[mutation] = used[mutation] ? used[mutation] : []
+      used[mutation].push(gasUsed)
+    } catch (e) {
+      // Do nothing
+    }
+  })
+}
+
+export function showGasTable() {
+  pubsub.unsubscribe(subscriptionId)
+  console.log('')
+  console.log('--------------------------------------------------')
+  console.log('Gas used (max, min)')
+  console.log('--------------------------------------------------')
+  const keys = Object.keys(used).sort()
+  keys.forEach(key => {
+    const values = used[key].sort((a,b) => a - b)
+    const min = values[0]
+    const max = values[values.length-1]
+    console.log([
+      key.padEnd(18),
+      max.toLocaleString().padStart(10),
+      min.toLocaleString().padStart(10)
+    ].join('\t'))
+  })
+}
+

--- a/experimental/origin-graphql/test/index.js
+++ b/experimental/origin-graphql/test/index.js
@@ -7,6 +7,7 @@ import contracts, { setNetwork } from '../src/contracts'
 import { getOffer, mutate } from './_helpers'
 import queries from './_queries'
 import mutations from './_mutations'
+import { trackGas, showGasTable } from './_gasTable'
 
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
 
@@ -16,9 +17,14 @@ describe('Marketplace', function() {
 
   before(async function() {
     setNetwork('test')
+    trackGas()
     const res = await client.query({ query: queries.GetNodeAccounts })
     const nodeAccounts = get(res, 'data.web3.nodeAccounts').map(a => a.id)
     ;[Admin, Seller, Buyer, Arbitrator, Affiliate] = nodeAccounts
+  })
+  
+  after(async function(){
+    showGasTable()
   })
 
   it('should deploy the token contract', async function() {


### PR DESCRIPTION
Shows a table of min and max gas usage per Origin GraphQL mutation.

No dependencies. 

![image](https://user-images.githubusercontent.com/837/52974038-2b84b200-338e-11e9-83ce-25b71be99d61.png)
