### PR TITLE
[GraphQL] Set default currency conversion rates

### DIFF
--- a/packages/graphql/src/utils/currencies.js
+++ b/packages/graphql/src/utils/currencies.js
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch'
 
+const API_TIMEOUT_MS = 5000 // 5sec
 const EXCHANGE_RATES_POLL_INTERVAL = 10 * 60 * 1000 // 10 min.
 
 class Currencies {
@@ -111,7 +112,7 @@ class Currencies {
       this.currencyCodes.join(',')
     let rates
     try {
-      const response = await fetch(url, { timeout: 2000 })
+      const response = await fetch(url, { timeout: API_TIMEOUT_MS })
       rates = await response.json()
     } catch (e) {
       console.error('API call to fetch xrates from CryptoCompare failed.')


### PR DESCRIPTION
### Description:

Set default exchange rates for currencies to deal with the case where the centralized server we query to dynamically fetch the rates is down.

Also fixed a bug in the rate ! It was storing the reverse of what we want... :)

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Wrap any new text/strings for translation (see [fbt](https://facebookincubator.github.io/fbt/))
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace#translation)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
