### PR TITLE
Fix default value for attestation createdAt

### DIFF
--- a/origin-bridge/src/models/attestation.js
+++ b/origin-bridge/src/models/attestation.js
@@ -26,7 +26,7 @@ module.exports = (sequelize, DataTypes) => {
       // Creation date
       createdAt: {
         type: DataTypes.DATE,
-        default: Sequelize.fn('NOW')
+        defaultValue: Sequelize.fn('NOW')
       }
     },
     {


### PR DESCRIPTION
### Description:

I noticed this was not working while working on a different table...
I don't think it is exercises in the bridge so nothing is currently broken

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
