### PR TITLE
Fix discovery test

### DIFF
--- a/origin-discovery/package.json
+++ b/origin-discovery/package.json
@@ -47,7 +47,8 @@
     "chalk": "^2.4.1",
     "mocha": "^5.2.0",
     "nodemon": "^1.18.7",
-    "rewire": "^4.0.1"
+    "rewire": "^4.0.1",
+    "sinon": "^7.1.1"
   },
   "scripts": {
     "lint": "eslint '**/*.js' && npm run prettier:check",

--- a/origin-discovery/test/listener-handler.test.js
+++ b/origin-discovery/test/listener-handler.test.js
@@ -114,7 +114,8 @@ describe('Listener Handlers', () => {
       logIndex: 1,
       transactionHash: 'testTxnHash',
       transactionIndex: 1,
-      topics: ['topic0', 'topic1', 'topic2', 'topic3']
+      topics: ['topic0', 'topic1', 'topic2', 'topic3'],
+      date: new Date()
     }
 
     // Identity test fixtures.
@@ -145,7 +146,8 @@ describe('Listener Handlers', () => {
       logIndex: 1,
       transactionHash: 'testTxnHash',
       transactionIndex: 1,
-      topics: ['topic0', 'topic1', 'topic2', 'topic3']
+      topics: ['topic0', 'topic1', 'topic2', 'topic3'],
+      date: new Date()
     }
   })
 


### PR DESCRIPTION

### Description:

The change I made recently to not populate automatically growth_event.created_at broke a discovery unit test....

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
