### PR TITLE
Make Airbnb's confirmation code textarea wider

### DIFF
--- a/dapps/marketplace/src/pages/identity/AirbnbAttestation.js
+++ b/dapps/marketplace/src/pages/identity/AirbnbAttestation.js
@@ -105,12 +105,13 @@ class AirbnbAttestation extends Component {
           </fbt>
         </div>
         <div className="my-3 verification-code">
-          <input
+          <textarea
             ref={ref => (this.inputRef = ref)}
-            className="form-control form-control-lg"
-            value={this.state.code}
+            className="form-control form-control-lg airbnb-verification-code"
             readOnly
-          />
+          >
+            {this.state.code}
+          </textarea>
           {this.state.error && (
             <div className="alert alert-danger mt-3">{this.state.error}</div>
           )}
@@ -258,4 +259,8 @@ class AirbnbAttestation extends Component {
 export default AirbnbAttestation
 
 require('react-styl')(`
+  .attestation-modal > div .verification-code .form-control.airbnb-verification-code
+    height: 6rem
+    max-width: 24rem
+    resize: none
 `)


### PR DESCRIPTION
### Description:

Make Airbnb's confirmation code textarea wider so the whole confirmation code fits in there

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
