### PR TITLE
Disable growth enrolment on mobile

### DIFF
--- a/origin-dapp/src/pages/growth/Welcome.js
+++ b/origin-dapp/src/pages/growth/Welcome.js
@@ -40,7 +40,7 @@ class GrowthWelcome extends Component {
     const localStorageKey = 'growth_invite_code'
 
     const storedInviteCode = localStorage.getItem(localStorageKey)
-    // prefer the stored invite code, than newly fetched invite code
+    // prefer the stored invite code, over newly fetched invite code
     this.setState({
       inviteCode: storedInviteCode || inviteCode || null
     })

--- a/origin-dapp/src/pages/growth/WithEnrolmentModal.js
+++ b/origin-dapp/src/pages/growth/WithEnrolmentModal.js
@@ -10,6 +10,7 @@ import allCampaignsQuery from 'queries/AllGrowthCampaigns'
 import profileQuery from 'queries/Profile'
 import QueryError from 'components/QueryError'
 import Enroll from 'pages/growth/mutations/Enroll'
+import { mobileDevice } from 'utils/mobile'
 
 const GrowthEnum = require('Growth$FbtEnum')
 
@@ -47,8 +48,14 @@ function withEnrolmentModal(WrappedComponent) {
 
     handleClick(e, enrollmentStatus, walletPresent) {
       e.preventDefault()
+      
 
-      if (!walletPresent) {
+      if (mobileDevice() !== null) {
+        this.setState({
+          open: true,
+          stage: 'NotSupportedOnMobile'
+        })
+      } else if (!walletPresent) {
         this.props.history.push(this.props.urlforonboarding)
       } else if (enrollmentStatus === 'Enrolled') {
         this.props.history.push('/campaigns')
@@ -333,6 +340,21 @@ function withEnrolmentModal(WrappedComponent) {
 
     renderMetamaskSignature() {
       return <Enroll />
+    }
+
+    renderNotSupportedOnMobile() {
+      return(<div>
+        <div className="title mt-4">Mobile not supported</div>
+        <div className="mt-3 mr-auto ml-auto normal-line-height info-text">
+          Use desktop device in order to earn Origin tokens.
+        </div>
+        <button
+          className="btn btn-primary btn-rounded btn-lg"
+          onClick={() => this.handleCloseModal()}
+          children="Ok"
+        />
+      </div>
+      )
     }
 
     render() {

--- a/origin-dapp/src/pages/growth/WithEnrolmentModal.js
+++ b/origin-dapp/src/pages/growth/WithEnrolmentModal.js
@@ -48,7 +48,6 @@ function withEnrolmentModal(WrappedComponent) {
 
     handleClick(e, enrollmentStatus, walletPresent) {
       e.preventDefault()
-      
 
       if (mobileDevice() !== null) {
         this.setState({
@@ -343,17 +342,18 @@ function withEnrolmentModal(WrappedComponent) {
     }
 
     renderNotSupportedOnMobile() {
-      return(<div>
-        <div className="title mt-4">Mobile not supported</div>
-        <div className="mt-3 mr-auto ml-auto normal-line-height info-text">
-          Use desktop device in order to earn Origin tokens.
+      return (
+        <div>
+          <div className="title mt-4">Mobile not supported</div>
+          <div className="mt-3 mr-auto ml-auto normal-line-height info-text">
+            Use desktop device in order to earn Origin tokens.
+          </div>
+          <button
+            className="btn btn-primary btn-rounded btn-lg"
+            onClick={() => this.handleCloseModal()}
+            children="Ok"
+          />
         </div>
-        <button
-          className="btn btn-primary btn-rounded btn-lg"
-          onClick={() => this.handleCloseModal()}
-          children="Ok"
-        />
-      </div>
       )
     }
 


### PR DESCRIPTION
### Description:

On mobile prevent users from joining the growth campaign

**!Important** change base branch to master once `sparrowDom/growthOnboarding ` gets merged
### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
