### PR TITLE
fix cross-origin-error on Coinbase IOS wallet

### DIFF
--- a/dapps/marketplace/src/hoc/withFingerprint.js
+++ b/dapps/marketplace/src/hoc/withFingerprint.js
@@ -28,6 +28,7 @@ async function getFingerprintFn() {
     })
   })
 }
+
 const getFingerprint = memoize(getFingerprintFn)
 
 function withFingerprint(WrappedComponent) {
@@ -40,7 +41,7 @@ function withFingerprint(WrappedComponent) {
       let timeout, idleCallback
       if (cachedFingerprintData) {
         return
-      } else if (window.requestIdleCallback) {
+      } else if (typeof requestIdleCallback === 'function') {
         idleCallback = requestIdleCallback(async () =>
           setFingerprintData(await getFingerprint())
         )
@@ -52,7 +53,9 @@ function withFingerprint(WrappedComponent) {
       }
       return function cleanup() {
         clearTimeout(timeout)
-        cancelIdleCallback(idleCallback)
+        if (typeof cancelIdleCallback === 'function') {
+          cancelIdleCallback(idleCallback)
+        }
       }
     })
 


### PR DESCRIPTION
### Description:

One of the weirdest bugs to hunt down... the problem was that `cancelIdleCallback` is not defined in IOS's browser component in CoinBase and instead of throwing an error saying `cancelIdleCallback  is not defined` a `React cross-origin-error` was thrown. 

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
