### PR TITLE
Fix fractional listing calendar to show booked dates

### DIFF
--- a/packages/eventsource/src/index.js
+++ b/packages/eventsource/src/index.js
@@ -298,7 +298,7 @@ class OriginEventSource {
         if (!offer.valid || offer.status === 0) {
           // No need to do anything here.
         } else if (offer.startDate && offer.endDate) {
-          booked.push(`${offer.startDate}-${offer.endDate}`)
+          booked.push(`${offer.startDate}/${offer.endDate}`)
         }
       })
     } else if (listing.__typename !== 'AnnouncementListing') {


### PR DESCRIPTION
Fixes #2088 

The [AvailabilityCalculator](https://github.com/OriginProtocol/origin/blob/master/packages/graphql/src/utils/AvailabilityCalculator.js#L138) expects the range separator to be '/' but was getting '-'. That caused this bug.