### PR TITLE
Fix indexing of offer status

### DIFF
--- a/infra/discovery/src/listener/handler_marketplace.js
+++ b/infra/discovery/src/listener/handler_marketplace.js
@@ -188,10 +188,11 @@ class MarketplaceEventHandler {
     const blockDate = new Date(block.timestamp * 1000)
 
     logger.info(`Indexing offer in DB: id=${offer.id}`)
+
     const offerData = {
       id: offer.id,
       listingId: removeListingIdBlockNumber(listing.id),
-      status: offer.status,
+      status: offer.statusStr,
       sellerAddress: listing.seller.id.toLowerCase(),
       buyerAddress: offer.buyer.id.toLowerCase(),
       data: offer

--- a/infra/discovery/src/listener/queries/Fragments.js
+++ b/infra/discovery/src/listener/queries/Fragments.js
@@ -74,6 +74,7 @@ module.exports = {
         refund
         commission
         status
+        statusStr
         finalizes
         quantity
         valid

--- a/infra/discovery/src/listener/webhooks.js
+++ b/infra/discovery/src/listener/webhooks.js
@@ -72,7 +72,7 @@ async function postToDiscordWebhook(url, data) {
           )}`,
           description: [
             `${listing.description.split('\n')[0].slice(0, 60)}...`,
-            `https://dapp.originprotocol.com/#/listing/${listing}`,
+            `https://dapp.originprotocol.com/#/listing/${listing.id}`,
             `Seller: ${personDisp(listing.seller)}`
           ].join('\n')
         }

--- a/infra/discovery/test/listener-handler.test.js
+++ b/infra/discovery/test/listener-handler.test.js
@@ -56,7 +56,7 @@ const mockIdentity = {
 }
 const mockOffer = {
   id: offerId,
-  status: 'finalized',
+  statusStr: 'Finalized',
   buyer: {
     id: buyer
   },
@@ -196,7 +196,7 @@ describe('Listener Handlers', () => {
       where: {
         id: offerId,
         listingId: listingId,
-        status: 'finalized',
+        status: 'Finalized',
         sellerAddress: seller,
         buyerAddress: buyer
       }


### PR DESCRIPTION
Fixes offer status indexing which is `offerStr` not `offer` in graphql. The `offer` attribute is an integer representing the status.