### PR TITLE
Make GIT_COMMIT_HASH and GIT_BRANCH available to dapp2 build

### DIFF
--- a/deployment/cloudbuild-deploy.yaml
+++ b/deployment/cloudbuild-deploy.yaml
@@ -84,7 +84,8 @@ steps:
         docker build \
           -f deployment/dockerfiles/${_CONTAINER} \
           -t gcr.io/${PROJECT_ID}/$(cat .namespace)/${_CONTAINER}:${SHORT_SHA} \
-          --build-arg DEPLOY_TAG=${SHORT_SHA} \
+          --build-arg GIT_COMMIT_HASH=${SHORT_SHA} \
+          --build-arg GIT_BRANCH=${BRANCH_NAME} \
           --build-arg ENVKEY=$${_ENVKEY} \
           --build-arg NAMESPACE=$(cat .namespace) \
           .

--- a/deployment/dockerfiles/origin-dapp2
+++ b/deployment/dockerfiles/origin-dapp2
@@ -1,13 +1,12 @@
-ARG DEPLOY_TAG=dev
+ARG GIT_COMMIT_HASH=dev
+ARG GIT_BRANCH=dev
 ARG NAMESPACE=dev
 
 FROM node:10 as build
 
 WORKDIR /app
 
-# The DEPLOY_TAG is to make the commit hash of the currently built version
-# available in the DApp info screen.
-ENV DEPLOY_TAG=$DEPLOY_TAG
+ENV GIT_COMMIT_HASH=$GIT_COMMIT_HASH GIT_BRANCH=$GIT_BRANCH
 
 # Copy the necessary files for building origin-dapp
 COPY package*.json ./


### PR DESCRIPTION
Make some env vars available to dapp2 inside Docker container

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
