### PR TITLE
Add env vars to dapp2's dapp-info page

### DIFF
--- a/experimental/origin-dapp2/src/pages/about/DappInfo.js
+++ b/experimental/origin-dapp2/src/pages/about/DappInfo.js
@@ -218,6 +218,38 @@ const DappInfo = () => {
                     ))}
                   </tbody>
                 </table>
+
+                <table className="config-table">
+                  <thead>
+                    <tr>
+                      <th>
+                        <h3>Environment Variables</h3>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th>DOCKER</th>
+                      <td>{process.env.DOCKER}</td>
+                    </tr>
+                    <tr>
+                      <th>ENABLE_GROWTH</th>
+                      <td>{process.env.ENABLE_GROWTH}</td>
+                    </tr>
+                    <tr>
+                      <th>HOST</th>
+                      <td>{process.env.HOST}</td>
+                    </tr>
+                    <tr>
+                      <th>IPFS_SWARM</th>
+                      <td>{process.env.IPFS_SWARM}</td>
+                    </tr>
+                    <tr>
+                      <th>ORIGIN_LINKING</th>
+                      <td>{process.env.ORIGIN_LINKING}</td>
+                    </tr>
+                  </tbody>
+                </table>
               </section>
             )
           }}


### PR DESCRIPTION
Add env vars to dapp-info for ease of debugging

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
