### PR TITLE
Reduce irrelevant search results

### DIFF
--- a/infra/discovery/src/lib/search.js
+++ b/infra/discovery/src/lib/search.js
@@ -134,7 +134,8 @@ class Listing {
         match: {
           all_text: {
             query,
-            fuzziness: 'AUTO'
+            fuzziness: 'AUTO',
+            minimum_should_match: '-20%' // most query tokens must be in the listing
           }
         }
       })
@@ -145,6 +146,15 @@ class Listing {
             query: query,
             boost: 2,
             fuzziness: 'AUTO'
+          }
+        }
+      })
+      // give extra score for search words being in proximity to each other
+      esQuery.bool.should.push({
+        match_phrase: {
+          all_text: {
+            query: query,
+            slop: 50
           }
         }
       })

--- a/infra/discovery/test/apollo-search.test.js
+++ b/infra/discovery/test/apollo-search.test.js
@@ -87,7 +87,15 @@ describe('Search', () => {
     )
 
     lastQuery.body.query.function_score.query.bool.must.should.include.something.that.deep.equals(
-      { match: { all_text: { fuzziness: 'AUTO', query: 'Taylor Swift' } } }
+      {
+        match: {
+          all_text: {
+            fuzziness: 'AUTO',
+            minimum_should_match: '-20%',
+            query: 'Taylor Swift'
+          }
+        }
+      }
     )
   })
 


### PR DESCRIPTION
### Description:

Currently our search results contain a lot of irrelevant listings, often ahead of the obvious choice. (see #2042)

Primarily this is because we were selecting any listing that contained *any* word from the search query. This placed many irrelevant featured listings ahead of real results, and adds in many listings with no relationship to the search phrase.

This PR makes two changes.  

1) When using multi-word searches, listings must contain almost of the query words in order to match. Searching for "origin event tshirt" will now require that a listing contains all three of those words, instead of matching both all listings with "tshirt" and all listings with "origin". I've set it to require all words, up to four words, then after allow 20% of the words not to match. Hopefully this number is a good tradeoff, but regardless it should be massively better.

2) We boost listings that contain the words from the search phrase in close proximity. A listing that said "Event T-shirt" would get boosted ahead of a listing that talked about "event pricing" in one area of the description, and "vendors will be selling custom T-shirts" later on.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [x] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [x] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
