### PR TITLE
Remove duplicate GA script tag (#1212)

### DIFF
--- a/origin-dapp/public/dev.html
+++ b/origin-dapp/public/dev.html
@@ -12,8 +12,7 @@
     <meta name="theme-color" content="#2585FB">
 
     <title>Origin Protocol DApp</title>
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-106384880-2%22%3E"></script>
+    <!-- Google Analytics --> 
     <script>
       /*eslint-disable */
       var hostname = window.location.hostname

--- a/origin-dapp/public/index.html
+++ b/origin-dapp/public/index.html
@@ -13,7 +13,6 @@
 
     <title>Origin Protocol DApp</title>
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-106384880-2%22%3E"></script>
     <script>
       /*eslint-disable */
       var hostname = window.location.hostname


### PR DESCRIPTION
Google Analytics is loaded through both analytics.js
and googletagmanager. Removing the load through googletagmanager.
