### PR TITLE
Fix wallet dapp URLs

### DIFF
--- a/origin-linking/src/logic/linker.js
+++ b/origin-linking/src/logic/linker.js
@@ -2,6 +2,7 @@
 import db from './../models/'
 import uuidv4 from 'uuid/v4'
 import { Op } from 'sequelize'
+import url from 'url'
 import { MessageTypes,EthNotificationTypes } from 'origin/common/enums'
 import MessageQueue from './../utils/message-queue'
 import origin, {providerUrl, perfModeEnabled, discoveryServerUrl, web3} from './../services/origin'
@@ -10,10 +11,13 @@ import apn from 'apn'
 import * as firebase from 'firebase-admin' // AKA "admin"
 
 const ATTESTATION_ACCOUNT = process.env.ATTESTATION_ACCOUNT
-const DAPP_URL = process.env.DAPP_URL
-const MESSAGING_URL = `${DAPP_URL}/#/messages?no-nav=true&skip-onboarding=true&wallet-container=`
-const PROFILE_URL = `${DAPP_URL}/#/profile`
-const SELLING_URL = `${DAPP_URL}/#/create`
+const DAPP_URL = url.resolve(process.env.DAPP_URL, '/#/')
+const MESSAGING_URL = url.resolve(
+  DAPP_URL,
+  '/#/messages?no-nav=true&skip-onboarding=true&wallet-container='
+)
+const PROFILE_URL = url.resolve(DAPP_URL, '/#/profile')
+const SELLING_URL = url.resolve(DAPP_URL, '/#/create')
 const CODE_EXPIRATION_TIME_MINUTES = 60
 const CODE_SIZE = 16
 
@@ -277,7 +281,7 @@ class Linker {
     }
     return {clientToken, sessionToken, code:linkedObj.code, linked:linkedObj.linked}
   }
-  
+
   async getLinkInfo(code) {
     const linkedObjs = await this.findUnexpiredCode(code)
     if (linkedObjs.length > 0)
@@ -396,7 +400,7 @@ class Linker {
 
   _getContextMsg(linkedObj, sessionToken) {
     const linked = linkedObj.linked
-    return { type:MessageTypes.CONTEXT, 
+    return { type:MessageTypes.CONTEXT,
       data:{session_token:sessionToken, linked, device:linked && linkedObj.currentDeviceContext}}
   }
 


### PR DESCRIPTION
The mobile wallet gets its URLs from the linking server. Right now,
we're returning bad URLs because staging's EnvKey has DAPP_URL set to
something that ends in `/#/`, which the linking server appends another
`/#/` to for the profile URL and other URLs.

This change uses Node's builtin `url` package to remove extra `/#/`s and
prevent double slashes. This should make the generated URLs a little
cleaner.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
