### PR TITLE
New dapp and docker fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         # Setting required for Elasticsearch to run
         - sudo sysctl -w vm.max_map_count=262144
       script:
-        - docker-compose build origin-dapp
+        - docker-compose build origin-ipfs-proxy
         - docker-compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from origin-tests
 
     - name: "javascript linting"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         # Setting required for Elasticsearch to run
         - sudo sysctl -w vm.max_map_count=262144
       script:
-        - docker-compose build origin-ipfs-proxy
+        - docker-compose build
         - docker-compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from origin-tests
 
     - name: "javascript linting"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
         # Setting required for Elasticsearch to run
         - sudo sysctl -w vm.max_map_count=262144
       script:
+        - docker-compose build origin-dapp
         - docker-compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from origin-tests
 
     - name: "javascript linting"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,6 @@ services:
       - postgres
       - elasticsearch
       - origin-dapp
-      - origin-ipfs-proxy
     command:
       >
       /bin/bash -c "wait-for.sh -t 0 -q origin-dapp:3000 --

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,9 +100,6 @@ services:
   origin-messaging:
     container_name: origin-messaging
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     environment:
       - MESSAGING_NAMESPACE=dev
@@ -115,9 +112,6 @@ services:
   origin-ipfs-proxy:
     container_name: origin-ipfs-proxy
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     ports:
       - "9999:9999"
@@ -129,9 +123,6 @@ services:
   origin-event-listener:
     container_name: origin-event-listener
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     environment:
       - ARBITRATOR_ACCOUNT=0x821aEa9a577a9b44299B9c15c88cf3087F3b5544
@@ -162,9 +153,6 @@ services:
   origin-discovery:
     container_name: origin-discovery
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     environment:
       - ARBITRATOR_ACCOUNT=0x821aEa9a577a9b44299B9c15c88cf3087F3b5544
@@ -187,9 +175,6 @@ services:
   origin-notifications:
     container_name: origin-notifications
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     depends_on:
       - postgres
@@ -206,9 +191,6 @@ services:
   origin-growth:
     container_name: origin-growth
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     environment:
       - DATABASE_URL=postgres://origin:origin@postgres/origin
@@ -222,9 +204,6 @@ services:
   origin-bridge:
     container_name: origin-bridge
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes: *volumes
     environment:
       - DATABASE_URL=postgres://origin:origin@postgres/origin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     environment:
       - DEPLOY_CONTRACTS=true
       - DOCKER=true
-      - ENABLE_GROWTH=false
+      - ENABLE_GROWTH=true
     command:
       # Waits for origin-messaging to start then uses a script to read the
       # origin-messaging IPFS peer id and export the IPFS_SWARM variable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,6 @@ services:
   origin-dapp:
     container_name: origin-dapp
     image: origin
-    build:
-      context: .
-      dockerfile: Dockerfile
     depends_on:
       - origin-messaging
     volumes: &volumes
@@ -100,6 +97,9 @@ services:
   origin-messaging:
     container_name: origin-messaging
     image: origin
+    build:
+      context: .
+      dockerfile: Dockerfile
     volumes: *volumes
     environment:
       - MESSAGING_NAMESPACE=dev

--- a/origin-services/index.js
+++ b/origin-services/index.js
@@ -95,7 +95,7 @@ const populateIpfs = () =>
 
 const deployContracts = () =>
   new Promise((resolve, reject) => {
-    const originContractsPath = '../../origin-contracts/'
+    const originContractsPath = '../origin-contracts/'
     const truffleMigrate = spawn(
       `./node_modules/.bin/truffle`,
       ['migrate', '--reset'],


### PR DESCRIPTION
### Description:
In this pr: 
- docker images build a lot faster since they are built only once. Seems that `build` config triggers rebuilding of image and Lerna hoisting for each of the containers
- fix contracts path preventing `origin-dapp` container to start
- (slightly unrelated) enable `origin-growth` by default since this won't effect staging/production deployment

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
