### PR TITLE
Fix "open in wallet" button

### DIFF
--- a/experimental/origin-dapp2/src/components/MobileLinkerCode.js
+++ b/experimental/origin-dapp2/src/components/MobileLinkerCode.js
@@ -68,7 +68,7 @@ export default class MobileLinkerCode extends Component {
                   <button
                     className="btn btn-primary"
                     style={{ width: 'auto' }}
-                    onClick={() => this.openLinkerApp(role)}
+                    onClick={() => this.openLinkerApp(role, linkCode)}
                   >
                     Copy &amp; Open App
                   </button>


### PR DESCRIPTION
Wasn't passing in linkCode to openLinkerApp()

### Description:

Please explain the changes you made here:

- A description of the problem you're trying to solve
- An overview of the suggested solution
- If the feature changes current behavior, reasons why your solution is better

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
