### PR TITLE
[Growth] Store browser fingerprint during campaign enrollment

### DIFF
--- a/dapps/marketplace/package.json
+++ b/dapps/marketplace/package.json
@@ -48,6 +48,7 @@
     "dayjs": "^1.8.10",
     "express": "^4.16.4",
     "fbt-runtime": "^0.9.4",
+    "fingerprintjs2": "^2.0.6",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.1",
     "ipfs-api": "^26.1.2",

--- a/dapps/marketplace/src/mutations/GrowthEnroll.js
+++ b/dapps/marketplace/src/mutations/GrowthEnroll.js
@@ -6,12 +6,14 @@ export default gql`
     $agreementMessage: String!
     $signature: String!
     $inviteCode: String
+    $fingerprint: String!
   ) {
     enroll(
       accountId: $accountId
       agreementMessage: $agreementMessage
       signature: $signature
       inviteCode: $inviteCode
+      fingerprint: $fingerprint
     ) {
       authToken
       error

--- a/dapps/marketplace/src/pages/growth/WithEnrolmentModal.js
+++ b/dapps/marketplace/src/pages/growth/WithEnrolmentModal.js
@@ -3,6 +3,7 @@ import Modal from 'components/Modal'
 import { Query } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
 import { fbt } from 'fbt-runtime'
+import Fingerprint2 from 'fingerprintjs2'
 
 import growthEligibilityQuery from 'queries/GrowthEligibility'
 import enrollmentStatusQuery from 'queries/EnrollmentStatus'
@@ -44,7 +45,8 @@ function withEnrolmentModal(WrappedComponent) {
         notCitizenChecked: false,
         notCitizenConfirmed: false,
         termsAccepted: false,
-        userAlreadyEnrolled: false
+        userAlreadyEnrolled: false,
+        fingerprint: null
       }
     }
 
@@ -76,6 +78,22 @@ function withEnrolmentModal(WrappedComponent) {
           )
         )
       }
+    }
+
+    componentDidMount() {
+      // Delay the fingerprint calculation to ensure consistent fingerprinting.
+      setTimeout(() => this.calcFingerprint(), 500)
+    }
+
+    async calcFingerprint() {
+      const options = {}
+      Fingerprint2.get(options, components => {
+        const values = components.map(component => component.value)
+        const hash = Fingerprint2.x64hash128(values.join(''), 31)
+        this.setState({
+          fingerprint: `V1-${hash}`
+        })
+      })
     }
 
     handleNotCitizenClick(e) {
@@ -384,7 +402,9 @@ function withEnrolmentModal(WrappedComponent) {
     }
 
     renderMetamaskSignature() {
-      return <Enroll />
+      return <Enroll
+        fingerprint={this.state.fingerprint}
+      />
     }
 
     renderNotSupportedOnMobile() {

--- a/dapps/marketplace/src/pages/growth/WithEnrolmentModal.js
+++ b/dapps/marketplace/src/pages/growth/WithEnrolmentModal.js
@@ -402,9 +402,7 @@ function withEnrolmentModal(WrappedComponent) {
     }
 
     renderMetamaskSignature() {
-      return <Enroll
-        fingerprint={this.state.fingerprint}
-      />
+      return <Enroll fingerprint={this.state.fingerprint} />
     }
 
     renderNotSupportedOnMobile() {

--- a/dapps/marketplace/src/pages/growth/mutations/Enroll.js
+++ b/dapps/marketplace/src/pages/growth/mutations/Enroll.js
@@ -17,7 +17,7 @@ class Enroll extends Component {
 
   async calcFingerprint() {
     const options = {}
-    Fingerprint2.get(options, (components) => {
+    Fingerprint2.get(options, components => {
       const values = components.map(component => component.value)
       const hash = Fingerprint2.x64hash128(values.join(''), 31)
       this.fingerprint = 'V1-' + hash

--- a/dapps/marketplace/src/pages/growth/mutations/Enroll.js
+++ b/dapps/marketplace/src/pages/growth/mutations/Enroll.js
@@ -1,6 +1,8 @@
 import React, { Component, Fragment } from 'react'
 import { Query, Mutation } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
+import Fingerprint2 from 'fingerprintjs2'
+
 import QueryError from 'components/QueryError'
 import profileQuery from 'queries/Profile'
 import SignMessageMutation from 'mutations/SignMessage'
@@ -12,7 +14,20 @@ class Enroll extends Component {
     // TODO: change version programatically
     message: 'I accept the terms of growth campaign version: 1.0'
   }
+
+  async calcFingerprint() {
+    const options = {}
+    Fingerprint2.get(options, (components) => {
+      const values = components.map(component => component.value)
+      const hash = Fingerprint2.x64hash128(values.join(''), 31)
+      this.fingerprint = 'V1-' + hash
+    })
+  }
+
   render() {
+    // Delay the fingerprint calculation to ensure consistent fingerprinting.
+    setTimeout(() => this.calcFingerprint(), 500)
+
     return (
       <Query query={profileQuery}>
         {({ networkStatus, error, loading, data }) => {
@@ -46,7 +61,8 @@ class Enroll extends Component {
                         accountId: accountId,
                         agreementMessage: this.state.message,
                         signature: signMessage,
-                        inviteCode: localStorage.getItem('growth_invite_code')
+                        inviteCode: localStorage.getItem('growth_invite_code'),
+                        fingerprint: this.fingerprint
                       }
                     })
                   }}

--- a/dapps/marketplace/src/pages/growth/mutations/Enroll.js
+++ b/dapps/marketplace/src/pages/growth/mutations/Enroll.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import { Query, Mutation } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
-import Fingerprint2 from 'fingerprintjs2'
 
 import QueryError from 'components/QueryError'
 import profileQuery from 'queries/Profile'
@@ -15,19 +14,7 @@ class Enroll extends Component {
     message: 'I accept the terms of growth campaign version: 1.0'
   }
 
-  async calcFingerprint() {
-    const options = {}
-    Fingerprint2.get(options, components => {
-      const values = components.map(component => component.value)
-      const hash = Fingerprint2.x64hash128(values.join(''), 31)
-      this.fingerprint = 'V1-' + hash
-    })
-  }
-
   render() {
-    // Delay the fingerprint calculation to ensure consistent fingerprinting.
-    setTimeout(() => this.calcFingerprint(), 500)
-
     return (
       <Query query={profileQuery}>
         {({ networkStatus, error, loading, data }) => {
@@ -37,7 +24,6 @@ class Enroll extends Component {
           }
 
           const accountId = data.web3.primaryAccount.id
-
           return (
             <Mutation
               mutation={GrowthEnroll}
@@ -62,7 +48,7 @@ class Enroll extends Component {
                         agreementMessage: this.state.message,
                         signature: signMessage,
                         inviteCode: localStorage.getItem('growth_invite_code'),
-                        fingerprint: this.fingerprint
+                        fingerprint: this.props.fingerprint
                       }
                     })
                   }}

--- a/infra/growth/src/apollo/resolvers.js
+++ b/infra/growth/src/apollo/resolvers.js
@@ -129,6 +129,7 @@ const resolvers = {
           args.accountId,
           args.agreementMessage,
           args.signature,
+          args.fingerprint,
           ip,
           countryCode
         )

--- a/infra/growth/src/apollo/resolvers.js
+++ b/infra/growth/src/apollo/resolvers.js
@@ -117,8 +117,18 @@ const resolvers = {
       return true
     },
     async enroll(_, args, context) {
-      const ip = context.req.headers['x-real-ip']
-      const { eligibility, countryCode } = await getLocationInfo(ip)
+      let ip, eligibility, countryCode
+      if (process.env.NODE_ENV !== 'production') {
+        ip = '192.168.1.1'
+        eligibilit = 'Eligible'
+        countryCode = 'NA'
+      } else {
+        ip = context.req.headers['x-real-ip']
+        const locationInfo = await getLocationInfo(ip)
+        eligibility = locationInfo.eligibility
+        countryCode = locationInfo.countryCode
+      }
+
       if (eligibility === 'Forbidden') {
         logger.warn('Enrollment declined for user in country ', countryCode)
         throw new ForbiddenError('Forbidden country')

--- a/infra/growth/src/apollo/resolvers.js
+++ b/infra/growth/src/apollo/resolvers.js
@@ -120,7 +120,7 @@ const resolvers = {
       let ip, eligibility, countryCode
       if (process.env.NODE_ENV !== 'production') {
         ip = '192.168.1.1'
-        eligibilit = 'Eligible'
+        eligibility = 'Eligible'
         countryCode = 'NA'
       } else {
         ip = context.req.headers['x-real-ip']

--- a/infra/growth/src/resources/authentication.js
+++ b/infra/growth/src/resources/authentication.js
@@ -16,6 +16,7 @@ const currentAgreementMessage =
  * @param {string} accountId - Eth address of the user.
  * @param {string} agreementMessage - Message presented to user to sign.
  * @param {string} signature - Signed message.
+ * @param {string} fingerprint - Browser fingerprint
  * @param {string} ip - IP address the request was initiated from.
  * @param {string} country - 2 letters country code.
  * @returns {Promise<any>}
@@ -24,6 +25,7 @@ async function authenticateEnrollment(
   accountId,
   agreementMessage,
   signature,
+  fingerprint,
   ip,
   country
 ) {
@@ -69,6 +71,7 @@ async function authenticateEnrollment(
     status: enums.GrowthParticipantStatuses.Active,
     agreementId: agreementMessage,
     authToken: authToken,
+    data: { fingerprint },
     ip,
     country
   }

--- a/infra/growth/src/util/locationInfo.js
+++ b/infra/growth/src/util/locationInfo.js
@@ -10,14 +10,6 @@ const forbiddenCountryCodes = ['CU', 'IR', 'KP', 'SY']
  * @returns {{countryName: string, countryCode: string, eligibility: string}}
  */
 async function getLocationInfo(ip) {
-  if (process.env.NODE_ENV !== 'production') {
-    return {
-      eligibility: 'Unknown',
-      countryName: 'NA',
-      countryCode: 'NA'
-    }
-  }
-
   if (!ip) {
     return null
   }

--- a/infra/growth/src/util/locationInfo.js
+++ b/infra/growth/src/util/locationInfo.js
@@ -10,6 +10,14 @@ const forbiddenCountryCodes = ['CU', 'IR', 'KP', 'SY']
  * @returns {{countryName: string, countryCode: string, eligibility: string}}
  */
 async function getLocationInfo(ip) {
+  if (process.env.NODE_ENV !== 'production') {
+    return {
+      eligibility: 'Unknown',
+      countryName: 'NA',
+      countryCode: 'NA'
+    }
+  }
+
   if (!ip) {
     return null
   }

--- a/packages/graphql/src/typeDefs/Growth.js
+++ b/packages/graphql/src/typeDefs/Growth.js
@@ -154,7 +154,7 @@ module.exports =
     # Sends email invites with referral code on behalf of the referrer.
     invite(emails: [String!]!): Boolean
     # Enrolls user into the growth engine program.
-    enroll(accountId: ID!, agreementMessage: String!, signature: String!, inviteCode: String): EnrollResponse
+    enroll(accountId: ID!, agreementMessage: String!, signature: String!, inviteCode: String, fingerprint: String): EnrollResponse
     # Records a growth engine event.
     log(event: JSON!): Boolean
     # Remind a user that his invitation is still pending


### PR DESCRIPTION
### Description:

Compute a fingerprint on the enroll page and pass it to the back-end to store it in growth_participant.data

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
