### PR TITLE
Log webhook error details in listener

### DIFF
--- a/infra/discovery/src/listener/handler.js
+++ b/infra/discovery/src/listener/handler.js
@@ -119,6 +119,7 @@ async function handleEvent(event, context) {
       }, false)
     } catch (e) {
       logger.error(`Skipping notifications webhook for ${eventDetails}`)
+      logger.error(e)
     }
   }
 
@@ -131,6 +132,7 @@ async function handleEvent(event, context) {
       }, false)
     } catch (e) {
       logger.error(`Skipping email webhook for ${eventDetails}`)
+      logger.error(e)
     }
   }
 
@@ -143,6 +145,7 @@ async function handleEvent(event, context) {
       }, false)
     } catch (e) {
       logger.error(`Skipping discord webhook for ${eventDetails}`)
+      logger.error(e)
     }
   }
 
@@ -161,6 +164,7 @@ async function handleEvent(event, context) {
       }, false)
     } catch (e) {
       logger.error(`Skipping Google Cloud Pub/Sub for ${eventDetails}`)
+      logger.error(e)
     }
   }
 


### PR DESCRIPTION
Log the errors that cause webhook calls to fail.