### PR TITLE
 Whitelisting ERC20 token addresses

### DIFF
--- a/packages/contracts/contracts/marketplace/v00/Marketplace.sol
+++ b/packages/contracts/contracts/marketplace/v00/Marketplace.sol
@@ -184,8 +184,9 @@ contract V00_Marketplace is RestrictableContract {
     )
         public
         payable
-        onlyWhitelistedContracts(_currency)
+        // onlyWhitelistedContracts(_currency)
     {
+        require(isContractWhitelisted(_currency), "Contract not whitelisted");
         bool affiliateWhitelistDisabled = allowedAffiliates[address(this)];
         require(
             affiliateWhitelistDisabled || allowedAffiliates[_affiliate],
@@ -236,8 +237,9 @@ contract V00_Marketplace is RestrictableContract {
     )
         public
         payable
-        onlyWhitelistedContracts(_currency)
+        // onlyWhitelistedContracts(_currency)
     {
+        require(isContractWhitelisted(_currency), "Contract not whitelisted");
         withdrawOffer(listingID, _withdrawOfferID, _ipfsHash);
         makeOffer(listingID, _ipfsHash, _finalizes, _affiliate, _commission, _value, _currency, _arbitrator);
     }

--- a/packages/contracts/contracts/marketplace/v00/RestrictableContract.sol
+++ b/packages/contracts/contracts/marketplace/v00/RestrictableContract.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.4.24;
+
+import "../../../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
+// import "../../../node_modules/openzeppelin-solidity/contracts/AddressUtils.sol";
+
+/**
+ * @title RestrictableContract
+ * @author Shahul Hameed <hello@hameid.net>
+ *
+ * Extends Ownable contract and maintains a whitelist of users and whitelist of contracts
+ */
+
+contract RestrictableContract is Ownable {
+    mapping(address => bool) public allowedContracts;
+    mapping(address => bool) public allowedUsers;
+
+    constructor() public {
+        // Set owner to contract creator
+        owner = msg.sender;
+
+        // Whitelist self
+        allowedContracts[address(this)] = true;
+    }
+
+    modifier onlyWhitelistedContracts(address contractAddress) {
+        require(allowedContracts[contractAddress], "Contract is not whitelisted");
+        _;
+    }
+
+    modifier onlyWhitelistedContractsOrOwner(address _address) {
+        require(_address == owner || allowedContracts[_address], "Must be a whitelisted contract or owner");
+        _;
+    }
+
+    modifier onlyWhitelistedUsers(address userAddress) {
+        require(allowedUsers[userAddress], "Must be a whitelisted user");
+        _;
+    }
+
+    modifier onlyWhitelistedUsersOrOwner(address userAddress) {
+        require(userAddress == owner || allowedUsers[userAddress], "Must be a whitelisted user or owner");
+        _;
+    }
+
+    // Add contract address to whitelist
+    function whitelistContract(address contractAddress) public onlyOwner {
+        // require(AddressUtils.isContract(contractAddress), "Must be a contract address AAA");
+        allowedContracts[contractAddress] = true;
+    }
+
+    // Remove contract address from whitelist
+    function blacklistContract(address contractAddress) public onlyOwner {
+        // require(AddressUtils.isContract(contractAddress), "Must be a contract address");
+        allowedContracts[contractAddress] = false;
+    }
+
+    // Adds user address to whitelist
+    function whitelistUser(address userAddress) public onlyOwner {
+        // require(!AddressUtils.isContract(userAddress), "Must be an user address");
+        allowedUsers[userAddress] = true;
+    }
+
+    // Removes user from whitelist
+    function blacklistUser(address userAddress) public onlyOwner {
+        // require(!AddressUtils.isContract(userAddress), "Must be an user address");
+        allowedUsers[userAddress] = false;
+    }
+
+    // @returns true if contract is whitelisted
+    function isContractWhitelisted(address contractAddress) public view returns(bool) {
+        return allowedContracts[contractAddress];
+    }
+
+    // @returns true if user address is whitelisted
+    function isUserWhitelisted(address userAddress) public view returns(bool) {
+        return allowedContracts[userAddress];
+    }
+}

--- a/packages/contracts/test-alt/Marketplace.js
+++ b/packages/contracts/test-alt/Marketplace.js
@@ -36,6 +36,7 @@ describe('Marketplace.sol', async function() {
   let Marketplace,
     OriginToken,
     DaiStableCoin,
+    UntrustedToken,
     Buyer,
     // BuyerIdentity,
     Owner,
@@ -86,6 +87,13 @@ describe('Marketplace.sol', async function() {
       // args: [12000]
     })
 
+    UntrustedToken = await deploy('UntrustedToken', {
+      from: Owner,
+      path: `${__dirname}/contracts/`,
+      args: ['Untrusted token', 'UNTRUSTED', 2, 12000]
+      // args: [12000]
+    })
+
     Arbitrator = await deploy('CentralizedArbitrator', {
       from: ArbitratorAddr,
       path: `${__dirname}/contracts/arbitration/`,
@@ -116,6 +124,9 @@ describe('Marketplace.sol', async function() {
     //   path: `${contractPath}/identity`
     // })
 
+    await Marketplace.methods.whitelistContract(DaiStableCoin._address).send({
+      from: Owner
+    })
     await Marketplace.methods.addAffiliate(Affiliate, IpfsHash).send()
     await OriginToken.methods.transfer(Seller, 400).send()
     await OriginToken.methods.transfer(Seller2, 400).send()
@@ -188,6 +199,23 @@ describe('Marketplace.sol', async function() {
       gasTable.push([...u, gasPriceInDollars(u[1]), gasPriceInDollars(u[2])])
     })
     console.log(gasTable.toString())
+  })
+
+  describe('RestrictableContract', function() {
+    it('should have whitelisted address 0x0', async function() {
+      const whitelisted = await Marketplace.methods.isContractWhitelisted('0x0000000000000000000000000000000000000000').call();
+      assert.equal(whitelisted, true);  
+    })
+    it('should have whitelisted OGN and DAI contracts', async function() {
+      const ognWhitelisted = await Marketplace.methods.isContractWhitelisted(OriginToken._address).call();
+      assert.equal(ognWhitelisted, true);  
+      const daiWhitelisted = await Marketplace.methods.isContractWhitelisted(DaiStableCoin._address).call();
+      assert.equal(daiWhitelisted, true);  
+    })
+    it('should not have whitelisted untrusted token contract', async function() {
+      const whitelisted = await Marketplace.methods.isContractWhitelisted(UntrustedToken._address).call();
+      assert.equal(whitelisted, false);
+    })
   })
 
   describe('A listing in ETH', function() {
@@ -281,6 +309,17 @@ describe('Marketplace.sol', async function() {
         assert(result2.events.OfferWithdrawn)
         assert(result2.events.OfferCreated)
       })
+
+      it('should NOT allow an offer to be updated with untrusted tokens', async function() {
+        try {
+          await helpers.makeERC20Offer({
+            Token: UntrustedToken
+          })
+        } catch (e) {
+          return
+        }
+        assert(false)
+      })
     })
 
     describe('withdrawing a listing', function() {
@@ -333,7 +372,7 @@ describe('Marketplace.sol', async function() {
         assert(result)
       })
 
-      it('should allow an offer to be made', async function() {
+      it('should allow an offer to be made with whitelisted token', async function() {
         const result = await helpers.makeERC20Offer({
           Buyer,
           Token: DaiStableCoin,
@@ -343,6 +382,19 @@ describe('Marketplace.sol', async function() {
 
         const offer = await Marketplace.methods.offers(listingID, 0).call()
         assert.equal(offer.buyer, Buyer)
+      })
+      
+      it('should NOT allow an offer to be made with untrusted tokens', async function() {
+        try {
+          await helpers.makeERC20Offer({
+            Buyer,
+            Token: UntrustedToken,
+            listingID
+          })
+        } catch (e) {
+          return
+        }
+        assert(false)
       })
 
       it('should allow an offer to be accepted', async function() {

--- a/packages/contracts/test-alt/_helper.js
+++ b/packages/contracts/test-alt/_helper.js
@@ -4,6 +4,7 @@ import solc from 'solc'
 import linker from 'solc/linker'
 import Ganache from 'ganache-core'
 import Web3 from 'web3'
+import path from 'path'
 
 const solcOpts = {
   language: 'Solidity',
@@ -34,17 +35,17 @@ export async function web3Helper(provider = defaultProvider) {
 }
 
 function findImportsPath(prefix) {
-  return function findImports(path) {
+  return function findImports(importPath) {
     try {
-      if (path.indexOf('node_modules') < 0) {
-        path = prefix + path
+      if (importPath.indexOf('node_modules') < 0) {
+        importPath = path.join(prefix, importPath)
       }
-      const contents = fs.readFileSync(path).toString()
+      const contents = fs.readFileSync(importPath).toString()
       return {
         contents
       }
     } catch (e) {
-      console.log(`File not found: ${path}`)
+      console.log(`File not found: ${importPath}`)
       return { error: 'File not found' }
     }
   }

--- a/packages/contracts/test-alt/contracts/UntrustedToken.sol
+++ b/packages/contracts/test-alt/contracts/UntrustedToken.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.24;
+
+import '../../../node_modules/openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
+
+contract UntrustedToken is StandardToken {
+  string public name;
+  string public symbol;
+  uint8 public decimals;
+
+  constructor(string _name, string _symbol, uint8 _decimals, uint _supply) public {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+    totalSupply_ = _supply;
+    balances[msg.sender] = _supply;
+  }
+}


### PR DESCRIPTION
### Description:

This changeset fixes #1117 

Changes made:

- Have added a new contract called `RestrictableContract` that inherits from `Ownable` contract.
- The contract contains two lists. One for whitelisted users and another one for whitelisted contracts. The methods `whitelistUser`, `whitelistContract`, `blacklistUser` and `blacklistContract` can be used add user/contract addresses to whitelist.
- The contract also adds the following modifiers on top of already existing modifiers from `Ownable` contract. 
    - `onlyWhitelistedContracts`
    - `onlyWhitelistedContractsOrOwner`
    - `onlyWhitelistedUsers`
    - `onlyWhitelistedUsersOrOwner`

### Some behavior by design:
- I wanted to keep the contract `RestrictableContract` as generic as possible so that it can be reused.
- Only owner of the contract can whitelist/blacklist user and contract addresses.
- I initially added `AddressUtil.sol` from zeppelin contract to check whether an address is a valid contract or not. However, ETH is internally represented using address 0x0 and 0x0 is not a valid contract. So, there is no direct way to whitelist 0x0. So I have commented out the code for now.
    
    We can manually whitelist address 0x0. But, since only owner of the contract can whitelist or blacklist, I don't think we have to be strict with whitelisting contract addresses. 

### Checklist:

- [ ] Write unit tests with 100% coverage
- [ ] Change name of the contract to a more reasonable one