### PR TITLE
Nick/messages bottleneck

### DIFF
--- a/dapps/marketplace/src/hoc/withCounterpartyEvents.js
+++ b/dapps/marketplace/src/hoc/withCounterpartyEvents.js
@@ -17,11 +17,11 @@ function withCounterpartyEvents(WrappedComponent) {
             <WrappedComponent
               {...props}
               counterpartyEventsLoading={loading}
-              counterpartyEvents={get(
-                data,
-                'marketplace.user.counterparty.nodes',
-                []
-              )}
+              counterpartyEvents={
+                loading
+                  ? []
+                  : get(data, 'marketplace.user.counterparty.nodes', [])
+              }
             />
           )
         }}

--- a/dapps/marketplace/src/pages/messaging/Room.js
+++ b/dapps/marketplace/src/pages/messaging/Room.js
@@ -100,7 +100,7 @@ class AllMessages extends Component {
                 message={message}
                 lastMessage={idx > 0 ? messages[idx - 1] : null}
                 nextMessage={messages[idx + 1]}
-                key={idx}
+                key={`message-${idx}`}
                 wallet={get(message, 'address')}
                 isUser={this.props.wallet === get(message, 'address')}
               />
@@ -108,7 +108,7 @@ class AllMessages extends Component {
           } else if (event) {
             return (
               <OfferEventWithIdentity
-                key={idx}
+                key={`event-${idx}`}
                 event={event}
                 wallet={this.props.wallet}
               />

--- a/packages/messaging-client/package.json
+++ b/packages/messaging-client/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "ajv": "^6.10.0",
+    "bottleneck": "^2.17.1",
     "crypto-js": "^3.1.9-1",
     "crypto-random-string": "^1.0.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
For users with large numbers of conversations, such as Origin Store, the messages API was being overwhelmed with requests. This sets a bottleneck of 25 concurrent requests.

Should also fix #1954