### PR TITLE
Stan/wrap listing details fix

### DIFF
--- a/dapps/marketplace/src/pages/create-listing/listing-types/FractionalListing/Details.js
+++ b/dapps/marketplace/src/pages/create-listing/listing-types/FractionalListing/Details.js
@@ -31,6 +31,7 @@ class Details extends Component {
     const input = formInput(this.state, state => this.setState(state))
     const Feedback = formFeedback(this.state)
 
+
     return (
       <div className="row">
         <div className="col-md-8">
@@ -42,7 +43,9 @@ class Details extends Component {
                   <fbt:param name="step">{this.props.step}</fbt:param>
                 </fbt>
               </div>
-              <fbt desc="create.details.title">Provide listing details</fbt>
+              <div className="step-description">
+                <fbt desc="create.details.title">Provide listing details</fbt>
+              </div>
               <Steps steps={this.props.steps} step={this.props.step} />
 
               <form
@@ -67,9 +70,11 @@ class Details extends Component {
                   <label className="mb-0">
                     <fbt desc="create.details.description">Description</fbt>
                   </label>
-                  <fbt desc="create.description.hourly">
-                    Make sure to include special conditions of your rental here.
-                  </fbt>
+                  <div className="help-text">
+                    <fbt desc="create.description.hourly">
+                      Make sure to include special conditions of your rental here.
+                    </fbt>
+                  </div>
                   <textarea {...input('description')} />
                   {Feedback('description')}
                 </div>

--- a/dapps/marketplace/src/pages/create-listing/listing-types/FractionalListing/Details.js
+++ b/dapps/marketplace/src/pages/create-listing/listing-types/FractionalListing/Details.js
@@ -31,7 +31,6 @@ class Details extends Component {
     const input = formInput(this.state, state => this.setState(state))
     const Feedback = formFeedback(this.state)
 
-
     return (
       <div className="row">
         <div className="col-md-8">
@@ -72,7 +71,8 @@ class Details extends Component {
                   </label>
                   <div className="help-text">
                     <fbt desc="create.description.hourly">
-                      Make sure to include special conditions of your rental here.
+                      Make sure to include special conditions of your rental
+                      here.
                     </fbt>
                   </div>
                   <textarea {...input('description')} />

--- a/dapps/marketplace/src/pages/create-listing/listing-types/UnitListing/Details.js
+++ b/dapps/marketplace/src/pages/create-listing/listing-types/UnitListing/Details.js
@@ -43,7 +43,9 @@ class Details extends Component {
                   <fbt:param name="step">{this.props.step}</fbt:param>
                 </fbt>
               </div>
-              <div className="step-description">Provide listing details</div>
+              <div className="step-description">
+                <fbt desc="create.details.title">Provide listing details</fbt>
+              </div>
               <Steps steps={this.props.steps} step={this.props.step} />
 
               <form


### PR DESCRIPTION
Wrap text, and fix formatting, of title on listing details pages

![image](https://user-images.githubusercontent.com/673455/55492340-4df82500-55f4-11e9-8661-43aa97b32010.png)


