### PR TITLE
fixes #1536 by forcing re-render of QRCodeScanner on nav switch

### DIFF
--- a/origin-mobile/src/screens/scan.js
+++ b/origin-mobile/src/screens/scan.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { View } from 'react-native'
+import { NavigationEvents } from 'react-navigation';
 import QRCodeScanner from 'react-native-qrcode-scanner'
 
 import ScanMarker from 'components/scan-marker'
@@ -15,19 +16,36 @@ export default class ScanScreen extends Component {
       fontWeight: 'normal',
     },
   }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isFocused: false
+    }
+  }
     
   render() {
+    const { isFocused } = this.state
+
     return (
       <View style={{ flex: 1 }}>
-        <QRCodeScanner
-          reactivate={true}
-          reactivateTimeout={5000}
-          onRead={originWallet.onQRScanned}
-          showMarker={true}
-          customMarker={<ScanMarker />}
-          cameraProps={{ captureAudio: false }}
-          cameraStyle={{ height: '100%' }}
+        <NavigationEvents
+          onDidFocus={payload => this.setState({ isFocused: true })}
+          onDidBlur={payload => this.setState({ isFocused: false })}
         />
+        {isFocused && (
+          <QRCodeScanner
+            reactivate={true}
+            reactivateTimeout={5000}
+            ref={node => this.scanner = node}
+            onRead={originWallet.onQRScanned}
+            showMarker={true}
+            customMarker={<ScanMarker />}
+            cameraProps={{ captureAudio: false }}
+            cameraStyle={{ height: '100%' }}
+          />
+        )}
       </View>
     )
   }


### PR DESCRIPTION
### Description:

Fixes #1536 by re-rendering `QRCodeScanner` on nav change. 

This fix adds a small delay to rendering.  Probably ~500ms.  If #1536 can not be reproduced on iOS, then this fix could be adjusted to be Android-only.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
