### PR TITLE
No Messaging Prerequisite

### DIFF
--- a/origin-dapp/src/components/onboarding.js
+++ b/origin-dapp/src/components/onboarding.js
@@ -138,7 +138,7 @@ class Onboarding extends Component {
       }, 60 * ONE_SECOND)
     }
 
-    const supportAccount = this.props.messagingRequired
+    const supportAccount = process.env.MESSAGING_ACCOUNT
     const welcomeAccountEnabled = supportAccount &&
       formattedAddress(supportAccount) !== formattedAddress(wallet.address)
 

--- a/origin-dapp/src/reducers/App.js
+++ b/origin-dapp/src/reducers/App.js
@@ -4,7 +4,7 @@ const initialState = {
   betaModalDismissed: true,
   // a timestamp for when the messages dropdown was last closed
   messagingDismissed: null,
-  messagingRequired: process.env.MESSAGING_ACCOUNT,
+  messagingRequired: false,
   mobileDevice: null,
   // a list of ids that were present last time the notifications dropdown was closed
   notificationsDismissed: [],


### PR DESCRIPTION
This removes the requirement to enable messaging before buying or selling as discussed below. 🔥 

![messaging](https://user-images.githubusercontent.com/273937/53441227-2db4c500-39bb-11e9-9f38-dbdbc46a442b.png)