### PR TITLE
Cleanup: get rid of INFURA_ACCESS_TOKEN

### DIFF
--- a/packages/contracts/truffle.js
+++ b/packages/contracts/truffle.js
@@ -7,6 +7,8 @@ const NonceTrackerSubprovider = require("web3-provider-engine/subproviders/nonce
 // Note: This is not used for Mainnet - only for Testnet and local deployment.
 const numAddressesToUnlock = 4
 
+const providerUrl = process.env.PROVIDER_URL
+
 // Local setup
 truffleSetup = {
   migrations_directory: "./migrations",
@@ -46,7 +48,6 @@ function withNonceTracker(provider) {
 if (process.env.MAINNET_PRIVATE_KEY || process.env.MAINNET_MNEMONIC) {
   const privateKey = process.env.MAINNET_PRIVATE_KEY
   const mnemonic = process.env.MAINNET_MNEMONIC
-  const providerUrl = `https://mainnet.infura.io/${process.env.INFURA_ACCESS_TOKEN}`
 
   // Private key takes precedence over mnemonic.
   if (privateKey) {
@@ -72,7 +73,7 @@ if (process.env.RINKEBY_MNEMONIC) {
     provider: function() {
       return withNonceTracker(new HDWalletProvider(
         process.env.RINKEBY_MNEMONIC,
-        `https://rinkeby.infura.io/${process.env.INFURA_ACCESS_TOKEN}`,
+        providerUrl,
         0, numAddressesToUnlock
       ))
     },
@@ -84,7 +85,7 @@ if (process.env.ROPSTEN_MNEMONIC) {
     provider: function() {
       return withNonceTracker(new HDWalletProvider(
         process.env.ROPSTEN_MNEMONIC,
-        `https://ropsten.infura.io/${process.env.INFURA_ACCESS_TOKEN}`,
+        providerUrl,
         0, numAddressesToUnlock
       ))
     },
@@ -99,7 +100,7 @@ if (process.env.ORIGIN_MNEMONIC) {
     provider: function() {
       return withNonceTracker(new HDWalletProvider(
         process.env.ORIGIN_MNEMONIC,
-        'https://testnet.originprotocol.com/rpc',
+        providerUrl,
         0,
         numAddressesToUnlock
       ))

--- a/packages/token/src/config.js
+++ b/packages/token/src/config.js
@@ -45,12 +45,10 @@ function createProviders(networkIds) {
         if (!privateKey && !mnemonic) {
           throw 'Must have either MAINNET_PRIVATE_KEY or MAINNET_MNEMONIC env var'
         }
-        if (!process.env.INFURA_ACCESS_TOKEN) {
-          throw 'Missing INFURA_ACCESS_TOKEN env var'
+        if (!process.env.MAINNET_PROVIDER_URL) {
+          throw 'Missing MAINNET_PROVIDER_URL env var'
         }
-        providerUrl = `https://mainnet.infura.io/${
-          process.env.INFURA_ACCESS_TOKEN
-        }`
+        providerUrl = process.env.MAINNET_PROVIDER_URL
         break
       case ROPSTEN_NETWORK_ID:
         privateKey = process.env.ROPSTEN_PRIVATE_KEY
@@ -58,12 +56,10 @@ function createProviders(networkIds) {
         if (!privateKey && !mnemonic) {
           throw 'Must have either ROPSTEN_PRIVATE_KEY or ROPSTEN_MNEMONIC env var'
         }
-        if (!process.env.INFURA_ACCESS_TOKEN) {
-          throw 'Missing INFURA_ACCESS_TOKEN env var'
+        if (!process.env.ROPSTEN_PROVIDER_URL) {
+          throw 'Missing RPOSTEN_PROVIDER_URL env var'
         }
-        providerUrl = `https://ropsten.infura.io/${
-          process.env.INFURA_ACCESS_TOKEN
-        }`
+        providerUrl = process.env.ROPSTEN_PROVIDER_URL
         break
       case RINKEBY_NETWORK_ID:
         privateKey = process.env.RINKEBY_PRIVATE_KEY
@@ -71,12 +67,10 @@ function createProviders(networkIds) {
         if (!privateKey && !mnemonic) {
           throw 'Must have either RINKEBY_PRIVATE_KEY or RINKEBY_MNEMONIC env var'
         }
-        if (!process.env.INFURA_ACCESS_TOKEN) {
-          throw 'Missing INFURA_ACCESS_TOKEN env var'
+        if (!process.env.RINKEBY_PROVIDER_URL) {
+          throw 'Missing RINKEBY_PROVIDER_URL env var'
         }
-        providerUrl = `https://rinkeby.infura.io/${
-          process.env.INFURA_ACCESS_TOKEN
-        }`
+        providerUrl = process.env.RINKEBY_PROVIDER_URL
         break
       case LOCAL_NETWORK_ID:
         privateKey = process.env.LOCAL_PRIVATE_KEY


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Description:

Replace with PROVIDER_URL which will be pointing to infura or alchemy.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
