### PR TITLE
Compress event cache to prevent localStorage overflow

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -34,6 +34,7 @@
     "apollo-link-http": "^1.5.12",
     "dayjs": "^1.8.10",
     "json-stable-stringify": "^1.0.1",
+    "lz-string": "^1.4.4",
     "mocha": "^5.2.0",
     "prettier": "^1.16.4",
     "rlp": "^2.2.2"

--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -48,7 +48,7 @@ const Configs = {
     OriginToken: '0x8207c1ffc5b6804f6024322ccf34f29c3541ae26',
     V00_Marketplace: '0x819bb9964b6ebf52361f1ae42cf4831b921510f9',
     V00_Marketplace_Epoch: '6436157',
-    ipfsEventCache: 'QmUu2kP6akKKujcqBfGFAo35xjAXXactvierQDH5KFCTtW',
+    ipfsEventCache: 'QmWyqzZMoQB1zzxJyCAhTZ5XenzX5H8sfE3Uh58uEN3MJh',
     messagingAccount: '0xBfDd843382B36FFbAcd00b190de6Cb85ff840118',
     messaging: {
       ipfsSwarm:


### PR DESCRIPTION
the event cache is currently stored in localStorage but has recently gone over the limit, causing errors in the dapp.

This PR is a short term fix to compress the events before storing in localStorage.