### PR TITLE
Fixes a bug where invite code didn't show up on second open of invite screen

### DIFF
--- a/dapps/marketplace/src/pages/growth/Invite.js
+++ b/dapps/marketplace/src/pages/growth/Invite.js
@@ -112,6 +112,7 @@ class GrowthInvite extends Component {
     return (
       <Query
         query={inviteCodeQuery}
+        fetchPolicy="network-only"
         onCompleted={({ inviteCode }) => {
           if (inviteCode !== this.state.inviteCode) {
             this.setState({ inviteCode })


### PR DESCRIPTION
### Description:

This fixes a bug where `origin-invite-code` field does not get populated on the second open of invite page. The problem was that Query was hitting cache and not triggering `onComplete` function that populated the invite code state. 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
