### PR TITLE
Fix logger import

### DIFF
--- a/infra/notifications/src/app.js
+++ b/infra/notifications/src/app.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 
+const logger = require('./logger')
 try {
   require('envkey')
 } catch (error) {
@@ -14,7 +15,6 @@ const { RateLimiterMemory } = require('rate-limiter-flexible')
 const { mobilePush } = require('./mobilePush')
 const { browserPush } = require('./browserPush')
 const { emailSend } = require('./emailSend')
-const logger = require('./logger')
 
 const app = express()
 const port = 3456


### PR DESCRIPTION
Fix missing logger module error. @wanderingstan this probably worked locally because you had an ENVKEY variable set so it never hit the logger call.