### PR TITLE
separate apollo adapter logic to a separate file

### DIFF
--- a/origin-growth/src/apollo/adapter.js
+++ b/origin-growth/src/apollo/adapter.js
@@ -1,0 +1,116 @@
+const BigNumber = require('bignumber.js')
+
+const sumUpRewards = rewards => {
+  if (rewards === null || rewards.length === 0) {
+    return null
+  }
+
+  const totalReward = rewards.reduce((first, second) => {
+    if (first.currency !== second.currency)
+      throw new Error(
+        `At least two rewards have different currencies. ${first.currency} ${
+          second.currency
+        }`
+      )
+    return {
+      amount: BigNumber(first.amount).plus(BigNumber(second.amount)),
+      currency: first.currency
+    }
+  })
+
+  return {
+    amount: totalReward.amount.toString(),
+    currency: totalReward.currency
+  }
+}
+
+const eventTypeToActionType = eventType => {
+  const eventToActionType = {
+    ProfilePublished: 'Profile',
+    EmailAttestationPublished: 'Email',
+    FacebookAttestationPublished: 'Facebook',
+    AirbnbAttestationPublished: 'Airbnb',
+    TwitterAttestationPublished: 'Twitter',
+    PhoneAttestationPublished: 'Phone',
+    RefereeSignedUp: 'Referral',
+    ListingCreated: 'ListingCreated',
+    ListingPurchased: 'ListingPurchased'
+  }
+
+  return eventToActionType[eventType]
+}
+
+/**
+ * Formats the campaign object according to the Growth schema
+ *
+ * @returns {Object} - formatted object
+ */
+const multiEventRuleApolloObject = (rule, ethAddress, events, currentUserLevel) => {
+  const rewards = rule.getRewards(ethAddress, events)
+
+  return {
+    // TODO: we need event types for MultiEventsRule
+    type: eventTypeToActionType(rule.config.eventTypes[0]),
+    status: rule.getStatus(ethAddress, events, currentUserLevel),
+    rewardEarned: sumUpRewards(rewards),
+    reward: rule.config.reward
+  }
+}
+
+/**
+ * Formats the campaign object according to the Growth schema
+ *
+ * @returns {Object} - formatted object
+ */
+const singleEventRuleApolloObject = (rule, ethAddress, events, currentUserLevel) => {
+  const rewards = rule.getRewards(ethAddress, events)
+  const objectToReturn = {
+    type: eventTypeToActionType(rule.config.eventType),
+    status: rule.getStatus(ethAddress, events, currentUserLevel),
+    rewardEarned: sumUpRewards(rewards),
+    reward: rule.config.reward
+  }
+
+  if (objectToReturn.type === 'Referral') {
+    // TODO implement this
+    objectToReturn.rewardPending = rule.config.reward
+  }
+
+  return objectToReturn
+}
+
+/**
+ * Formats the campaign object according to the Growth schema
+ *
+ * @returns {Object} - formatted object
+ */
+const campaignToApolloObject = async (campaign, ethAddress) => {
+  //TODO: change to true, true
+  //const events = this.getEvents(ethAddress, true, true)
+  const events = await campaign.getEvents(ethAddress, false, false)
+  const levels = Object.values(campaign.levels)
+  const rules = levels.flatMap(level => level.rules)
+  const currentLevel = await campaign.getCurrentLevel(ethAddress, false)
+
+  return {
+    id: campaign.campaign.id,
+    name: campaign.campaign.name,
+    startDate: campaign.campaign.startDate,
+    endDate: campaign.campaign.endDate,
+    distributionDate: campaign.campaign.distributionDate,
+    status: campaign.getStatus(),
+    actions: rules
+      .filter(rule => rule.isVisible())
+      .map(rule => {
+        if (rule.constructor.name === 'SingleEventRule')
+          return singleEventRuleApolloObject(rule, ethAddress, events, currentLevel)
+        else if (rule.constructor.name === 'MultiEventsRule')
+          return multiEventRuleApolloObject(rule, ethAddress, events, currentLevel)
+      }),
+    rewardEarned: sumUpRewards(
+      levels.flatMap(level => level.getRewards(ethAddress, events))
+    )
+  }
+}
+
+module.exports = { campaignToApolloObject }

--- a/origin-growth/src/apollo/adapter.js
+++ b/origin-growth/src/apollo/adapter.js
@@ -45,7 +45,12 @@ const eventTypeToActionType = eventType => {
  *
  * @returns {Object} - formatted object
  */
-const multiEventRuleApolloObject = (rule, ethAddress, events, currentUserLevel) => {
+const multiEventRuleApolloObject = (
+  rule,
+  ethAddress,
+  events,
+  currentUserLevel
+) => {
   const rewards = rule.getRewards(ethAddress, events)
 
   return {
@@ -62,7 +67,12 @@ const multiEventRuleApolloObject = (rule, ethAddress, events, currentUserLevel) 
  *
  * @returns {Object} - formatted object
  */
-const singleEventRuleApolloObject = (rule, ethAddress, events, currentUserLevel) => {
+const singleEventRuleApolloObject = (
+  rule,
+  ethAddress,
+  events,
+  currentUserLevel
+) => {
   const rewards = rule.getRewards(ethAddress, events)
   const objectToReturn = {
     type: eventTypeToActionType(rule.config.eventType),
@@ -103,9 +113,19 @@ const campaignToApolloObject = async (campaign, ethAddress) => {
       .filter(rule => rule.isVisible())
       .map(rule => {
         if (rule.constructor.name === 'SingleEventRule')
-          return singleEventRuleApolloObject(rule, ethAddress, events, currentLevel)
+          return singleEventRuleApolloObject(
+            rule,
+            ethAddress,
+            events,
+            currentLevel
+          )
         else if (rule.constructor.name === 'MultiEventsRule')
-          return multiEventRuleApolloObject(rule, ethAddress, events, currentLevel)
+          return multiEventRuleApolloObject(
+            rule,
+            ethAddress,
+            events,
+            currentLevel
+          )
       }),
     rewardEarned: sumUpRewards(
       levels.flatMap(level => level.getRewards(ethAddress, events))

--- a/origin-growth/src/apollo/resolvers.js
+++ b/origin-growth/src/apollo/resolvers.js
@@ -3,6 +3,7 @@ const { GraphQLDateTime } = require('graphql-iso-date')
 //const db = require('./db')
 const { Fetcher } = require('../rules/rules')
 const { getLocationInfo } = require('../util/locationInfo')
+const { campaignToApolloObject } = require('./adapter')
 // const { GrowthInvite } = require('../resources/invite')
 
 // Resolvers define the technique for fetching the types in the schema.
@@ -28,7 +29,7 @@ const resolvers = {
       return {
         totalCount: campaigns.length,
         nodes: campaigns.map(
-          async campaign => await campaign.toApolloObject(args.walletAddress)
+          async campaign => await campaignToApolloObject(campaign, args.walletAddress)
         ),
         pageInfo: {
           endCursor: 'TODO implement',

--- a/origin-growth/src/apollo/resolvers.js
+++ b/origin-growth/src/apollo/resolvers.js
@@ -29,7 +29,8 @@ const resolvers = {
       return {
         totalCount: campaigns.length,
         nodes: campaigns.map(
-          async campaign => await campaignToApolloObject(campaign, args.walletAddress)
+          async campaign =>
+            await campaignToApolloObject(campaign, args.walletAddress)
         ),
         pageInfo: {
           endCursor: 'TODO implement',


### PR DESCRIPTION
### Description:
Separating Apollo formatting functionality out of rules class

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
