### PR TITLE
Revert "Fix bridge attestation enum"

### DIFF
--- a/infra/bridge/migrations/20190408083420-add-google-attestion-type.js
+++ b/infra/bridge/migrations/20190408083420-add-google-attestion-type.js
@@ -2,12 +2,12 @@
 module.exports = {
   up: queryInterface => {
     return queryInterface.sequelize.query(`
-      ALTER TYPE attestationtypes ADD VALUE 'GOOGLE';
+      ALTER TYPE enum_attestation_method ADD VALUE 'GOOGLE';
     `)
   },
   down: queryInterface => {
     return queryInterface.sequelize.query(`
-      ALTER TYPE attestationtypes REMOVE VALUE 'GOOGLE';
+      ALTER TYPE enum_attestation_method REMOVE VALUE 'GOOGLE';
     `)
   }
 }


### PR DESCRIPTION
This is correct for the deployments but it is then out of sync with the tests (this is due to legacy enum name from the old Python bridge server). I'll revert this and rename the enum on the deployment SQL databases.