### PR TITLE
Add `type` attributes to button

### DIFF
--- a/dapps/marketplace/src/pages/identity/EmailAttestation.js
+++ b/dapps/marketplace/src/pages/identity/EmailAttestation.js
@@ -126,6 +126,7 @@ class EmailAttestation extends Component {
               />
               <button
                 className="btn btn-link"
+                type="button"
                 onClick={() => this.setState({ shouldClose: true })}
                 children={fbt('Cancel', 'Cancel')}
               />

--- a/dapps/marketplace/src/pages/identity/PhoneAttestation.js
+++ b/dapps/marketplace/src/pages/identity/PhoneAttestation.js
@@ -130,6 +130,7 @@ class PhoneAttestation extends Component {
               />
               <button
                 className="btn btn-link"
+                type="button"
                 onClick={() => this.setState({ shouldClose: true })}
                 children={fbt('Cancel', 'Cancel')}
               />


### PR DESCRIPTION
Fixes #1709 

When `type` attribute is not set, it defaults to `submit`. That caused both submit and cancel buttons to act as submit.