### PR TITLE
Don't crash with a string as a listing media

### DIFF
--- a/experimental/origin-eventsource/src/index.js
+++ b/experimental/origin-eventsource/src/index.js
@@ -166,7 +166,7 @@ class OriginEventSource {
         urlExpanded: `${this.ipfsGateway}/${m.url.replace(':/', '')}`
       }))
     } else {
-      data.media = [] // If invalid, send something clean onward
+      data.media = [] // If invalid, set a clean, empty media array
     }
 
     let __typename = data.__typename

--- a/experimental/origin-eventsource/src/index.js
+++ b/experimental/origin-eventsource/src/index.js
@@ -160,11 +160,13 @@ class OriginEventSource {
       data.categoryStr = startCase(data.category.replace(/^schema\./, ''))
     }
 
-    if (data.media && data.media.length) {
+    if (data.media && Array.isArray(data.media)) {
       data.media = data.media.map(m => ({
         ...m,
         urlExpanded: `${this.ipfsGateway}/${m.url.replace(':/', '')}`
       }))
+    } else {
+      data.media = [] // If invalid, send something clean onward
     }
 
     let __typename = data.__typename


### PR DESCRIPTION
A listing json containing `{...media:"string"...}` would crash the dapp.

There was an existing check making sure media had a "length", but this also succeeded for a string.