### PR TITLE
Fix word-break in messaging

### DIFF
--- a/origin-dapp/src/pages/messaging/Message.js
+++ b/origin-dapp/src/pages/messaging/Message.js
@@ -191,7 +191,7 @@ require('react-styl')(`
       .content
         font-weight: normal
         font-size: 16px
-        word-break: break-all
+        word-break: break-word
         .image-container
           overflow: auto
       &.tail::after


### PR DESCRIPTION
Quick one-liner to make messages look like this:
<img width="610" alt="Screen Shot 2019-03-18 at 10 39 31 AM" src="https://user-images.githubusercontent.com/982234/54550919-2c4b3c80-496a-11e9-844e-86db36db3fab.png">

Instead of splitti
ng mid-word.

<img width="619" alt="Screen Shot 2019-03-18 at 10 39 08 AM" src="https://user-images.githubusercontent.com/982234/54550929-310ff080-496a-11e9-8e2e-4228b04eb85c.png">

