### PR TITLE
Adds an option to allow for more accounts to be used with ganache

### DIFF
--- a/packages/services/index.js
+++ b/packages/services/index.js
@@ -19,7 +19,7 @@ const portInUse = port =>
 const startGanache = (opts = {}) =>
   new Promise((resolve, reject) => {
     const ganacheOpts = {
-      total_accounts: 5,
+      total_accounts: opts.total_accounts || 5,
       default_balance_ether: 100,
       db_path: `${__dirname}/data/db`,
       network_id: 999,


### PR DESCRIPTION
### Description:

Change to @origin/services to allow someone to provide an option for ganache to generate more accounts for testing.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
