### PR TITLE
Use PROVIDER_URL in faucet

### DIFF
--- a/origin-faucet/src/eth.js
+++ b/origin-faucet/src/eth.js
@@ -201,7 +201,7 @@ class EthDistributor {
         '0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
       providerUrl = 'http://localhost:8545'
     } else {
-      hotWalletPk = process.env.HOT_WALLET_PK,
+      hotWalletPk = process.env.HOT_WALLET_PK
       providerUrl = process.env.PROVIDER_URL
     }
 

--- a/origin-faucet/src/eth.js
+++ b/origin-faucet/src/eth.js
@@ -201,10 +201,8 @@ class EthDistributor {
         '0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
       providerUrl = 'http://localhost:8545'
     } else {
-      hotWalletPk = process.env.HOT_WALLET_PK
-      providerUrl = `https://mainnet.infura.io/${
-        process.env.INFURA_ACCESS_TOKEN
-      }`
+      hotWalletPk = process.env.HOT_WALLET_PK,
+      providerUrl = process.env.PROVIDER_URL
     }
 
     const provider = new Web3.providers.HttpProvider(providerUrl)


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Allow passing of PROVIDER_URL to faucet rather than using INFURA_ACCESS_TOKEN.

@franckc I was looking for a way to leverage your work on the eth faucet for distributing eth on our testnet. I think this is the only change I need to make (and add a row to the campaign table with a large limit and invite code). What do you think? I think we should change this anyway because it gives us the option of using other web3 providers.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
