### PR TITLE
Dapp2 staging deploy

### DIFF
--- a/deployment/cloudbuild-deploy.yaml
+++ b/deployment/cloudbuild-deploy.yaml
@@ -86,6 +86,7 @@ steps:
           -t gcr.io/${PROJECT_ID}/$(cat .namespace)/${_CONTAINER}:${SHORT_SHA} \
           --build-arg DEPLOY_TAG=${SHORT_SHA} \
           --build-arg ENVKEY=$${_ENVKEY} \
+          --build-arg NAMESPACE=$(cat .namespace)
           .
 
   # Push the container image

--- a/deployment/dockerfiles/origin-dapp2
+++ b/deployment/dockerfiles/origin-dapp2
@@ -1,8 +1,9 @@
+ARG DEPLOY_TAG=dev
+ARG NAMESPACE=dev
+
 FROM node:10 as build
 
 WORKDIR /app
-
-ARG DEPLOY_TAG=dev
 
 # The DEPLOY_TAG is to make the commit hash of the currently built version
 # available in the DApp info screen.
@@ -42,8 +43,6 @@ RUN mv /app/experimental/origin-dapp2/public/rinkeby.html \
 FROM build as build-prod
 RUN mv /app/experimental/origin-dapp2/public/mainnet.html \
 	/app/experimental/origin-dapp2/public/index.html
-
-ARG NAMESPACE=dev
 
 FROM build-${NAMESPACE} AS build-complete
 

--- a/deployment/dockerfiles/origin-dapp2
+++ b/deployment/dockerfiles/origin-dapp2
@@ -2,14 +2,11 @@ FROM node:10 as build
 
 WORKDIR /app
 
-ARG DEPLOY_TAG
-ARG ENVKEY
+ARG DEPLOY_TAG=dev
 
-# Set environment variables. NODE_ENV is set to production to avoid installing
-# any dependencies that aren't necessary for the build. The DEPLOY_TAG is to
-# make the commit hash of the currently built version available in the DApp
-# info screen.
-ENV NODE_ENV=production DEPLOY_TAG=$DEPLOY_TAG
+# The DEPLOY_TAG is to make the commit hash of the currently built version
+# available in the DApp info screen.
+ENV DEPLOY_TAG=$DEPLOY_TAG
 
 # Copy the necessary files for building origin-dapp
 COPY package*.json ./
@@ -32,11 +29,26 @@ COPY ./origin-contracts/releases/0.8.5/build/ ./origin-contracts/build/
 
 RUN npm run build --prefix experimental/origin-dapp2
 
+# Conditional copy of config depending on NAMESPACE build arg using multi stage
+# builds
+FROM build as build-dev
 RUN mv /app/experimental/origin-dapp2/public/kovan.html \
 	/app/experimental/origin-dapp2/public/index.html
 
+FROM build as build-staging
+RUN mv /app/experimental/origin-dapp2/public/rinkeby.html \
+	/app/experimental/origin-dapp2/public/index.html
+
+FROM build as build-prod
+RUN mv /app/experimental/origin-dapp2/public/mainnet.html \
+	/app/experimental/origin-dapp2/public/index.html
+
+ARG NAMESPACE=dev
+
+FROM build-${NAMESPACE} AS build-complete
+
 # Copy built static files to nginx for serving
 FROM nginx:1.15.2-alpine
-COPY --from=build /app/experimental/origin-dapp2/public /usr/share/nginx/html
+COPY --from=build-complete /app/experimental/origin-dapp2/public /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/deployment/kubernetes/charts/origin/templates/dapp2.deployment.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp2.deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Release.Namespace "dev" -}}
+{{- if ne .Release.Namespace "prod" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployment/kubernetes/charts/origin/templates/dapp2.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp2.ingress.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Release.Namespace "dev" -}}
+{{- if ne .Release.Namespace "prod" -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/deployment/kubernetes/charts/origin/templates/dapp2.service.yaml
+++ b/deployment/kubernetes/charts/origin/templates/dapp2.service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Release.Namespace "dev" -}}
+{{- if ne .Release.Namespace "prod" -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/experimental/origin-dapp2/webpack.config.js
+++ b/experimental/origin-dapp2/webpack.config.js
@@ -144,6 +144,12 @@ if (isProduction) {
       inject: false,
       filename: 'kovan.html',
       network: 'kovanTst'
+    }),
+    new HtmlWebpackPlugin({
+      template: 'public/template.html',
+      inject: false,
+      filename: 'rinkeby.html',
+      network: 'rinkeby'
     })
   )
   config.resolve.alias = {


### PR DESCRIPTION
Adds dapp2.staging.originprotocol.com configured for Rinkeby. 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
