### PR TITLE
Add Sold/Pending/Available data to buy box for seller.

### DIFF
--- a/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
+++ b/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
@@ -46,7 +46,6 @@ require('react-styl')(`
       margin-bottom: 16px
       .row
         div:nth-child(1)
-          width: auto
           flex: 1
           padding-left: 16px
         div:nth-child(2)

--- a/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
+++ b/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
@@ -13,6 +13,20 @@ const EditOnly = ({ listing, isAnnouncement }) => (
         </div>
       </div>
     )}
+    <div className="listing-buy-editonly">
+      <div className="row">
+        <div>Sold</div>
+        <div>{listing.unitsSold}</div>
+      </div>
+      <div className="row">
+        <div>Pending</div>
+        <div>{listing.unitsPending}</div>
+      </div>
+      <div className="row">
+        <div>Available</div>
+        <div>{listing.unitsAvailable}</div>
+      </div>
+    </div>
     <Link
       className="btn btn-primary mt-2"
       to={`/listing/${listing.id}/edit`}
@@ -22,3 +36,21 @@ const EditOnly = ({ listing, isAnnouncement }) => (
 )
 
 export default EditOnly
+
+require('react-styl')(`
+  .listing-buy
+    .listing-buy-editonly
+      border-top: 1px solid var(--dark)
+      border-bottom: 1px solid var(--dark)
+      padding: 16px
+      margin-bottom: 16px
+      .row
+        div:nth-child(1)
+          width: auto
+          flex: 1
+          padding-left: 16px
+        div:nth-child(2)
+          flex: 1
+          text-align: right
+          padding-right: 16px
+`)

--- a/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
+++ b/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
@@ -40,16 +40,16 @@ export default EditOnly
 require('react-styl')(`
   .listing-buy
     .listing-buy-editonly
-      border-top: 1px solid var(--dark)
-      border-bottom: 1px solid var(--dark)
-      padding: 16px
-      margin-bottom: 16px
+      border-top: 1px solid var(--light)
+      border-bottom: 1px solid var(--light)
+      padding: 1rem
+      margin-bottom: 1rem
       .row
         div:nth-child(1)
           flex: 1
-          padding-left: 16px
+          padding-left: 1rem
         div:nth-child(2)
           flex: 1
           text-align: right
-          padding-right: 16px
+          padding-right: 1rem
 `)

--- a/experimental/origin-dapp2/src/queries/Fragments.js
+++ b/experimental/origin-dapp2/src/queries/Fragments.js
@@ -61,6 +61,7 @@ export default {
           unitsTotal
           unitsAvailable
           unitsSold
+          unitsPending
           multiUnit
         }
         ... on FractionalListing {


### PR DESCRIPTION
NOTE: This expects there to be a `listing.unitsPending` field *which does not yet exist*. Best to hold off on merging this PR until that change gets made. @nick is on it. 

Resolves P0 blocker number 6  "[No way to see number of remaining units on a created unit listing](https://docs.google.com/spreadsheets/d/1IPsBe-08Bnq5WEtg4KMdZKgEWLF2AbLqo0LLhLriW5Q/edit#gid=794850718&range=6:6) " from spreadsheet:

Styling not yet blessed by Aure, but a request has been made. 

![image](https://user-images.githubusercontent.com/673455/53846184-36803a80-3f69-11e9-83ba-944e035ba504.png)
