### PR TITLE
Simplify ingress and just use /eth for faucet.originprotocol.com

### DIFF
--- a/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/faucet.ingress.yaml
@@ -26,16 +26,7 @@ spec:
   - host: {{ template "faucet.host" . }}
     http:
       paths:
-        {{ if eq .Release.Namespace "prod" }}
-        # Production faucet used for distributing ETH via invite codes
-        - path: /eth
-          backend:
-            serviceName: {{ template "faucet.fullname" . }}
-            servicePort: 5000
-        {{ else }}
-        ## Staging, dev faucet used for distributing OGN on test network
         - path: /
           backend:
             serviceName: {{ template "faucet.fullname" . }}
             servicePort: 5000
-        {{ end }}


### PR DESCRIPTION
Per title

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
