### PR TITLE
Add titles from marketplace creator to PageTitle component in DApp2

### DIFF
--- a/experimental/origin-dapp2/src/components/PageTitle.js
+++ b/experimental/origin-dapp2/src/components/PageTitle.js
@@ -1,13 +1,16 @@
 import { Component } from 'react'
 
-export default class PageTitle extends Component {
+import withCreatorConfig from 'hoc/withCreatorConfig'
+
+class PageTitle extends Component {
   componentDidMount() {
-    if (!this.props.children) return 'Origin'
-    const title = this._cleanTitle(this.props.children)
-    document.title = title + ' - Origin'
+    const siteTitle = this.props.creatorConfig.title ? this.props.creatorConfig.title : 'Origin'
+    if (!this.props.children) return siteTitle
+    const pageTitle = this._cleanPageTitle(this.props.children)
+    document.title = `${pageTitle} - ${siteTitle}`
   }
 
-  _cleanTitle(raw) {
+  _cleanPageTitle(raw) {
     // Since we are using react children for the title,
     // we get in multiple text elements if variables are used.
     // If so, join and clean up whitespace.
@@ -18,3 +21,5 @@ export default class PageTitle extends Component {
     return null
   }
 }
+
+export default withCreatorConfig(PageTitle)

--- a/experimental/origin-dapp2/src/components/PageTitle.js
+++ b/experimental/origin-dapp2/src/components/PageTitle.js
@@ -4,7 +4,9 @@ import withCreatorConfig from 'hoc/withCreatorConfig'
 
 class PageTitle extends Component {
   componentDidMount() {
-    const siteTitle = this.props.creatorConfig.title ? this.props.creatorConfig.title : 'Origin'
+    const siteTitle = this.props.creatorConfig.title
+      ? this.props.creatorConfig.title
+      : 'Origin'
     if (!this.props.children) return siteTitle
     const pageTitle = this._cleanPageTitle(this.props.children)
     document.title = `${pageTitle} - ${siteTitle}`

--- a/experimental/origin-dapp2/src/components/PageTitle.js
+++ b/experimental/origin-dapp2/src/components/PageTitle.js
@@ -1,12 +1,11 @@
 import { Component } from 'react'
+import get from 'lodash/get'
 
 import withCreatorConfig from 'hoc/withCreatorConfig'
 
 class PageTitle extends Component {
   componentDidMount() {
-    const siteTitle = this.props.creatorConfig.title
-      ? this.props.creatorConfig.title
-      : 'Origin'
+    const siteTitle = get(this.props, 'creatorConfig.title', 'Origin')
     if (!this.props.children) return siteTitle
     const pageTitle = this._cleanPageTitle(this.props.children)
     document.title = `${pageTitle} - ${siteTitle}`


### PR DESCRIPTION
Title says it all!

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)~~
- [ ] ~~Wrap any new text/strings for translation~~
- [ ] ~~Run `npm run translations` if there are any changes to translated strings~~
- [ ] ~~Map any new environment variables with a default value in the Webpack config~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)~~
