### PR TITLE
[Growth] change Price.currency to String in short-term

### DIFF
--- a/packages/graphql/src/typeDefs/Common.js
+++ b/packages/graphql/src/typeDefs/Common.js
@@ -1,6 +1,7 @@
 module.exports = `
   type Price {
-    currency: CurrencyResult
+    # TODO: change currency to CurrencyResult
+    currency: String
     amount: String
   }
 


### PR DESCRIPTION


### Description:

It would be better to use CurrencyResult but it involves changing the rules in the DB.
For the sake of not blocking the stable coins launch, let's use String which is waht is currently being used in prod.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
