### PR TITLE
Store avatar profile

### DIFF
--- a/dapps/marketplace/src/pages/user/Profile.js
+++ b/dapps/marketplace/src/pages/user/Profile.js
@@ -45,6 +45,7 @@ const ProfileFields = [
   'lastName',
   'description',
   'avatar',
+  'avatarUrl',
   'strength',
   'attestations',
   'facebookVerified',
@@ -221,7 +222,8 @@ class UserProfile extends Component {
                     'firstName',
                     'lastName',
                     'description',
-                    'avatar'
+                    'avatar',
+                    'avatarUrl'
                   ]),
                   attestations: [
                     ...(this.state.attestations || []),
@@ -268,7 +270,9 @@ class UserProfile extends Component {
             onChange={newState =>
               this.setState(newState, () => this.validate())
             }
-            onAvatarChange={avatar => this.setState({ avatar })}
+            onAvatarChange={(avatar, avatarUrl) =>
+              this.setState({ avatar, avatarUrl })
+            }
           />
         )}
       </div>

--- a/dapps/marketplace/src/pages/user/_EditModal.js
+++ b/dapps/marketplace/src/pages/user/_EditModal.js
@@ -5,8 +5,11 @@ import { fbt } from 'fbt-runtime'
 import Modal from 'components/Modal'
 import Avatar from 'components/Avatar'
 import ImageCropper from 'components/ImageCropper'
+import { uploadImages } from 'utils/uploadImages'
 
 import { formInput, formFeedback } from 'utils/formHelpers'
+
+import withConfig from 'hoc/withConfig'
 
 class EditProfileModal extends Component {
   constructor(props) {
@@ -14,7 +17,8 @@ class EditProfileModal extends Component {
     this.state = {
       ...pick(props, ['firstName', 'lastName', 'description']),
       imageCropperOpened: false,
-      avatar: this.props.avatar
+      avatar: this.props.avatar,
+      avatarUrl: this.props.avatarUrl
     }
   }
 
@@ -48,7 +52,15 @@ class EditProfileModal extends Component {
           <div className="row">
             <div className="col-6">
               <ImageCropper
-                onChange={avatar => this.setState({ avatar })}
+                onChange={async avatar => {
+                  const { ipfsRPC } = this.props.config
+                  const uploadedImages = await uploadImages(ipfsRPC, [avatar])
+                  const avatarImg = uploadedImages[0]
+                  if (avatarImg) {
+                    const avatarUrl = avatarImg.url
+                    this.setState({ avatar, avatarUrl })
+                  }
+                }}
                 openChange={open =>
                   this.setState({
                     imageCropperOpened: open
@@ -112,7 +124,10 @@ class EditProfileModal extends Component {
                     pick(this.state, ['firstName', 'lastName', 'description'])
                   )
                   if (this.state.avatar) {
-                    this.props.onAvatarChange(this.state.avatar)
+                    this.props.onAvatarChange(
+                      this.state.avatar,
+                      this.state.avatarUrl
+                    )
                   }
                   this.setState({ shouldClose: true })
                 }
@@ -146,7 +161,7 @@ class EditProfileModal extends Component {
   }
 }
 
-export default EditProfileModal
+export default withConfig(EditProfileModal)
 
 require('react-styl')(`
   .edit-profile-modal

--- a/dapps/marketplace/src/utils/uploadImages.js
+++ b/dapps/marketplace/src/utils/uploadImages.js
@@ -1,0 +1,44 @@
+import loadImage from 'utils/loadImage'
+import { fileSize, postFile } from 'utils/fileUtils'
+
+export const acceptedFileTypes = [
+  'image/jpeg',
+  'image/pjpeg',
+  'image/png',
+  'image/webp'
+]
+
+/**
+ * Uploads an array of image files to IPFS.
+ * Resizes images down to a maximum size if they are too big.
+ * Returns file information, IPFS hash, and base64 encoded data urls
+ * @param {string} ipfsRPC 
+ * @param {File[]} files
+ */
+
+export async function uploadImages(ipfsRPC, files) {
+  const newImages = []
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    const newFile = await new Promise(resolve => {
+      loadImage(file, img => img.toBlob(blob => resolve(blob), 'image/jpeg'), {
+        orientation: true,
+        maxWidth: 2000,
+        maxHeight: 2000
+      })
+    })
+    if (acceptedFileTypes.indexOf(newFile.type) >= 0) {
+      const hash = await postFile(ipfsRPC, newFile, newFile.type)
+      newImages.push({
+        contentType: file.type,
+        size: fileSize(file.size),
+        name: file.name,
+        src: window.URL.createObjectURL(newFile),
+        urlExpanded: window.URL.createObjectURL(newFile),
+        hash,
+        url: `ipfs://${hash}`
+      })
+    }
+  }
+  return newImages
+}

--- a/dapps/marketplace/src/utils/uploadImages.js
+++ b/dapps/marketplace/src/utils/uploadImages.js
@@ -12,7 +12,7 @@ export const acceptedFileTypes = [
  * Uploads an array of image files to IPFS.
  * Resizes images down to a maximum size if they are too big.
  * Returns file information, IPFS hash, and base64 encoded data urls
- * @param {string} ipfsRPC 
+ * @param {string} ipfsRPC
  * @param {File[]} files
  */
 

--- a/packages/graphql/src/typeDefs/Identity.js
+++ b/packages/graphql/src/typeDefs/Identity.js
@@ -20,6 +20,7 @@ module.exports = `
     lastName: String
     description: String
     avatar: String
+    avatarUrl: String
   }
 
   type IdentityEvents {


### PR DESCRIPTION
### Goal:

We are wanting to transition the identity avatar image out being embedded as a base64 string in the profile, and change to posting the image to IPFS and linking to it as we do with listing images. See issue #1795.

The first step of this transition is to save newly uploaded avatars in IPFS, while keeping the old data url method as the one actively used. This way we don't have to carefully time our avatar IPFS image backfill, and the transition should be seamless.

### This PR:

- Refactors out our image uploading and resizing code to a util file, which is then used by both listing and avatar photos.
- Stores avatar photos in IPFS, and adds a new profile field  `avatarUrl` with an 'ipfs://HASHHERE' style url.
- Nothing about reading or using profile avatars is changed.