### PR TITLE
[ETH Faucet] Return txn hash right away rather than waiting for receipt

### DIFF
--- a/origin-faucet/src/eth.js
+++ b/origin-faucet/src/eth.js
@@ -223,7 +223,7 @@ class EthDistributor {
   }
 
   // Processes ETH distribution requests.
-  async process(req, res, next) {
+  async process(req, res) {
     const code = req.query.code
     if (!code) {
       return this._error(res, 'An invite code must be supplied.')

--- a/origin-faucet/src/eth.js
+++ b/origin-faucet/src/eth.js
@@ -29,8 +29,10 @@ const MaxNumberPendingTxnCount = 30
  *  - It only works if we run a single instance of the faucet process.
  *  An improvement could be to store the nonce in a central storage like
  *  Redis or Postgres.
- *  - The nonce would go out of sync if anything else than
- *  the faucet process sends a transaction from the hotwallet.
+ *  - The nonce could go out of sync if the server is restarted while
+ *  it is processing a batch of transactions.
+ *  - The nonce could go out of sync if anything else than
+ *  the faucet server sends a transaction from the hotwallet.
  *  - A failure of one of the transaction within a batch will cause subsequent
  *  transaction to be stuck until the nonce hole is filled.
  *  For more info on hole in nonce sequence, see this article:


### PR DESCRIPTION
### Description:
Waiting for a txn receipt on mainnet can take several minutes (it took over 2 min when I tested today)... This is not a great user experience since upon form submission, the use has to wait with no feedback as to what's happening.

Changes logic to return the txn hash right away, with a link to the pending transaction on etherscan so that the user can check there on the status.
In order to do this, I refactored the code to introduce a TxnManager which wraps calls to web3 for sending transaction, getting hash and receipt.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
