### PR TITLE
Exclude an invalid listing from listings search, rather than return no results at all

### DIFF
--- a/experimental/origin-graphql/src/resolvers/marketplace/listings.js
+++ b/experimental/origin-graphql/src/resolvers/marketplace/listings.js
@@ -78,9 +78,8 @@ async function resultsFromIds({ after, ids, first, totalCount, fields }) {
 
   if (!fields || fields.nodes) {
     nodes = (await Promise.all(
-      ids.map(id => contracts.eventSource.getListing(id).catch(e => e) )
-    ))
-    .filter(node => !(node instanceof Error))
+      ids.map(id => contracts.eventSource.getListing(id).catch(e => e))
+    )).filter(node => !(node instanceof Error))
   }
   const firstNodeId = ids[0] || 0
   const lastNodeId = ids[ids.length - 1] || 0

--- a/experimental/origin-graphql/src/resolvers/marketplace/listings.js
+++ b/experimental/origin-graphql/src/resolvers/marketplace/listings.js
@@ -77,9 +77,10 @@ async function resultsFromIds({ after, ids, first, totalCount, fields }) {
   ids = ids.slice(start, end)
 
   if (!fields || fields.nodes) {
-    nodes = await Promise.all(
-      ids.map(id => contracts.eventSource.getListing(id))
-    )
+    nodes = (await Promise.all(
+      ids.map(id => contracts.eventSource.getListing(id).catch(e => e) )
+    ))
+    .filter(node => !(node instanceof Error));
   }
   const firstNodeId = ids[0] || 0
   const lastNodeId = ids[ids.length - 1] || 0

--- a/experimental/origin-graphql/src/resolvers/marketplace/listings.js
+++ b/experimental/origin-graphql/src/resolvers/marketplace/listings.js
@@ -80,7 +80,7 @@ async function resultsFromIds({ after, ids, first, totalCount, fields }) {
     nodes = (await Promise.all(
       ids.map(id => contracts.eventSource.getListing(id).catch(e => e) )
     ))
-    .filter(node => !(node instanceof Error));
+    .filter(node => !(node instanceof Error))
   }
   const firstNodeId = ids[0] || 0
   const lastNodeId = ids[ids.length - 1] || 0


### PR DESCRIPTION
Currently a single invalid listing will break the entire listing results page. This is because `Promise.all` will immediately reject if any sub-promise rejects. 

While there might be better ways to handle this long term (will make separate issue for discussion), the simplest approach is to just exclude from the results any listings that fail to load, are invalid, or throw errors.

This does have the downside of possibly returning fewer listings than were asked for, but it's certainly better than breaking the whole front page, and making people unable to browse listings.