### PR TITLE
Fix display of "Edit Only" box on listing detail

### DIFF
--- a/experimental/origin-dapp2/src/pages/listing/ListingDetail.js
+++ b/experimental/origin-dapp2/src/pages/listing/ListingDetail.js
@@ -121,7 +121,13 @@ class ListingDetail extends Component {
     const isAnnouncement = listing.__typename === 'AnnouncementListing'
 
     if (listing.seller.id === this.props.from) {
-      return <EditOnly {...this.props} isAnnouncement={isAnnouncement} />
+      return (
+        <EditOnly
+          {...this.props}
+          isAnnouncement={isAnnouncement}
+          isFractional={isFractional}
+        />
+      )
     } else if (isAnnouncement) {
       return null
     } else if (listing.status === 'sold') {

--- a/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
+++ b/experimental/origin-dapp2/src/pages/listing/_ListingEditOnly.js
@@ -3,9 +3,9 @@ import React from 'react'
 import Link from 'components/Link'
 import Price from 'components/Price'
 
-const EditOnly = ({ listing, isAnnouncement }) => (
+const EditOnly = ({ listing, isAnnouncement, isFractional }) => (
   <div className="listing-buy">
-    {isAnnouncement ? null : (
+    {isAnnouncement || isFractional ? null : (
       <div className="price">
         <div className="eth">{`${listing.price.amount} ETH`}</div>
         <div className="usd">
@@ -13,20 +13,22 @@ const EditOnly = ({ listing, isAnnouncement }) => (
         </div>
       </div>
     )}
-    <div className="listing-buy-editonly">
-      <div className="row">
-        <div>Sold</div>
-        <div>{listing.unitsSold}</div>
+    {isFractional ? null : (
+      <div className="listing-buy-editonly">
+        <div className="row">
+          <div>Sold</div>
+          <div>{listing.unitsSold}</div>
+        </div>
+        <div className="row">
+          <div>Pending</div>
+          <div>{listing.unitsPending}</div>
+        </div>
+        <div className="row">
+          <div>Available</div>
+          <div>{listing.unitsAvailable}</div>
+        </div>
       </div>
-      <div className="row">
-        <div>Pending</div>
-        <div>{listing.unitsPending}</div>
-      </div>
-      <div className="row">
-        <div>Available</div>
-        <div>{listing.unitsAvailable}</div>
-      </div>
-    </div>
+    )}
     <Link
       className="btn btn-primary mt-2"
       to={`/listing/${listing.id}/edit`}


### PR DESCRIPTION
We were showing a "Price " and "Units Sold" etc.. for fractional listings, which makes no sense.

I'm loathe to add more if/then display logic, but for now we're already on that path, so here's to more!

