### PR TITLE
[Growth] Add admin access

### DIFF
--- a/devops/kubernetes/charts/origin/templates/growth.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/growth.ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,X-AppEngine-Country,authentication"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authentication,X-Growth-Secret,X-Growth-Wallet"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/rewrite-target: /graphql

--- a/infra/growth/src/apollo/app.js
+++ b/infra/growth/src/apollo/app.js
@@ -47,6 +47,7 @@ const server = new ApolloServer({
   playground: true,
   context: async context => {
     const headers = context.req.headers
+    logger.error('APOLLO HEADERS:', headers)
 
     let authStatus = enums.GrowthParticipantAuthenticationStatus.NotEnrolled
     let authToken, walletAddress
@@ -62,6 +63,15 @@ const server = new ApolloServer({
           e.message,
           e.stack
         )
+      }
+    } else if (headers['x-growth-secret'] && headers['x-growth-wallet']) {
+      if (headers['x-growth-secret'] === process.env.GROWTH_ADMIN_SECRET) {
+        // Grant admin access.
+        authToken = 'AdminToken'
+        walletAddress = headers['x-growth-wallet']
+        authStatus = enums.GrowthParticipantAuthenticationStatus.Enrolled
+      } else {
+        logger.error('Invalid admin secret')
       }
     }
 

--- a/infra/growth/src/apollo/app.js
+++ b/infra/growth/src/apollo/app.js
@@ -47,7 +47,6 @@ const server = new ApolloServer({
   playground: true,
   context: async context => {
     const headers = context.req.headers
-    logger.error('APOLLO HEADERS:', headers)
 
     let authStatus = enums.GrowthParticipantAuthenticationStatus.NotEnrolled
     let authToken, walletAddress


### PR DESCRIPTION

### Description:

After we launch, it will be handy for us to be able to query the reward data via the prod growth graphql server for a given user to be able to troubleshoot potential issues.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
