### PR TITLE
[Event-cache] Fix IPFS cache loading condition

### DIFF
--- a/packages/event-cache/src/EventCache.js
+++ b/packages/event-cache/src/EventCache.js
@@ -34,7 +34,7 @@ const getPastEvents = memoize(
       instance.ipfsEventCache && // IPFS cache configured.
       !instance.loadedCache && // IPFS cache hasn't been loaded yet.
       (!instance.latestIndexedBlock || // Back-end does not support persistent storage. Always load cache at startup.
-        instance.latestIndexedBlock < instance.cacheMaxBlock) // Back-end supports indexing but indexed data is not as fresh as cache.
+        instance.latestIndexedBlock < instance.cacheMaxBlock) // Data indexed in back-end is not as fresh as cache.
     ) {
       try {
         debug('Loading event cache from IPFS', instance.ipfsEventCache)

--- a/packages/event-cache/src/EventCache.js
+++ b/packages/event-cache/src/EventCache.js
@@ -33,7 +33,7 @@ const getPastEvents = memoize(
     if (
       instance.ipfsEventCache && // IPFS cache configured.
       !instance.loadedCache && // IPFS cache hasn't been loaded yet.
-      (!instance.latestIndexedBlock || // Back-end does not support indexing. Always load cache.
+      (!instance.latestIndexedBlock || // Back-end does not support persistent storage. Always load cache at startup.
         instance.latestIndexedBlock < instance.cacheMaxBlock) // Back-end supports indexing but indexed data is not as fresh as cache.
     ) {
       try {


### PR DESCRIPTION
### Description:

Fix an issue where the listener, which is currently using in-memory storage, was not loading the IPFS cache at startup.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
