### PR TITLE
Disable growth banner in webview

### DIFF
--- a/dapps/marketplace/src/pages/App.js
+++ b/dapps/marketplace/src/pages/App.js
@@ -78,10 +78,12 @@ class App extends Component {
     const { creatorConfig } = this.props
     applyConfiguration(creatorConfig)
 
-    // hide the rewards bar if you're on any of the rewards pages
+    // hide the rewards bar if you're on any of the rewards pages or using
+    // the DApp via the webview in the mobile app
     const hideRewardsBar =
       this.props.location.pathname.match(/^\/welcome$/g) ||
-      this.props.location.pathname.match(/^\/campaigns$/g)
+      this.props.location.pathname.match(/^\/campaigns$/g) ||
+      window.__mobileBridge
 
     // hide navigation bar on growth welcome screen and show it
     // in onboarding variation of that screen


### PR DESCRIPTION
- Hides growth banner in webview while it doesn't work on mobile.