### PR TITLE
Replace config signing with nicer message

### DIFF
--- a/origin-dapp-creator-client/src/pages/App.js
+++ b/origin-dapp-creator-client/src/pages/App.js
@@ -45,7 +45,10 @@ class App extends React.Component {
     if (this.state.config.subdomain) {
       // Generate a valid signature if a subdomain is in use
       const dataToSign = JSON.stringify(this.state.config)
-      return this.web3Sign(dataToSign, web3.eth.accounts[0])
+      return this.web3Sign(
+        'I would like to publish an Origin marketplace.',
+        web3.eth.accounts[0]
+      )
     }
   }
 

--- a/origin-dapp-creator-server/src/middleware.js
+++ b/origin-dapp-creator-server/src/middleware.js
@@ -78,7 +78,10 @@ export function validateSignature(req, res, next) {
   const { address, config, signature } = req.body
   if (config.subdomain) {
     // Validate signature matches
-    const signer = web3.eth.accounts.recover(JSON.stringify(config), signature)
+    const signer = web3.eth.accounts.recover(
+      'I would like to publish an Origin marketplace.',
+      signature
+    )
     // Address from recover is checksummed so lower case it
     if (!signature || signer.toLowerCase() !== address.toLowerCase()) {
       logger.warn(`Invalid signature: ${config.subdomain}`)


### PR DESCRIPTION
- Fix for broken signing on creator and replaced signing of config with a better message

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
