### PR TITLE
[Listener] Add retries to blockchain calls in main loop

### DIFF
--- a/infra/discovery/src/listener/listener.js
+++ b/infra/discovery/src/listener/listener.js
@@ -132,7 +132,9 @@ async function main() {
 
     // Compute the range of blocks to process,
     // while respecting trailing block configuration.
-    const currentBlock = await context.web3.eth.getBlockNumber()
+    const currentBlock = await withRetrys(async () => {
+      return context.web3.eth.getBlockNumber()
+    })
     const toBlock = Math.max(currentBlock - context.config.trailBlocks, 0)
 
     // Listener is up to date. Nothing to do.
@@ -148,8 +150,12 @@ async function main() {
 
     // Retrieve all events for the relevant contracts
     const eventArrays = await Promise.all([
-      contractsContext.marketplace.eventCache.allEvents(),
-      contractsContext.identityEvents.eventCache.allEvents()
+      withRetrys(async () => {
+        return contractsContext.marketplace.eventCache.allEvents()
+      }),
+      withRetrys(async () => {
+        return contractsContext.identityEvents.eventCache.allEvents()
+      })
     ])
 
     // Flatten array of arrays filtering out anything undefined


### PR DESCRIPTION
### Description:

I noticed the listener gets stuck if it hits either rate limiting error or network errors when calling Infura/Alchemy.

This change wraps those calls with exponential backoff retries.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
