### PR TITLE
Two-Week Finalization Window

### DIFF
--- a/packages/graphql/src/mutations/marketplace/makeOffer.js
+++ b/packages/graphql/src/mutations/marketplace/makeOffer.js
@@ -104,7 +104,7 @@ async function toIpfsData(data) {
       currency: 'ETH'
     },
     commission,
-    finalizes: data.finalizes || 60 * 60 * 24 * 365,
+    finalizes: data.finalizes || 60 * 60 * 24 * 14,
     ...(data.fractionalData || {})
   }
 


### PR DESCRIPTION
As requested by @joshfraser and @matthewliu, this intends to shorten the finalization window from one year to two weeks. I recommend that we eventually prescribe different timeframes depending on the listing types or consider a different approach altogether.