### PR TITLE
attempt to configure crowdin translations for the new facebook plugin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
-  - source: /origin-dapp/translations/all-messages.json
-    translation: /languages/%locale%/%original_file_name%
+  - source: /dapps/marketplace/translations/all-messages.json
+    translation: /dapps/marketplace/translations/crowdin_translations/languages/%locale%-%original_file_name%

--- a/dapps/marketplace/scripts/fbToSimpleJsonFormat.js
+++ b/dapps/marketplace/scripts/fbToSimpleJsonFormat.js
@@ -5,10 +5,10 @@ const phrases = JSON.parse(facebookTranslations).phrases
 const allMessages = {}
 
 phrases.forEach(phrase => {
-	Object.keys(phrase.hashToText)
-		.forEach(key => {
-			allMessages[key] = phrase.hashToText[key]
-		})
+  Object.keys(phrase.hashToText)
+    .forEach(key => {
+      allMessages[key] = phrase.hashToText[key]
+    })
 
 })
 

--- a/dapps/marketplace/scripts/fbToSimpleJsonFormat.js
+++ b/dapps/marketplace/scripts/fbToSimpleJsonFormat.js
@@ -1,0 +1,16 @@
+const fs = require('fs')
+
+const facebookTranslations = fs.readFileSync(`${__dirname}/../.source_strings.json`)
+const phrases = JSON.parse(facebookTranslations).phrases
+const allMessages = {}
+
+phrases.forEach(phrase => {
+	Object.keys(phrase.hashToText)
+		.forEach(key => {
+			allMessages[key] = phrase.hashToText[key]
+		})
+
+})
+
+const output = JSON.stringify(allMessages, null, 2)
+fs.writeFileSync(`${__dirname}/../translations/all-messages.json`, output)


### PR DESCRIPTION
### Description:
Dapp2 seems to not have Crowdin integration. What this PR attempts to do is: 
- convert the new fbt output translation files into the simple JSON format
- prepare a crowdin.yml configuration file that should configure Crowdin where to look for source files and where to put the translated files.

**Remark:**
- the new dapp2 `all-messages.json` was manually uploaded to Crowdin so Anna could start with the Chinese translations. 

**TODO:**
- read what Crowdin produces and integrate those translations back to Dapp2


### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any displayed ETH addresses with [`formattedAddress`](https://github.com/OriginProtocol/origin/blob/master/origin-dapp/src/utils/user.js#L15-L17)
- [ ] Wrap any new text/strings for translation
- [ ] Run `npm run translations` if there are any changes to translated strings
- [ ] Map any new environment variables with a default value in the Webpack config
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/origin-docs)
