### PR TITLE
[Growth] Set event createdAt to blockchain event date.

### DIFF
--- a/origin-discovery/src/listener/handler_identity.js
+++ b/origin-discovery/src/listener/handler_identity.js
@@ -121,10 +121,11 @@ class IdentityEventHandler {
    * Records a ProfilePublished event in the growth_event table.
    * @param {Object} user - Origin js user model object.
    * @param {{blockNumber: number, logIndex: number}} blockInfo
+   * @param {Date} Event date.
    * @returns {Promise<void>}
    * @private
    */
-  async _recordGrowthProfileEvent(user, blockInfo) {
+  async _recordGrowthProfileEvent(user, blockInfo, date) {
     // Check profile is populated.
     const profile = user.profile
     const validProfile =
@@ -140,7 +141,8 @@ class IdentityEventHandler {
       user.address,
       GrowthEventTypes.ProfilePublished,
       null,
-      { blockInfo }
+      { blockInfo },
+      date
     )
   }
 
@@ -148,10 +150,11 @@ class IdentityEventHandler {
    * Records AttestationPublished events in the growth_event table.
    * @param {Object} user - Origin js user model object.
    * @param {{blockNumber: number, logIndex: number}} blockInfo
+   * @param {Date} Event date.
    * @returns {Promise<void>}
    * @private
    */
-  async _recordGrowthAttestationEvents(user, blockInfo) {
+  async _recordGrowthAttestationEvents(user, blockInfo, date) {
     await Promise.all(
       user.attestations.map(attestation => {
         const eventType = AttestationServiceToEventType[attestation.service]
@@ -164,9 +167,14 @@ class IdentityEventHandler {
           return
         }
 
-        return GrowthEvent.insert(logger, user.address, eventType, null, {
-          blockInfo
-        })
+        return GrowthEvent.insert(
+          logger,
+          user.address,
+          eventType,
+          null,
+          { blockInfo },
+          date
+          )
       })
     )
   }
@@ -212,8 +220,8 @@ class IdentityEventHandler {
     await this._indexIdentity(user, blockInfo)
 
     if (this.config.growth) {
-      await this._recordGrowthProfileEvent(user, blockInfo)
-      await this._recordGrowthAttestationEvents(user, blockInfo)
+      await this._recordGrowthProfileEvent(user, blockInfo, log.date)
+      await this._recordGrowthAttestationEvents(user, blockInfo, log.date)
     }
 
     return { user }

--- a/origin-discovery/src/listener/handler_marketplace.js
+++ b/origin-discovery/src/listener/handler_marketplace.js
@@ -277,7 +277,8 @@ class MarketplaceEventHandler {
           details.listing.seller.toLowerCase(),
           GrowthEventTypes.ListingCreated,
           details.listing.id,
-          { blockInfo }
+          { blockInfo },
+          log.date
         )
         break
       case 'OfferFinalized':
@@ -288,14 +289,16 @@ class MarketplaceEventHandler {
           details.offer.buyer.toLowerCase(),
           GrowthEventTypes.ListingPurchased,
           details.offer.id,
-          { blockInfo }
+          { blockInfo },
+          log.date
         )
         await GrowthEvent.insert(
           logger,
           details.listing.seller.toLowerCase(),
           GrowthEventTypes.ListingSold,
           details.offer.id,
-          { blockInfo }
+          { blockInfo },
+          log.date
         )
         break
     }

--- a/origin-growth/src/models/growth_event.js
+++ b/origin-growth/src/models/growth_event.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const Sequelize = require('sequelize')
+
 const enums = require('../enums')
 
 module.exports = (sequelize, DataTypes) => {
@@ -10,10 +12,21 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.ENUM(enums.GrowthEventTypes),
       status: DataTypes.ENUM(enums.GrowthEventStatuses),
       ethAddress: DataTypes.STRING,
-      data: DataTypes.JSONB
+      data: DataTypes.JSONB,
+      createdAt: {
+        type: DataTypes.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      },
+      // Creation date
+      updatedAt: {
+        type: DataTypes.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      }
     },
     {
-      tableName: 'growth_event'
+      tableName: 'growth_event',
+      // Do not automatically add the timestamp attributes (updatedAt, createdAt).
+      timestamps: false
     }
   )
 

--- a/origin-growth/src/models/growth_event.js
+++ b/origin-growth/src/models/growth_event.js
@@ -13,11 +13,7 @@ module.exports = (sequelize, DataTypes) => {
       status: DataTypes.ENUM(enums.GrowthEventStatuses),
       ethAddress: DataTypes.STRING,
       data: DataTypes.JSONB,
-      createdAt: {
-        type: DataTypes.DATE,
-        defaultValue: Sequelize.fn('NOW')
-      },
-      // Creation date
+      createdAt: DataTypes.DATE,
       updatedAt: {
         type: DataTypes.DATE,
         defaultValue: Sequelize.fn('NOW')

--- a/origin-growth/src/models/growth_event.js
+++ b/origin-growth/src/models/growth_event.js
@@ -21,7 +21,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     {
       tableName: 'growth_event',
-      // Do not automatically add the timestamp attributes (updatedAt, createdAt).
+      // Do not automatically populate the timestamp attributes (updatedAt, createdAt).
       timestamps: false
     }
   )

--- a/origin-growth/src/resources/event.js
+++ b/origin-growth/src/resources/event.js
@@ -30,7 +30,7 @@ class GrowthEvent {
    * @param {GrowthEventTypes} eventType
    * @param {string} customId - Optional custom id. For ex can hold listing or offer Id.
    * @param {Object} data - Optional data to record along with the event.
-   * @param {Date} createdAt - Optional creation time. If not set will use current time.
+   * @param {Date} createdAt - Creation time.
    * @returns {Promise<void>}
    */
   static async insert(
@@ -65,10 +65,8 @@ class GrowthEvent {
       type: eventType,
       status: GrowthEventStatuses.Logged,
       customId,
-      data
-    }
-    if (createdAt) {
-      eventData.createdAt = createdAt
+      data,
+      createdAt
     }
     await db.GrowthEvent.create(eventData)
     logger.info(

--- a/origin-growth/src/resources/event.js
+++ b/origin-growth/src/resources/event.js
@@ -30,9 +30,17 @@ class GrowthEvent {
    * @param {GrowthEventTypes} eventType
    * @param {string} customId - Optional custom id. For ex can hold listing or offer Id.
    * @param {Object} data - Optional data to record along with the event.
+   * @param {Date} createdAt - Optional creation time. If not set will use current time.
    * @returns {Promise<void>}
    */
-  static async insert(logger, ethAddress, eventType, customId, data) {
+  static async insert(
+    logger,
+    ethAddress,
+    eventType,
+    customId,
+    data,
+    createdAt
+  ) {
     // Check input.
     if (!Web3.utils.isAddress(ethAddress)) {
       throw new Error(`Invalid eth address ${ethAddress}`)
@@ -59,8 +67,11 @@ class GrowthEvent {
       customId,
       data
     }
+    if (createdAt) {
+      eventData.createdAt = createdAt
+    }
     await db.GrowthEvent.create(eventData)
-    logger.debug(
+    logger.info(
       `Inserted growth event ${eventType} for account  ${ethAddress}`
     )
   }

--- a/origin-growth/src/resources/event.js
+++ b/origin-growth/src/resources/event.js
@@ -69,9 +69,7 @@ class GrowthEvent {
       createdAt
     }
     await db.GrowthEvent.create(eventData)
-    logger.info(
-      `Inserted growth event ${eventType} for account  ${ethAddress}`
-    )
+    logger.info(`Inserted growth event ${eventType} for account  ${ethAddress}`)
   }
 
   /**


### PR DESCRIPTION
### Description:

Use date from blockchain rather than current date so that if the listener is down for a period of time or if we do some re-indexing, the createdAt field won't vary.


### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
