### PR TITLE
GraphQL tests of dispute and executeRuling mutations.

### DIFF
--- a/experimental/origin-graphql/src/mutations/_gasCost.js
+++ b/experimental/origin-graphql/src/mutations/_gasCost.js
@@ -10,8 +10,8 @@ export default {
   withdrawListing: 29367,
   addFunds: 200000, // Needs real value. Needs GraphQL tests.
   updateRefund: 200000, // Needs real value. Needs GraphQL tests.
-  disputeOffer: 60000, // Contract test at 32164. Needs GraphQL tests.
-  executeRuling: 200000, // Needs real value. Needs GraphQL tests.
+  disputeOffer: 60000, // Contract test at 32164.
+  executeRuling: 200000, // If ERC20 token used, actual cost will vary
   addData: 28690, // Contract test. Uses offer addData, since amount is larger.
 
   // Identity

--- a/experimental/origin-graphql/src/mutations/marketplace/executeRuling.js
+++ b/experimental/origin-graphql/src/mutations/marketplace/executeRuling.js
@@ -9,16 +9,28 @@ async function executeRuling(_, data) {
   await checkMetaMask(from)
   const ipfsHash = await post(contracts.ipfsRPC, data)
   const { listingId, offerId } = parseId(data.offerID)
+
   let ruling = 0,
-    refund = '0'
-  if (data.ruling === 'partial-refund') {
+    refund = contracts.web3.utils.toWei('0', 'ether')
+  if (data.ruling === 'pay-seller') {
+    ruling = 0
+  } else if (data.ruling === 'partial-refund') {
+    ruling = 0
     refund = data.refund
   } else if (data.ruling === 'refund-buyer') {
     ruling = 1
-    refund = data.refund
+  } else {
+    throw new Error(
+      'ruling must be one of "pay-seller", "partial-refund", or "refund-buyer"'
+    )
   }
+
   if (data.commission === 'pay') {
     ruling += 2
+  } else if (data.commission === 'refund') {
+    // no change needed
+  } else {
+    throw new Error('commission must be either "pay", or "refund"')
   }
 
   const tx = contracts.marketplaceExec.methods

--- a/experimental/origin-graphql/src/typeDefs/Marketplace.js
+++ b/experimental/origin-graphql/src/typeDefs/Marketplace.js
@@ -91,7 +91,17 @@ module.exports = `
 
     executeRuling(
       offerID: ID!
+      offerID: ID!
+      # ruling may be one of:
+      # 
+      # - refund-buyer: Buyer gets all value in the offer
+      # - pay-seller: Seller gets all value in the offer
+      # - partial-refund: Buyer the refund value, Seller gets all remaining value
       ruling: String!
+      # commission may be one of:
+      # 
+      # - pay: Affiliate receives commission tokens, if any
+      # - refund: Seller refunded commission tokens, if any
       commission: String!
       message: String
       refund: String

--- a/experimental/origin-graphql/test/_mutations.js
+++ b/experimental/origin-graphql/test/_mutations.js
@@ -159,6 +159,36 @@ const AddData = gql`
     }
   }
 `
+const DisputeOffer = gql`
+  mutation DisputeOffer($offerID: String!, $data: String!, $from: String) {
+    disputeOffer(offerID: $offerID, data: $data, from: $from) {
+      id
+    }
+  }
+`
+
+const ExecuteRuling = gql`
+  mutation ExecuteRuling(
+    $offerID: ID!,
+    $ruling: String!,
+    $commission: String!,
+    $message: String,
+    $refund: String,
+    $from: String
+  ) {
+    executeRuling(
+      offerID: $offerID,
+      ruling: $ruling,
+      commission: $commission,
+      message: $message,
+      refund: $refund,
+      from: $from
+    ) {
+      id
+    }
+  }
+`
+
 
 const UpdateTokenAllowance = gql`
   mutation UpdateTokenAllowance(
@@ -194,6 +224,8 @@ export default {
   AcceptOffer,
   FinalizeOffer,
   AddData,
+  DisputeOffer,
+  ExecuteRuling,
   UpdateTokenAllowance,
   TransferToken,
   AddAffiliate,


### PR DESCRIPTION
- Add test of disputeOffer mutation
- Add several tests of executeRuling mutation
- Add explicit checking to executeRuling `commission` and `ruling` parameters
- Document allowed value strings in GraphQL types file