### PR TITLE
Fixes an event arg for getEvents

### DIFF
--- a/packages/graphql/src/resolvers/Offer.js
+++ b/packages/graphql/src/resolvers/Offer.js
@@ -33,7 +33,7 @@ export default {
     const { listingId, offerId } = parseId(offer.id)
     const events = await offer.contract.eventCache.getEvents({
       listingID: String(listingId),
-      offerID: offerId
+      offerID: String(offerId)
     })
     return events.map(event => {
       const ipfsHash = getIpfsHashFromBytes32(event.returnValues.ipfsHash)


### PR DESCRIPTION
### Description:

This was missed in my original PR #1975  Event args given to `EventCache.getEvents` should be strings since that's what's originally returned by web3.js.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
