### PR TITLE
add uuid as fingerprint data

### DIFF
--- a/dapps/marketplace/src/hoc/withFingerprint.js
+++ b/dapps/marketplace/src/hoc/withFingerprint.js
@@ -2,7 +2,10 @@ import React, { useState, useEffect } from 'react'
 import Fingerprint2 from 'fingerprintjs2'
 import memoize from 'lodash/memoize'
 
-let cachedFingerprintData
+import withWallet from './withWallet'
+
+let cachedFingerprintData, cachedUUID
+const uuidKey = 'rewards_uuid'
 
 const browserPropsWhitelist = [
   'language',
@@ -11,28 +14,60 @@ const browserPropsWhitelist = [
   'userAgent'
 ]
 
-async function getFingerprintFn() {
-  return await new Promise(resolve => {
-    Fingerprint2.get({}, components => {
-      const values = components.map(component => component.value)
-      const hash = `V1-${Fingerprint2.x64hash128(values.join(''), 31)}`
+function fetchFingerprint() {
+  return Fingerprint2.getPromise({}).then(components => {
+    const values = components.map(component => component.value)
+    const hash = `V1-${Fingerprint2.x64hash128(values.join(''), 31)}`
 
-      // Select the browser properties to export along with the fingerprint.
-      const browserProps = {}
-      components
-        .filter(x => browserPropsWhitelist.includes(x.key))
-        .forEach(x => (browserProps[x.key] = x.value))
-      cachedFingerprintData = { fingerprint: hash, ...browserProps }
-
-      resolve(cachedFingerprintData)
-    })
+    // Select the browser properties to export along with the fingerprint.
+    const browserProps = {}
+    components
+      .filter(x => browserPropsWhitelist.includes(x.key))
+      .forEach(x => (browserProps[x.key] = x.value))
+    cachedFingerprintData = { fingerprint: hash, ...browserProps }
   })
+}
+
+async function getLocalStorageUUID() {
+  const uuid = localStorage.getItem(uuidKey)
+  cachedUUID = uuid ? uuid : cachedUUID
+}
+
+async function getCookieUUID() {
+  const cookie = document.cookie
+    .split(';')
+    .filter(cookie => cookie.split('=')[0] === uuidKey)[0]
+
+  cachedUUID = cookie ? cookie.split('=')[1] : cachedUUID
+}
+
+async function storeUUID(uuid) {
+  localStorage.setItem(uuidKey, uuid)
+  document.cookie = `${uuidKey}=${uuid}; expires=18 Dec 2050 12:00:00 UTC`
+}
+
+async function getFingerprintFn(walletId) {
+  await Promise.all([
+    fetchFingerprint(),
+    getLocalStorageUUID(),
+    getCookieUUID()
+  ])
+
+  cachedUUID = cachedUUID === undefined ? walletId : cachedUUID
+
+  cachedFingerprintData.uuid = cachedUUID
+  storeUUID(cachedUUID)
+  return cachedFingerprintData
 }
 
 const getFingerprint = memoize(getFingerprintFn)
 
 function withFingerprint(WrappedComponent) {
   const WithFingerprint = props => {
+    if (!props.wallet) {
+      return ''
+    }
+
     const [fingerprintData, setFingerprintData] = useState(
       cachedFingerprintData
     )
@@ -43,11 +78,11 @@ function withFingerprint(WrappedComponent) {
         return
       } else if (typeof requestIdleCallback === 'function') {
         idleCallback = requestIdleCallback(async () =>
-          setFingerprintData(await getFingerprint())
+          setFingerprintData(await getFingerprint(props.wallet))
         )
       } else {
         timeout = setTimeout(
-          async () => setFingerprintData(await getFingerprint()),
+          async () => setFingerprintData(await getFingerprint(props.wallet)),
           500
         )
       }
@@ -61,7 +96,7 @@ function withFingerprint(WrappedComponent) {
 
     return <WrappedComponent {...props} fingerprintData={fingerprintData} />
   }
-  return WithFingerprint
+  return withWallet(WithFingerprint)
 }
 
 export default withFingerprint

--- a/dapps/marketplace/src/hoc/withFingerprint.js
+++ b/dapps/marketplace/src/hoc/withFingerprint.js
@@ -55,8 +55,10 @@ async function getFingerprintFn(walletId) {
 
   cachedUUID = cachedUUID === undefined ? walletId : cachedUUID
 
-  cachedFingerprintData.uuid = cachedUUID
-  storeUUID(cachedUUID)
+  if (cachedUUID) {
+    cachedFingerprintData.uuid = cachedUUID
+    storeUUID(cachedUUID)
+  }
   return cachedFingerprintData
 }
 
@@ -64,10 +66,6 @@ const getFingerprint = memoize(getFingerprintFn)
 
 function withFingerprint(WrappedComponent) {
   const WithFingerprint = props => {
-    if (!props.wallet) {
-      return ''
-    }
-
     const [fingerprintData, setFingerprintData] = useState(
       cachedFingerprintData
     )


### PR DESCRIPTION
### Description:

Create an UUID and populate it with first `walletId` that tries to Enrol into growth (or use `withFingerprint` hoc). Store that UUID in `localStorage` and a `cookie`

In future it would be even more resilient storing this into IndexedDB, but that is not a part of this PR. 

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
