### PR TITLE
Add services container dependacy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - ./packages/contracts/migrations:/app/packages/contracts/migrations
       # Core packages
       - ./packages/services/:/app/packages/services/
-      - ./packages/origin-js/:/app/packages/origin-js/
       - ./packages/graphql/:/app/packages/graphql/
       - ./packages/eventsource/:/app/packages/eventsource/
       - ./packages/event-cache/:/app/packages/event-cache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - ./packages/contracts/migrations:/app/packages/contracts/migrations
       # Core packages
       - ./packages/services/:/app/packages/services/
+      - ./packages/origin-js/:/app/packages/origin-js/
       - ./packages/graphql/:/app/packages/graphql/
       - ./packages/eventsource/:/app/packages/eventsource/
       - ./packages/event-cache/:/app/packages/event-cache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,6 @@ services:
       - ./infra/notifications/:/app/infra/notifications/
       - ./infra/growth/:/app/infra/growth/
       - ./infra/identity/:/app/infra/identity/
-      - ./infra/linking/:/app/infra/linking/
       # Exclude IPFS and blockchain data from @origin/services
       - /app/packages/services/data
       # Exclude all node_modules from the host
@@ -82,7 +81,6 @@ services:
       - /app/infra/notifications/node_modules/
       - /app/infra/growth/node_modules/
       - /app/infra/identity/node_modules/
-      - /app/infra/linking/node_modules/
     ports:
       # IPFS ports are exposed here for convenience but IPFS should be
       # interacted with via ipfs-proxy


### PR DESCRIPTION
### Description:
I needed to add `origin-js` folder mapping in order for services to run. I couldn't find it as a dependancy in `services/package.json` though

![Screenshot 2019-04-26 10 45 45](https://user-images.githubusercontent.com/579910/56795745-63d2c180-6811-11e9-9d36-0704fe222ba1.png)


### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
