### PR TITLE
Fix shaking/lockup due to react-native SafeAreaView

### DIFF
--- a/mobile/ios/OriginCatcher/Info.plist
+++ b/mobile/ios/OriginCatcher/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>10</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>We will not be using the location</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/mobile/src/OriginWallet.js
+++ b/mobile/src/OriginWallet.js
@@ -96,7 +96,7 @@ class OriginWallet extends Component {
   componentDidUpdate(prevProps) {
     // Reinit web3 if the network we are using changes, this will cause a change
     // of provider to match
-    if (prevProps.settings.network.id !== this.props.settings.network.id) {
+    if (prevProps.settings.network.name !== this.props.settings.network.name) {
       this.initWeb3()
       this.updateBalancesNow()
     }
@@ -171,7 +171,7 @@ class OriginWallet extends Component {
    */
   initWeb3() {
     // Verify that the saved network is valid
-    const networkExists = NETWORKS.find(n => n === this.props.settings.network)
+    const networkExists = NETWORKS.find(n => n.name === this.props.settings.network.name)
     if (!networkExists) {
       // Set to mainnet if for some reason the network doesn't exist
       this.props.setNetwork(NETWORKS.find(n => n.id === 1))

--- a/mobile/src/components/onboarding.js
+++ b/mobile/src/components/onboarding.js
@@ -6,10 +6,10 @@ import {
   Dimensions,
   FlatList,
   Image,
-  SafeAreaView,
   StatusBar,
   StyleSheet
 } from 'react-native'
+import { SafeAreaView } from 'react-navigation'
 
 import OnboardingPage from 'components/onboarding-page'
 import OnboardingPagination from 'components/onboarding-pagination'

--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -6,11 +6,11 @@ import {
   Modal,
   Platform,
   StyleSheet,
-  SafeAreaView,
   StatusBar,
   View
 } from 'react-native'
 import { WebView } from 'react-native-webview'
+import { SafeAreaView } from 'react-navigation'
 import { connect } from 'react-redux'
 
 import { DEFAULT_NOTIFICATION_PERMISSIONS } from '../constants'


### PR DESCRIPTION
This was a hard one to track down, but it looks like the `SafeAreaView` component from react-native [is broken](https://github.com/callstack/react-native-paper/issues/800). The one from `react-navigation` seems to work fine.

Also fixed a little issue with network detection.