### PR TITLE
Repair Delayed Messaging Requirement

### DIFF
--- a/origin-dapp/src/actions/Activation.js
+++ b/origin-dapp/src/actions/Activation.js
@@ -23,7 +23,7 @@ export function detectMessagingEnabled(account) {
   return async function(dispatch) {
     if (MESSAGING_API_URL) {
       try {
-        const clientResponse = origin.messaging.canSendMessages()
+        const clientResponse = origin.messaging.getMessagingKey()
 
         if (!clientResponse) {
           return dispatch({
@@ -107,6 +107,7 @@ export function enableMessaging() {
 }
 
 export function setMessagingEnabled(enabled) {
+console.log('setMessagingEnabled', enabled)
   return {
     type: ActivationConstants.MESSAGING_ENABLED,
     enabled

--- a/origin-dapp/src/components/onboarding.js
+++ b/origin-dapp/src/components/onboarding.js
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router'
 import queryString from 'query-string'
 
 import {
-  detectMessagingEnabled,
   enableMessaging,
   handleNotificationsSubscription,
   setMessagingEnabled,
@@ -131,12 +130,6 @@ class Onboarding extends Component {
       messagingInitialized,
       wallet
     } = this.props
-
-    // on account change
-    if (wallet.address && wallet.address !== prevProps.wallet.address) {
-      // cheat and detect activation from central server
-      this.props.detectMessagingEnabled(wallet.address)
-    }
 
     if (wallet.address && !this.notificationsInterval) {
       // Poll for notifications every 60 seconds.
@@ -388,7 +381,6 @@ const mapStateToProps = ({ activation, app, messages, wallet }) => ({
 
 const mapDispatchToProps = dispatch => ({
   addMessage: obj => dispatch(addMessage(obj)),
-  detectMessagingEnabled: addr => dispatch(detectMessagingEnabled(addr)),
   enableMessaging: () => dispatch(enableMessaging()),
   fetchNotifications: () => dispatch(fetchNotifications()),
   fetchUser: addr => dispatch(fetchUser(addr)),

--- a/origin-dapp/src/components/web3-provider.js
+++ b/origin-dapp/src/components/web3-provider.js
@@ -6,6 +6,7 @@ import clipboard from 'clipboard-polyfill'
 import QRCode from 'qrcode.react'
 import queryString from 'query-string'
 
+import { detectMessagingEnabled } from 'actions/Activation'
 import { storeWeb3Intent, storeNetwork } from 'actions/App'
 import { fetchProfile } from 'actions/Profile'
 import { getEthBalance, storeAccountAddress } from 'actions/Wallet'
@@ -580,11 +581,13 @@ class Web3Provider extends Component {
 
       // update global state
       storeAccountAddress(current)
-    }
 
-    if (current && !messagingInitialized) {
-      // trigger messaging service
-      origin.messaging.onAccount(current)
+      if (!messagingInitialized) {
+        // trigger messaging service
+        origin.messaging.onAccount(current)
+        // check after initializing messaging
+        this.props.detectMessagingEnabled(current)
+      }
     }
   }
 
@@ -698,6 +701,7 @@ const mapStateToProps = ({ activation, app, wallet }) => {
 }
 
 const mapDispatchToProps = dispatch => ({
+  detectMessagingEnabled: addr => dispatch(detectMessagingEnabled(addr)),
   fetchProfile: () => dispatch(fetchProfile()),
   getEthBalance: () => dispatch(getEthBalance()),
   storeAccountAddress: addr => dispatch(storeAccountAddress(addr)),


### PR DESCRIPTION
Please see [this comment](https://github.com/OriginProtocol/origin/issues/1437#issuecomment-466588391) @crazybuster in case we should also make a change to the messaging resource.

In https://github.com/OriginProtocol/origin/pull/1358, we added a client-side check so that a user who had previously enabled messaging but since deleted cookies or moved to a different device would be prompted to enable messaging. The problem with this in the real world is that [it depends on `this.account`](https://github.com/OriginProtocol/origin/blob/bd562ea4533f2c1588ead919155eb16fb676e9ba/origin-js/src/resources/messaging.js#L890), which in turn [depends on `initKeys`](https://github.com/OriginProtocol/origin/blob/bd562ea4533f2c1588ead919155eb16fb676e9ba/origin-js/src/resources/messaging.js#L240), which [depends on `this.ipfs_bound_account`](https://github.com/OriginProtocol/origin/blob/bd562ea4533f2c1588ead919155eb16fb676e9ba/origin-js/src/resources/messaging.js#L249), which [is delayed until ipfs is ready](https://github.com/OriginProtocol/origin/blob/bd562ea4533f2c1588ead919155eb16fb676e9ba/origin-js/src/resources/messaging.js#L389).

This changes the `detectMessagingEnabled` action to [check for the cookie directly](https://github.com/OriginProtocol/origin/compare/micah/messaging?expand=1#diff-4ea0a5fa371e4b62224a959683d7870cR26). It also resolves an issue of `onAccount` being called repeatedly.

Hopefully, this resolves https://github.com/OriginProtocol/origin/issues/1437. 🤞 