### PR TITLE
Past event batching

### DIFF
--- a/origin-graphql/src/contracts.js
+++ b/origin-graphql/src/contracts.js
@@ -32,6 +32,8 @@ if (typeof window !== 'undefined') {
 
 const Configs = {
   mainnet: {
+    // provider:
+    //   'https://eth-mainnet.alchemyapi.io/jsonrpc/FCA-3myPH5VFN8naOWyxDU6VkxelafK6',
     provider: 'https://mainnet.infura.io/v3/98df57f0748e455e871c48b96f2095b2',
     // providerWS: 'wss://mainnet.infura.io/ws',
     ipfsGateway: 'https://ipfs.originprotocol.com',
@@ -83,7 +85,9 @@ const Configs = {
     linkerWS: `wss://linking.originprotocol.com`
   },
   rinkeby: {
-    provider: 'https://rinkeby.infura.io',
+    provider:
+      'https://eth-rinkeby.alchemyapi.io/jsonrpc/D0SsolVDcXCw6K6j2LWqcpW49QIukUkI',
+    // provider: 'https://rinkeby.infura.io',
     // providerWS: 'wss://rinkeby.infura.io/ws',
     ipfsGateway: 'https://ipfs.staging.originprotocol.com',
     ipfsRPC: `https://ipfs.staging.originprotocol.com`,

--- a/origin-graphql/src/utils/eventCache.js
+++ b/origin-graphql/src/utils/eventCache.js
@@ -13,7 +13,7 @@ const pastEventBatcher = async (contract, fromBlock, uptoBlock) => {
   // const start = +new Date() // Uncomment for benchmarking
   if (fromBlock > uptoBlock) throw new Error('fromBlock > toBlock')
   const partitions = []
-  while (fromBlock < uptoBlock) {
+  while (fromBlock <= uptoBlock) {
     const toBlock = Math.min(fromBlock + 20000, uptoBlock)
     partitions.push(contract.getPastEvents('allEvents', { fromBlock, toBlock }))
     fromBlock += 20000

--- a/origin-graphql/src/utils/eventCache.js
+++ b/origin-graphql/src/utils/eventCache.js
@@ -1,9 +1,31 @@
 import { get } from 'origin-ipfs'
 // import { post } from 'origin-ipfs'
 import uniqBy from 'lodash/uniqBy'
+import chunk from 'lodash/chunk'
+import flattenDeep from 'lodash/flattenDeep'
 import createDebug from 'debug'
 
 const debug = createDebug('event-cache:')
+
+// Given a contract and block range, break the range up into requests of no
+// more than 20,000 blocks, then send those requests in batches of 7.
+const pastEventBatcher = async (contract, fromBlock, uptoBlock) => {
+  // const start = +new Date() // Uncomment for benchmarking
+  if (fromBlock > uptoBlock) throw new Error('fromBlock > toBlock')
+  const partitions = []
+  while (fromBlock < uptoBlock) {
+    const toBlock = Math.min(fromBlock + 20000, uptoBlock)
+    partitions.push(contract.getPastEvents('allEvents', { fromBlock, toBlock }))
+    fromBlock += 20000
+  }
+  const results = []
+  const chunks = chunk(partitions, 7)
+  for (const chunklet of chunks) {
+    results.push(await Promise.all(chunklet))
+  }
+  // debug('Got events in ', +new Date() - start) // Uncomment for benchmarking
+  return flattenDeep(results)
+}
 
 export default function eventCache(contract, fromBlock = 0, web3, config) {
   function padNum(num) {
@@ -84,10 +106,7 @@ export default function eventCache(contract, fromBlock = 0, web3, config) {
     )
     lastLookup = toBlock
 
-    const newEvents = await contract.getPastEvents('allEvents', {
-      fromBlock,
-      toBlock
-    })
+    const newEvents = await pastEventBatcher(contract, fromBlock, toBlock)
 
     events = uniqBy(
       [


### PR DESCRIPTION
The event cache finds all events in a given range and stores them in local storage. Previously this was all done in a single call which could take a long time to respond. This new code takes a range of blocks and splits it up into requests of 20,000 each. It then sends those requests in batches of 7.

For example, a range of blocks of 6,000,000 to 7,000,000 would result in 100 requests.These requests are then sent in batches of 7, so that the node is not hit with 100 requests at once.

I reached the 20,000 blocks in batches of 7 after a bit of experimentation... seems to be a sweet spot.