### PR TITLE
Enable faucet in production

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/_helpers.tpl
+++ b/deployment/kubernetes/charts/origin/templates/_helpers.tpl
@@ -58,7 +58,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{- end -}}
 
 {{- define "faucet.host" -}}
-{{- if eq .Release.Namespace "staging" -}}
+{{- if eq .Release.Namespace "prod" -}}
 {{- printf "faucet.originprotocol.com" }}
 {{- else -}}
 {{- printf "faucet.%s.originprotocol.com" .Release.Namespace -}}

--- a/deployment/kubernetes/charts/origin/templates/faucet.deployment.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: frontend
     app.kubernetes.io/part-of: origin-faucet
 spec:
-  replicas: {{ default 2 .Values.faucetReplicas }}
+  replicas: {{ default 1 .Values.faucetReplicas }}
   selector:
     matchLabels:
       app: {{ template "faucet.fullname" . }}

--- a/deployment/kubernetes/charts/origin/templates/faucet.deployment.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.deployment.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Release.Namespace "prod" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,4 +34,3 @@ spec:
               key: ENVKEY
         ports:
         - containerPort: 5000
-{{ end }}

--- a/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
@@ -26,7 +26,16 @@ spec:
   - host: {{ template "faucet.host" . }}
     http:
       paths:
+        {{- if eq .Release.Namespace "prod" -}}
+        # Production faucet used for distributing ETH via invite codes
+        - path: /eth
+          backend:
+            serviceName: {{ template "faucet.fullname" . }}
+            servicePort: 5000
+        {{- else -}}
+        ## Staging, dev faucet used for distributing OGN on test network
         - path: /
           backend:
             serviceName: {{ template "faucet.fullname" . }}
             servicePort: 5000
+        {{- end -}}

--- a/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Release.Namespace "prod" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -31,4 +30,3 @@ spec:
           backend:
             serviceName: {{ template "faucet.fullname" . }}
             servicePort: 5000
-{{ end }}

--- a/deployment/kubernetes/charts/origin/templates/faucet.secret.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.secret.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Release.Namespace "prod" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,4 +14,3 @@ metadata:
 type: Opaque
 data:
   ENVKEY: {{ required "Set a .Values.faucetEnvKey" .Values.faucetEnvKey | b64enc | quote}}
-{{ end }}

--- a/deployment/kubernetes/charts/origin/templates/faucet.service.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.service.yaml
@@ -1,4 +1,3 @@
-{{ if ne .Release.Namespace "prod" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,4 +18,3 @@ spec:
   ports:
   - name: http
     port: 5000
-{{ end }}


### PR DESCRIPTION
- Reduced faucet replicas to 1 so nonce manager works
- Prod uses /eth
- Staging and dev use /

Will need to update some DNS entries for this to work.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
