### PR TITLE
Add GCM_SENDER_ID to origin-mobile's README.md

### DIFF
--- a/origin-mobile/README.md
+++ b/origin-mobile/README.md
@@ -143,6 +143,8 @@ MAINNET_API_SERVER=https://linking.originprotocol.com
 RINKEBY_API_SERVER=https://linking.staging.originprotocol.com
 PROVIDER_URL=http://localhost:8545/
 CB_BW_CODE=
+
+GCM_SENDER_ID=
 ```
 
 **origin-notifications/.env**
@@ -251,7 +253,7 @@ This is likely a network error because your tunnels are not setup.  See [Android
 
 > FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 
-Add the `NODE_OPTIONS` env var to your Metro builder startup command to add the `--max_old_space_size` option like this: 
+Add the `NODE_OPTIONS` env var to your Metro builder startup command to add the `--max_old_space_size` option like this:
 
     NODE_OPTIONS="--max_old_space_size=8196" npm run start
 


### PR DESCRIPTION
This was added as part of Android wallet support. The wallet app doesn't start without this environment variable.

### Description:

Please explain the changes you made here:

- A description of the problem you're trying to solve
- An overview of the suggested solution
- If the feature changes current behavior, reasons why your solution is better

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
