### PR TITLE
Integrate on-boarding with growth enrolment flow

### DIFF
--- a/origin-dapp/src/components/GrowthCampaignBox.js
+++ b/origin-dapp/src/components/GrowthCampaignBox.js
@@ -48,8 +48,7 @@ const GrowthCampaignBox = props => (
                 {notEnrolled && (
                   <div className="enroll-gray-box campaign-enroll d-flex flex-column align-items-center">
                     <fbt desc="profile.enrollExplanation">
-                      <b>Enroll in Origin Campaigns</b> for a chance to earn
-                      Origin Tokens (OGN)
+                      <b>Enroll</b> to earn Origin cryptocurrency tokens (OGN).
                     </fbt>
                     <EnrollButton
                       className="btn-enroll mt-3"

--- a/origin-dapp/src/components/GrowthCampaignBox.js
+++ b/origin-dapp/src/components/GrowthCampaignBox.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import { Query } from 'react-apollo'
+import { fbt } from 'fbt-runtime'
+
+//import allCampaignsQuery from 'queries/AllGrowthCampaigns'
+import enrollmentStatusQuery from 'queries/EnrollmentStatus'
+import profileQuery from 'queries/Profile'
+import QueryError from 'components/QueryError'
+
+import withEnrolmentModal from 'pages/growth/WithEnrolmentModal'
+
+const EnrollButton = withEnrolmentModal('button')
+
+const GrowthCampaignBox = props => (
+  <Query query={profileQuery} notifyOnNetworkStatusChange={true}>
+    {({ error, data, networkStatus, loading }) => {
+      if (networkStatus === 1 || loading) {
+        return ''
+      } else if (error) {
+        return <QueryError error={error} query={profileQuery} />
+      }
+
+      const walletAddress = data.web3.primaryAccount
+        ? data.web3.primaryAccount.id
+        : null
+      return (
+        <Query
+          query={enrollmentStatusQuery}
+          variables={{
+            walletAddress: walletAddress ? walletAddress : '0xdummyAddress'
+          }}
+          // enrollment info can change, do not cache it
+          fetchPolicy="network-only"
+        >
+          {({ networkStatus, error, loading, data }) => {
+            if (networkStatus === 1 || loading) {
+              return 'Loading...'
+            } else if (error) {
+              return <QueryError error={error} query={enrollmentStatusQuery} />
+            }
+
+            const notEnrolled = ['NotEnrolled', 'Banned'].includes(
+              data.enrollmentStatus
+            )
+
+            return (
+              <div className="growth-campaign-box">
+                {notEnrolled && (
+                  <div className="enroll-gray-box campaign-enroll d-flex flex-column align-items-center">
+                    <fbt desc="profile.enrollExplanation">
+                      <b>Enroll in Origin Campaigns</b> for a chance to earn
+                      Origin Tokens (OGN)
+                    </fbt>
+                    <EnrollButton
+                      className="btn-enroll mt-3"
+                      type="submit"
+                      skipjoincampaign="false"
+                      urlforonboarding="/profile/onboard"
+                      startopen={(props.openmodalonstart || false).toString()}
+                    >
+                      <fbt desc="profile.enrollButton">
+                        <b>Enroll Now</b>
+                      </fbt>
+                    </EnrollButton>
+                  </div>
+                )}
+                {!notEnrolled && (
+                  <div className="enroll-gray-box">
+                    TODO: implement enrolled graphic
+                  </div>
+                )}
+              </div>
+            )
+          }}
+        </Query>
+      )
+    }}
+  </Query>
+)
+
+export default GrowthCampaignBox
+
+require('react-styl')(`
+  .growth-campaign-box
+    .enroll-gray-box
+      border: 1px solid var(--light)
+      border-radius: var(--default-radius)
+      padding: 1rem
+      margin-bottom: 2rem
+    .campaign-enroll
+      font-size: 14px;
+      background: url(images/growth/token-stack.svg) no-repeat center 1.5rem;
+      background-size: 7rem;
+      padding-top: 8rem;
+    .btn-enroll
+      font-size: 14px
+      font-weight: 900
+      color: var(--clear-blue)
+      border: 0px
+`)

--- a/origin-dapp/src/pages/growth/Welcome.js
+++ b/origin-dapp/src/pages/growth/Welcome.js
@@ -42,7 +42,7 @@ class GrowthWelcome extends Component {
     const storedInviteCode = localStorage.getItem(localStorageKey)
     // prefer the stored invite code, than newly fetched invite code
     this.setState({
-      inviteCode: storedInviteCode || inviteCode || null
+      inviteCode: storedInviteCode || inviteCode || null
     })
     if (storedInviteCode === null && inviteCode !== undefined) {
       localStorage.setItem(localStorageKey, inviteCode)
@@ -58,7 +58,7 @@ class GrowthWelcome extends Component {
   }
 
   render() {
-    return(
+    return (
       <Fragment>
         <PageTitle>Welcome to Origin Protocol</PageTitle>
         <Switch>
@@ -100,9 +100,9 @@ class GrowthWelcome extends Component {
 
   renderWelcomePage(arrivedFromOnboarding) {
     const personalised = true
-    const urlForOnboarding = '/welcome/onboard' + (this.state.inviteCode ?
-      `/${this.state.inviteCode}` :
-      '')
+    const urlForOnboarding =
+      '/welcome/onboard' +
+      (this.state.inviteCode ? `/${this.state.inviteCode}` : '')
 
     return (
       <div className="container growth-welcome">

--- a/origin-dapp/src/pages/growth/Welcome.js
+++ b/origin-dapp/src/pages/growth/Welcome.js
@@ -40,7 +40,7 @@ class GrowthWelcome extends Component {
     const localStorageKey = 'growth_invite_code'
 
     const storedInviteCode = localStorage.getItem(localStorageKey)
-    // prefer the stored invite code, than newly fetched invite code
+    // prefer the stored invite code, over newly fetched invite code
     this.setState({
       inviteCode: storedInviteCode || inviteCode || null
     })

--- a/origin-dapp/src/pages/growth/WithEnrolmentModal.js
+++ b/origin-dapp/src/pages/growth/WithEnrolmentModal.js
@@ -48,7 +48,6 @@ function withEnrolmentModal(WrappedComponent) {
     handleClick(e, enrollmentStatus, walletPresent) {
       e.preventDefault()
 
-      console.log("URL FOR ONBOARDING: ", this.props.urlforonboarding)
       if (!walletPresent) {
         this.props.history.push(this.props.urlforonboarding)
       } else if (enrollmentStatus === 'Enrolled') {
@@ -348,12 +347,16 @@ function withEnrolmentModal(WrappedComponent) {
               return <QueryError error={error} query={profileQuery} />
             }
 
-            const walletAddress = data.web3.primaryAccount ? data.web3.primaryAccount.id : null
+            const walletAddress = data.web3.primaryAccount
+              ? data.web3.primaryAccount.id
+              : null
             return (
               <Query
                 query={enrollmentStatusQuery}
                 variables={{
-                  walletAddress: walletAddress ? walletAddress : '0xdummyAddress'
+                  walletAddress: walletAddress
+                    ? walletAddress
+                    : '0xdummyAddress'
                 }}
                 // enrollment info can change, do not cache it
                 fetchPolicy="network-only"
@@ -372,7 +375,11 @@ function withEnrolmentModal(WrappedComponent) {
                       <WrappedComponent
                         {...this.props}
                         onClick={e =>
-                          this.handleClick(e, data.enrollmentStatus, walletAddress)
+                          this.handleClick(
+                            e,
+                            data.enrollmentStatus,
+                            walletAddress
+                          )
                         }
                       />
                       {open && (

--- a/origin-dapp/src/pages/growth/WithEnrolmentModal.js
+++ b/origin-dapp/src/pages/growth/WithEnrolmentModal.js
@@ -10,6 +10,7 @@ import allCampaignsQuery from 'queries/AllGrowthCampaigns'
 import profileQuery from 'queries/Profile'
 import QueryError from 'components/QueryError'
 import Enroll from 'pages/growth/mutations/Enroll'
+import { mobileDevice } from 'utils/mobile'
 
 const GrowthEnum = require('Growth$FbtEnum')
 
@@ -48,7 +49,12 @@ function withEnrolmentModal(WrappedComponent) {
     handleClick(e, enrollmentStatus, walletPresent) {
       e.preventDefault()
 
-      if (!walletPresent) {
+      if (mobileDevice() !== null) {
+        this.setState({
+          open: true,
+          stage: 'NotSupportedOnMobile'
+        })
+      } else if (!walletPresent) {
         this.props.history.push(this.props.urlforonboarding)
       } else if (enrollmentStatus === 'Enrolled') {
         this.props.history.push('/campaigns')
@@ -333,6 +339,22 @@ function withEnrolmentModal(WrappedComponent) {
 
     renderMetamaskSignature() {
       return <Enroll />
+    }
+
+    renderNotSupportedOnMobile() {
+      return (
+        <div>
+          <div className="title mt-4">Mobile not supported</div>
+          <div className="mt-3 mr-auto ml-auto normal-line-height info-text">
+            Use desktop device in order to earn Origin tokens.
+          </div>
+          <button
+            className="btn btn-primary btn-rounded btn-lg"
+            onClick={() => this.handleCloseModal()}
+            children="Ok"
+          />
+        </div>
+      )
     }
 
     render() {

--- a/origin-dapp/src/pages/growth/WithEnrolmentModal.js
+++ b/origin-dapp/src/pages/growth/WithEnrolmentModal.js
@@ -36,7 +36,7 @@ function withEnrolmentModal(WrappedComponent) {
           ? 'JoinActiveCampaign'
           : 'TermsAndEligibilityCheck'
       this.state = {
-        open: false,
+        open: props.startopen === 'true',
         stage: this.initialStage,
         notCitizenChecked: false,
         notCitizenConfirmed: false,
@@ -45,10 +45,13 @@ function withEnrolmentModal(WrappedComponent) {
       }
     }
 
-    handleClick(e, enrollmentStatus) {
+    handleClick(e, enrollmentStatus, walletPresent) {
       e.preventDefault()
 
-      if (enrollmentStatus === 'Enrolled') {
+      console.log("URL FOR ONBOARDING: ", this.props.urlforonboarding)
+      if (!walletPresent) {
+        this.props.history.push(this.props.urlforonboarding)
+      } else if (enrollmentStatus === 'Enrolled') {
         this.props.history.push('/campaigns')
       } else if (enrollmentStatus === 'NotEnrolled') {
         this.setState({
@@ -345,11 +348,13 @@ function withEnrolmentModal(WrappedComponent) {
               return <QueryError error={error} query={profileQuery} />
             }
 
-            const walletAddress = data.web3.primaryAccount.id
+            const walletAddress = data.web3.primaryAccount ? data.web3.primaryAccount.id : null
             return (
               <Query
                 query={enrollmentStatusQuery}
-                variables={{ walletAddress }}
+                variables={{
+                  walletAddress: walletAddress ? walletAddress : '0xdummyAddress'
+                }}
                 // enrollment info can change, do not cache it
                 fetchPolicy="network-only"
               >
@@ -367,7 +372,7 @@ function withEnrolmentModal(WrappedComponent) {
                       <WrappedComponent
                         {...this.props}
                         onClick={e =>
-                          this.handleClick(e, data.enrollmentStatus)
+                          this.handleClick(e, data.enrollmentStatus, walletAddress)
                         }
                       />
                       {open && (

--- a/origin-dapp/src/pages/onboard/Finished.js
+++ b/origin-dapp/src/pages/onboard/Finished.js
@@ -2,8 +2,10 @@ import React from 'react'
 
 import Link from 'components/Link'
 
-const Finished = ({ listing }) => {
-  const linkPrefix = listing ? `/listing/${listing.id}` : ''
+const Finished = ({ linkPrefix, redirectto }) => {
+
+  const continueTo = redirectto ? redirectto :
+    `${linkPrefix}/onboard/back`
 
   return (
     <div className="finished">
@@ -31,7 +33,7 @@ const Finished = ({ listing }) => {
       </div>
 
       <Link
-        to={`${linkPrefix}/onboard/back`}
+        to={continueTo}
         className={`btn btn-primary`}
         children={'OK'}
       />

--- a/origin-dapp/src/pages/onboard/Finished.js
+++ b/origin-dapp/src/pages/onboard/Finished.js
@@ -3,9 +3,7 @@ import React from 'react'
 import Link from 'components/Link'
 
 const Finished = ({ linkPrefix, redirectto }) => {
-
-  const continueTo = redirectto ? redirectto :
-    `${linkPrefix}/onboard/back`
+  const continueTo = redirectto ? redirectto : `${linkPrefix}/onboard/back`
 
   return (
     <div className="finished">
@@ -32,11 +30,7 @@ const Finished = ({ linkPrefix, redirectto }) => {
         </div>
       </div>
 
-      <Link
-        to={continueTo}
-        className={`btn btn-primary`}
-        children={'OK'}
-      />
+      <Link to={continueTo} className={`btn btn-primary`} children={'OK'} />
     </div>
   )
 }

--- a/origin-dapp/src/pages/onboard/Messaging.js
+++ b/origin-dapp/src/pages/onboard/Messaging.js
@@ -176,8 +176,7 @@ class OnboardMessaging extends Component {
   }
 }
 
-const Messaging = ({ listing }) => {
-  const linkPrefix = listing ? `/listing/${listing.id}` : ''
+const Messaging = ({ listing, linkPrefix }) => {
   return (
     <>
       <Header />

--- a/origin-dapp/src/pages/onboard/MetaMask.js
+++ b/origin-dapp/src/pages/onboard/MetaMask.js
@@ -162,8 +162,7 @@ const Connected = ({ networkName }) => (
 class OnboardMetaMask extends Component {
   state = {}
   render() {
-    const { listing } = this.props
-    const linkPrefix = listing ? `/listing/${listing.id}` : ''
+    const { listing, linkPrefix } = this.props
 
     return (
       <>

--- a/origin-dapp/src/pages/onboard/Notifications.js
+++ b/origin-dapp/src/pages/onboard/Notifications.js
@@ -121,8 +121,8 @@ class OnboardNotifications extends Component {
         : Notification.permission
   }
   render() {
-    const { listing } = this.props
-    const linkPrefix = listing ? `/listing/${listing.id}` : ''
+    const { listing, linkPrefix } = this.props
+
     const nextLink = `${linkPrefix}/onboard/profile`
     if (this.state.redirect || this.state.permission === 'unavailable') {
       return <Redirect to={nextLink} />

--- a/origin-dapp/src/pages/onboard/Onboard.js
+++ b/origin-dapp/src/pages/onboard/Onboard.js
@@ -14,37 +14,48 @@ const sessionStore = store('sessionStorage')
 
 class Onboard extends Component {
   render() {
-    const { listing } = this.props
-    const linkPrefix = listing ? '/listing/:listingID' : ''
+    const { listing, showoriginwallet, linkprefix, redirectTo } = this.props
+    const linkPathPrefix = linkprefix || (listing ? '/listing/:listingID' : '')
+    const linkPrefix = linkprefix || (listing ? `/listing/${listing.id}` : '')
 
     return (
       <div className="container onboard">
         <Switch>
           <Route
-            path={`${linkPrefix}/onboard/metamask`}
-            render={() => <MetaMask listing={listing} />}
+            path={`${linkPathPrefix}/onboard/metamask`}
+            render={() =>
+              <MetaMask listing={listing} linkPrefix={linkPrefix} />}
           />
           <Route
-            path={`${linkPrefix}/onboard/messaging`}
-            render={() => <Messaging listing={listing} />}
+            path={`${linkPathPrefix}/onboard/messaging`}
+            render={() => <Messaging listing={listing} linkPrefix={linkPrefix} />}
           />
           <Route
-            path={`${linkPrefix}/onboard/notifications`}
-            render={() => <Notifications listing={listing} />}
+            path={`${linkPathPrefix}/onboard/notifications`}
+            render={() => <Notifications listing={listing} linkPrefix={linkPrefix} />}
           />
           <Route
-            path={`${linkPrefix}/onboard/profile`}
-            render={() => <Profile listing={listing} />}
+            path={`${linkPathPrefix}/onboard/profile`}
+            render={() => <Profile listing={listing} linkPrefix={linkPrefix} />}
           />
           <Route
-            path={`${linkPrefix}/onboard/finished`}
-            render={() => <Finished />}
+            path={`${linkPathPrefix}/onboard/finished`}
+            render={() => <Finished redirectto={redirectTo} linkPrefix={linkPrefix} />}
           />
           <Redirect
-            from={`${linkPrefix}/onboard/back`}
+            from={`${linkPathPrefix}/onboard/back`}
             to={sessionStore.get('getStartedRedirect', '/')}
           />
-          <Route render={() => <Wallet listing={listing} />} />
+          <Route
+            render={() => 
+              <Wallet
+                listing={listing}
+                linkPrefix={linkPrefix}
+                // Growth engine does not support Origin Wallet for now
+                showoriginwallet={showoriginwallet}
+              />
+            }
+          />
         </Switch>
       </div>
     )

--- a/origin-dapp/src/pages/onboard/Onboard.js
+++ b/origin-dapp/src/pages/onboard/Onboard.js
@@ -23,16 +23,21 @@ class Onboard extends Component {
         <Switch>
           <Route
             path={`${linkPathPrefix}/onboard/metamask`}
-            render={() =>
-              <MetaMask listing={listing} linkPrefix={linkPrefix} />}
+            render={() => (
+              <MetaMask listing={listing} linkPrefix={linkPrefix} />
+            )}
           />
           <Route
             path={`${linkPathPrefix}/onboard/messaging`}
-            render={() => <Messaging listing={listing} linkPrefix={linkPrefix} />}
+            render={() => (
+              <Messaging listing={listing} linkPrefix={linkPrefix} />
+            )}
           />
           <Route
             path={`${linkPathPrefix}/onboard/notifications`}
-            render={() => <Notifications listing={listing} linkPrefix={linkPrefix} />}
+            render={() => (
+              <Notifications listing={listing} linkPrefix={linkPrefix} />
+            )}
           />
           <Route
             path={`${linkPathPrefix}/onboard/profile`}
@@ -40,21 +45,23 @@ class Onboard extends Component {
           />
           <Route
             path={`${linkPathPrefix}/onboard/finished`}
-            render={() => <Finished redirectto={redirectTo} linkPrefix={linkPrefix} />}
+            render={() => (
+              <Finished redirectto={redirectTo} linkPrefix={linkPrefix} />
+            )}
           />
           <Redirect
             from={`${linkPathPrefix}/onboard/back`}
             to={sessionStore.get('getStartedRedirect', '/')}
           />
           <Route
-            render={() => 
+            render={() => (
               <Wallet
                 listing={listing}
                 linkPrefix={linkPrefix}
                 // Growth engine does not support Origin Wallet for now
                 showoriginwallet={showoriginwallet}
               />
-            }
+            )}
           />
         </Switch>
       </div>

--- a/origin-dapp/src/pages/onboard/Profile.js
+++ b/origin-dapp/src/pages/onboard/Profile.js
@@ -63,10 +63,8 @@ class OnboardProfile extends Component {
   }
 
   render() {
-    const { listing } = this.props
+    const { listing, linkPrefix } = this.props
     const { avatar } = this.state
-
-    const linkPrefix = listing ? `/listing/${listing.id}` : ''
 
     const input = formInput(this.state, state => this.setState(state))
     const Feedback = formFeedback(this.state)

--- a/origin-dapp/src/pages/onboard/Wallet.js
+++ b/origin-dapp/src/pages/onboard/Wallet.js
@@ -60,8 +60,7 @@ const MetaMask = ({ linkPrefix }) => (
   </div>
 )
 
-const Step1 = ({ listing }) => {
-  const linkPrefix = listing ? `/listing/${listing.id}` : ''
+const Step1 = ({ listing, showoriginwallet, linkPrefix }) => {
   const showMetaMask = isChrome || isFirefox
 
   return (
@@ -87,7 +86,7 @@ const Step1 = ({ listing }) => {
 
               return (
                 <>
-                  <OriginWallet />
+                  {!showoriginwallet ? null : <OriginWallet />}
                   {!showMetaMask ? null : <MetaMask linkPrefix={linkPrefix} />}
                 </>
               )

--- a/origin-dapp/src/pages/user/Profile.js
+++ b/origin-dapp/src/pages/user/Profile.js
@@ -77,7 +77,7 @@ class UserProfile extends Component {
   }
 
   render() {
-    return(
+    return (
       <Fragment>
         <PageTitle>Welcome to Origin Protocol</PageTitle>
         <Switch>
@@ -95,9 +95,7 @@ class UserProfile extends Component {
             path="/profile/continue"
             render={() => this.renderProfile(true)}
           />
-          <Route
-            render={() => this.renderProfile(false)}
-          />
+          <Route render={() => this.renderProfile(false)} />
         </Switch>
       </Fragment>
     )
@@ -213,9 +211,7 @@ class UserProfile extends Component {
           </div>
           <div className="col-md-4">
             <Wallet />
-            <GrowthCampaignBox
-              openmodalonstart={arrivedFromOnboarding}
-            />
+            <GrowthCampaignBox openmodalonstart={arrivedFromOnboarding} />
             <div className="gray-box profile-help">
               <fbt desc="onboarding-steps.stepTwoContent">
                 <b>Verifying your profile</b> allows other users to know that

--- a/origin-dapp/src/pages/user/Profile.js
+++ b/origin-dapp/src/pages/user/Profile.js
@@ -112,6 +112,7 @@ class UserProfile extends Component {
     const name = []
     if (this.state.firstName) name.push(this.state.firstName)
     if (this.state.lastName) name.push(this.state.lastName)
+    const enableGrowth = process.env.ENABLE_GROWTH === 'true'
 
     return (
       <div className="container profile-edit">
@@ -211,7 +212,7 @@ class UserProfile extends Component {
           </div>
           <div className="col-md-4">
             <Wallet />
-            <GrowthCampaignBox openmodalonstart={arrivedFromOnboarding} />
+            {enableGrowth && <GrowthCampaignBox openmodalonstart={arrivedFromOnboarding} />}
             <div className="gray-box profile-help">
               <fbt desc="onboarding-steps.stepTwoContent">
                 <b>Verifying your profile</b> allows other users to know that

--- a/origin-dapp/src/pages/user/Profile.js
+++ b/origin-dapp/src/pages/user/Profile.js
@@ -212,7 +212,9 @@ class UserProfile extends Component {
           </div>
           <div className="col-md-4">
             <Wallet />
-            {enableGrowth && <GrowthCampaignBox openmodalonstart={arrivedFromOnboarding} />}
+            {enableGrowth && (
+              <GrowthCampaignBox openmodalonstart={arrivedFromOnboarding} />
+            )}
             <div className="gray-box profile-help">
               <fbt desc="onboarding-steps.stepTwoContent">
                 <b>Verifying your profile</b> allows other users to know that

--- a/origin-dapp/src/pages/user/Profile.js
+++ b/origin-dapp/src/pages/user/Profile.js
@@ -1,8 +1,9 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import pick from 'lodash/pick'
 import pickBy from 'lodash/pickBy'
 import get from 'lodash/get'
 import { fbt } from 'fbt-runtime'
+import { Switch, Route } from 'react-router-dom'
 
 import Store from 'utils/store'
 import unpublishedProfileStrength from 'utils/unpublishedProfileStrength'
@@ -15,6 +16,7 @@ import Avatar from 'components/Avatar'
 import Wallet from 'components/Wallet'
 import PageTitle from 'components/PageTitle'
 import ImageCropper from 'components/ImageCropper'
+import GrowthCampaignBox from 'components/GrowthCampaignBox'
 
 import PhoneAttestation from 'pages/identity/PhoneAttestation'
 import EmailAttestation from 'pages/identity/EmailAttestation'
@@ -22,6 +24,7 @@ import FacebookAttestation from 'pages/identity/FacebookAttestation'
 import TwitterAttestation from 'pages/identity/TwitterAttestation'
 import AirbnbAttestation from 'pages/identity/AirbnbAttestation'
 import DeployIdentity from 'pages/identity/mutations/DeployIdentity'
+import Onboard from 'pages/onboard/Onboard'
 
 import EditProfile from './_EditModal'
 
@@ -74,6 +77,33 @@ class UserProfile extends Component {
   }
 
   render() {
+    return(
+      <Fragment>
+        <PageTitle>Welcome to Origin Protocol</PageTitle>
+        <Switch>
+          <Route
+            path="/profile/onboard"
+            render={() => (
+              <Onboard
+                showoriginwallet={false}
+                linkprefix="/profile"
+                redirectTo="/profile/continue"
+              />
+            )}
+          />
+          <Route
+            path="/profile/continue"
+            render={() => this.renderProfile(true)}
+          />
+          <Route
+            render={() => this.renderProfile(false)}
+          />
+        </Switch>
+      </Fragment>
+    )
+  }
+
+  renderProfile(arrivedFromOnboarding) {
     const attestations = Object.keys(AttestationComponents).reduce((m, key) => {
       if (this.state[`${key}Attestation`]) {
         m.push(this.state[`${key}Attestation`])
@@ -183,6 +213,9 @@ class UserProfile extends Component {
           </div>
           <div className="col-md-4">
             <Wallet />
+            <GrowthCampaignBox
+              openmodalonstart={arrivedFromOnboarding}
+            />
             <div className="gray-box profile-help">
               <fbt desc="onboarding-steps.stepTwoContent">
                 <b>Verifying your profile</b> allows other users to know that
@@ -316,7 +349,6 @@ require('react-styl')(`
       background: url(images/identity/identity.svg) no-repeat center 1.5rem;
       background-size: 5rem;
       padding-top: 8rem;
-
   @media (max-width: 767.98px)
     .profile-edit
       margin-top: 1rem


### PR DESCRIPTION
### Description:
- creates a growth campaign box placeholder in profile view
- goes to on-boarding if user doesn't have a wallet installed
- removes the ability to register mobile wallet as part of growth on-boarding
- redirects back to profile or welcome pages after on-boarding and opens the growth enrolment modal to not break flow

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
