### PR TITLE
Pick up marketplacePublisher on edit listing

### DIFF
--- a/origin-dapp/src/pages/listing/Edit.js
+++ b/origin-dapp/src/pages/listing/Edit.js
@@ -3,6 +3,8 @@ import { Switch, Route } from 'react-router-dom'
 import pick from 'lodash/pick'
 import get from 'lodash/get'
 
+import withCreatorConfig from 'hoc/withCreatorConfig'
+
 import PageTitle from 'components/PageTitle'
 
 import Step1 from '../create-listing/Step1'
@@ -21,6 +23,9 @@ class EditListing extends Component {
         booked: get(props, 'listing.booked', []),
         customPricing: get(props, 'listing.customPricing', []),
         unavailable: get(props, 'listing.unavailable', []),
+
+        // Marketplace creator fields:
+        marketplacePublisher: get(props, 'creatorConfig.marketplacePublisher'),
 
         ...pick(props.listing, [
           '__typename',
@@ -74,7 +79,7 @@ class EditListing extends Component {
   }
 }
 
-export default EditListing
+export default withCreatorConfig(EditListing)
 
 require('react-styl')(`
 `)


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Per title. `marketplacePublisher` wasn't getting saved on edit listings.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
