### PR TITLE
Use IOS dates and ranges in fractional

### DIFF
--- a/experimental/origin-dapp2/src/components/Calendar.js
+++ b/experimental/origin-dapp2/src/components/Calendar.js
@@ -32,8 +32,8 @@ class Calendar extends Component {
       max = lastDay <= 35 ? 35 : 42,
       days = [],
       dayAvailability = this.props.availability.getAvailability(
-        date.format('YYYY/MM/DD'),
-        date.endOf('month').format('YYYY/MM/DD')
+        date.format('YYYY-MM-DD'),
+        date.endOf('month').format('YYYY-MM-DD')
       )
 
     let currentDay = 0
@@ -142,9 +142,9 @@ class Calendar extends Component {
           this.setState({ dragEnd: idx, dragging: false, endDate: day.date })
           if (this.props.onChange) {
             const start = dayjs(this.state.startDate)
-            let range = `${this.state.startDate}-${day.date}`
+            let range = `${this.state.startDate}/${day.date}`
             if (start.isAfter(day.date)) {
-              range = `${day.date}-${this.state.startDate}`
+              range = `${day.date}/${this.state.startDate}`
             }
             this.props.onChange({ range })
           }

--- a/experimental/origin-dapp2/src/pages/create-listing/Availability.js
+++ b/experimental/origin-dapp2/src/pages/create-listing/Availability.js
@@ -101,9 +101,7 @@ class Availability extends Component {
     const input = formInput(this.state, state => this.setState(state))
     const Feedback = formFeedback(this.state)
 
-    const [startRaw, endRaw] = this.state.range.split('-')
-    const start = startRaw.replace(/\//g, '-'),
-      end = endRaw.replace(/\//g, '-')
+    const [start, end] = this.state.range.split('/')
 
     return (
       <div className="availability-editor">

--- a/experimental/origin-graphql/src/utils/AvailabilityCalculator.js
+++ b/experimental/origin-graphql/src/utils/AvailabilityCalculator.js
@@ -7,9 +7,9 @@ dayjs.extend(isBetween)
 //   weekendPrice: '0.75',
 //   advanceNotice: 3, // Number of days of advanced notice
 //   bookingWindow: 180, // Book up to this many days in the future
-//   unavailable: ['2019/02/01-2019/02/07'],
-//   booked: ['2019/02/16-2019/02/18'],
-//   customPricing: ['2019/03/01-2019/03/05:0.6']
+//   unavailable: ['2019-02-01/2019-02-07'],
+//   booked: ['2019-02-16/2019-02-18'],
+//   customPricing: ['2019-03-01/2019-03-05:0.6']
 // })
 
 // const Keys = ['unavailable', 'booked', 'customPricing']
@@ -23,13 +23,13 @@ class AvailabilityCalculator {
   }
 
   /**
-   * @param range         Date range (eg 2019/01/01-2019-02-01)
+   * @param range         Date range (eg 2019-01-01/2019-02-01)
    * @param availability  'available', 'unavailable', 'booked'
    * @param price         '0.1', 'reset'
    */
   update(range, availability, price) {
     const slots = this.getAvailability(dayjs(), dayjs().add(1, 'year'))
-    const [startStr, endStr] = range.split('-')
+    const [startStr, endStr] = range.split('/')
     const start = dayjs(startStr).subtract(1, 'day'),
       end = dayjs(endStr).add(1, 'day')
 
@@ -63,9 +63,9 @@ class AvailabilityCalculator {
 
       if (slot.booked) {
         if (bookedRange) {
-          bookedRange = `${bookedRange.split('-')[0]}-${slot.date}`
+          bookedRange = `${bookedRange.split('/')[0]}/${slot.date}`
         } else {
-          bookedRange = `${slot.date}-${slot.date}`
+          bookedRange = `${slot.date}/${slot.date}`
         }
       } else if (bookedRange) {
         newBooked.push(bookedRange)
@@ -73,9 +73,9 @@ class AvailabilityCalculator {
       }
       if (slot.unavailable) {
         if (unavailableRange) {
-          unavailableRange = `${unavailableRange.split('-')[0]}-${slot.date}`
+          unavailableRange = `${unavailableRange.split('/')[0]}/${slot.date}`
         } else {
-          unavailableRange = `${slot.date}-${slot.date}`
+          unavailableRange = `${slot.date}/${slot.date}`
         }
       } else if (unavailableRange) {
         newUnavailable.push(unavailableRange)
@@ -84,11 +84,11 @@ class AvailabilityCalculator {
 
       if (slot.customPrice) {
         if (customPriceRange) {
-          customPriceRange = `${customPriceRange.split('-')[0]}-${slot.date}:${
+          customPriceRange = `${customPriceRange.split('/')[0]}/${slot.date}:${
             slot.price
           }`
         } else {
-          customPriceRange = `${slot.date}-${slot.date}:${slot.price}`
+          customPriceRange = `${slot.date}/${slot.date}:${slot.price}`
         }
       } else if (customPriceRange) {
         newCustomPrice.push(customPriceRange)
@@ -106,7 +106,7 @@ class AvailabilityCalculator {
   }
 
   estimatePrice(range) {
-    const [startStr, endStr] = range.split('-')
+    const [startStr, endStr] = range.split('/')
     const availability = this.getAvailability(startStr, endStr)
     const available = availability.every(slot => slot.unavailable === false)
     const price = availability.reduce((m, slot) => m + Number(slot.price), 0)
@@ -126,24 +126,24 @@ class AvailabilityCalculator {
 
     const unavailable = {}
     this.opts.unavailable.forEach(range => {
-      const [startStr, endStr] = range.split('-')
+      const [startStr, endStr] = range.split('/')
       let start = dayjs(startStr)
       const end = dayjs(endStr).add(1, 'day')
 
       while (start.isBefore(end)) {
-        unavailable[start.format('YYYY/MM/DD')] = true
+        unavailable[start.format('YYYY-MM-DD')] = true
         start = start.add(1, 'day')
       }
     })
 
     const booked = {}
     this.opts.booked.forEach(range => {
-      const [startStr, endStr] = range.split('-')
+      const [startStr, endStr] = range.split('/')
       let start = dayjs(startStr)
       const end = dayjs(endStr).add(1, 'day')
 
       while (start.isBefore(end)) {
-        booked[start.format('YYYY/MM/DD')] = true
+        booked[start.format('YYYY-MM-DD')] = true
         start = start.add(1, 'day')
       }
     })
@@ -151,18 +151,18 @@ class AvailabilityCalculator {
     const customPricing = {}
     this.opts.customPricing.forEach(customStr => {
       const [range, price] = customStr.split(':')
-      const [startStr, endStr] = range.split('-')
+      const [startStr, endStr] = range.split('/')
       let start = dayjs(startStr)
       const end = dayjs(endStr).add(1, 'day')
 
       while (start.isBefore(end)) {
-        customPricing[start.format('YYYY/MM/DD')] = price
+        customPricing[start.format('YYYY-MM-DD')] = price
         start = start.add(1, 'day')
       }
     })
 
     while (start.isBefore(end)) {
-      const date = start.format('YYYY/MM/DD'),
+      const date = start.format('YYYY-MM-DD'),
         day = start.day()
       let price = this.opts.weekdayPrice
       if (customPricing[date]) {

--- a/experimental/origin-graphql/test/availability-calculator.js
+++ b/experimental/origin-graphql/test/availability-calculator.js
@@ -17,67 +17,67 @@ describe('Availability Calculator', function() {
   })
 
   it('should allow a range of dates to be queried', function() {
-    const dates = instance.getAvailability(`${year}/02/16`, `${year}/02/18`)
+    const dates = instance.getAvailability(`${year}-02-16`, `${year}-02-18`)
     assert.deepEqual(dates, [
       {
-        date: `${year}/02/16`,
+        date: `${year}-02-16`,
         unavailable: false,
         booked: false,
-        price: dayjs(`${year}/02/16`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-16`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       },
       {
-        date: `${year}/02/17`,
+        date: `${year}-02-17`,
         unavailable: false,
         booked: false,
-        price: dayjs(`${year}/02/17`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-17`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       },
       {
-        date: `${year}/02/18`,
+        date: `${year}-02-18`,
         unavailable: false,
         booked: false,
-        price: dayjs(`${year}/02/18`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-18`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       }
     ])
   })
 
   it('should allow a range of dates to be made unavailable', function() {
-    const dates = instance.update(`${year}/02/01-${year}/02/02`, 'unavailable')
+    const dates = instance.update(`${year}-02-01/${year}-02-02`, 'unavailable')
     assert.deepEqual(dates, [
       {
-        date: `${year}/02/01`,
+        date: `${year}-02-01`,
         unavailable: true,
         booked: false,
-        price: dayjs(`${year}/02/01`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-01`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       },
       {
-        date: `${year}/02/02`,
+        date: `${year}-02-02`,
         unavailable: true,
         booked: false,
-        price: dayjs(`${year}/02/02`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-02`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       }
     ])
   })
 
   it('should allow a range of dates to be made available', function() {
-    const dates = instance.update(`${year}/02/01-${year}/02/02`, 'available')
+    const dates = instance.update(`${year}-02-01/${year}-02-02`, 'available')
     assert.deepEqual(dates, [
       {
-        date: `${year}/02/01`,
+        date: `${year}-02-01`,
         unavailable: false,
         booked: false,
-        price: dayjs(`${year}/02/01`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-01`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       },
       {
-        date: `${year}/02/02`,
+        date: `${year}-02-02`,
         unavailable: false,
         booked: false,
-        price: dayjs(`${year}/02/02`).day() >= 5 ? '0.75' : '0.5',
+        price: dayjs(`${year}-02-02`).day() >= 5 ? '0.75' : '0.5',
         customPrice: false
       }
     ])


### PR DESCRIPTION
Fractional was using a nonstandard way of respresenting dates and ranges. This switches us to use our standard ISO 8601 format.

Ranges (which are called "Intervals" in the ISO standard) are represented as 2 dates joined by a `/`, e.g. `2007-03-01/2008-05-11`
https://en.wikipedia.org/wiki/ISO_8601#Time_intervals

NOTES: 
- Should we write a little converter that recognizes dates/ranges in the old format and converts them on the fly? Would only be useful for pre-launch testing. 
- I think we should consider using a delimter other than `:` for adding a price to a range, as the colon is used in ISO time formats e.g. `2008-09-15T15:53:00`. We could not expand this format to include hourly fractional usage. 