### PR TITLE
Remove secure cookie requirement from bridge

### DIFF
--- a/origin-bridge/src/app.js
+++ b/origin-bridge/src/app.js
@@ -28,10 +28,6 @@ const sess = {
 // needed
 sessionStore.sync()
 
-if (process.env.NODE_ENV == 'production') {
-  sess.cookie.secure = true
-}
-
 app.use(session(sess))
 app.use(express.json())
 app.use(cors({ origin: true, credentials: true }))


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Remove the secure cookie setting from `origin-bridge`. This stops cookies working because the nginx -> origin-bridge communication is not via https, the https connection terminates at nginx. It isn't necessary either since nginx enforces https.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
