### PR TITLE
Centralized messaging Kubernetes configuration

### DIFF
--- a/deployment/dockerfiles/origin-messaging
+++ b/deployment/dockerfiles/origin-messaging
@@ -9,4 +9,4 @@ COPY ./origin-messaging /app
 RUN npm install --loglevel notice
 RUN npm run build
 
-CMD npm run start
+CMD npm run migrate && npm run start

--- a/deployment/kubernetes/charts/origin/templates/messaging.ingress.yaml
+++ b/deployment/kubernetes/charts/origin/templates/messaging.ingress.yaml
@@ -37,4 +37,4 @@ spec:
           - path: /
             backend:
               serviceName: {{ template "messaging.fullname" . }}
-              servicePort: 9012
+              servicePort: 443

--- a/deployment/kubernetes/charts/origin/templates/messaging.service.yaml
+++ b/deployment/kubernetes/charts/origin/templates/messaging.service.yaml
@@ -16,6 +16,8 @@ spec:
   selector:
     app: {{ template "messaging.fullname" . }}
   ports:
+  - name: https
+    port: 443
   - name: ipfs-api
     port: 5001
   - name: websocket

--- a/deployment/kubernetes/charts/origin/templates/messaging.statefulset.yaml
+++ b/deployment/kubernetes/charts/origin/templates/messaging.statefulset.yaml
@@ -57,7 +57,7 @@ spec:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
-volumeClaimTemplates:
+  volumeClaimTemplates:
   - metadata:
       name: {{ template "messaging.fullname" . }}-data
       labels:

--- a/deployment/kubernetes/charts/origin/templates/messaging.statefulset.yaml
+++ b/deployment/kubernetes/charts/origin/templates/messaging.statefulset.yaml
@@ -41,7 +41,23 @@ spec:
         resources:
           requests:
             memory: 1Gi
-  volumeClaimTemplates:
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:1.11
+        command: ["/cloud_sql_proxy",
+                  "-instances={{ .Values.databaseInstance }}=tcp:5432",
+                  "-credential_file=/secrets/cloudsql/credentials.json"]
+        securityContext:
+          runAsUser: 2  # non-root user
+          allowPrivilegeEscalation: false
+        volumeMounts:
+          - name: cloudsql-instance-credentials
+            mountPath: /secrets/cloudsql
+            readOnly: true
+      volumes:
+        - name: cloudsql-instance-credentials
+          secret:
+            secretName: cloudsql-instance-credentials
+volumeClaimTemplates:
   - metadata:
       name: {{ template "messaging.fullname" . }}-data
       labels:


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

- Exposes https rather than orbit
- Add SQL migrations and access to SQL via cloudsql proxy
- Configured REDIS_URL and DATABASE_URL in EnvKey

I think all that is left is `npm run orbit-to-db` when the new centralized messaging starts. Anything else @crazybuster?

We should merge this before #1691 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
