### PR TITLE
Add support for multiple custom price ranges

### DIFF
--- a/packages/graphql/src/utils/AvailabilityCalculator.js
+++ b/packages/graphql/src/utils/AvailabilityCalculator.js
@@ -43,7 +43,7 @@ class AvailabilityCalculator {
     }
 
     const modifiedSlots = []
-    let bookedRange, unavailableRange, customPriceRange
+    let bookedRange, unavailableRange
     const newBooked = [],
       newUnavailable = [],
       newCustomPrice = []

--- a/packages/graphql/src/utils/AvailabilityCalculator.js
+++ b/packages/graphql/src/utils/AvailabilityCalculator.js
@@ -92,16 +92,7 @@ class AvailabilityCalculator {
       }
 
       if (slot.customPrice) {
-        if (customPriceRange) {
-          customPriceRange = `${customPriceRange.split('/')[0]}/${slot.date}:${
-            slot.price
-          }`
-        } else {
-          customPriceRange = `${slot.date}/${slot.date}:${slot.price}`
-        }
-      } else if (customPriceRange) {
-        newCustomPrice.push(customPriceRange)
-        customPriceRange = ''
+        newCustomPrice.push(`${slot.date}/${slot.date}:${slot.price}`)
       }
 
       return slot

--- a/packages/graphql/test/availability-calculator.js
+++ b/packages/graphql/test/availability-calculator.js
@@ -82,4 +82,140 @@ describe('Availability Calculator', function() {
       }
     ])
   })
+
+  it('should allow a custom price to be set to a range of dates', function() {
+    const dates = instance.update(`${year}-02-01/${year}-02-04`, 'available', '1.5')
+    assert.deepEqual(dates, [
+      {
+        date: `${year}-02-01`,
+        unavailable: false,
+        booked: false,
+        price: '1.5',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-02`,
+        unavailable: false,
+        booked: false,
+        price: '1.5',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-03`,
+        unavailable: false,
+        booked: false,
+        price: '1.5',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-04`,
+        unavailable: false,
+        booked: false,
+        price: '1.5',
+        customPrice: true
+      }
+    ])
+  })
+
+  it('should allow different custom prices to be set over multiple range of dates', function() {
+    const customPriceRange1 = instance.update(`${year}-02-02/${year}-02-04`, 'available', '1')
+    assert.deepEqual(customPriceRange1, [
+      {
+        date: `${year}-02-02`,
+        unavailable: false,
+        booked: false,
+        price: '1',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-03`,
+        unavailable: false,
+        booked: false,
+        price: '1',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-04`,
+        unavailable: false,
+        booked: false,
+        price: '1',
+        customPrice: true
+      }
+    ])
+
+    const customPriceRange2 = instance.update(`${year}-02-01/${year}-02-02`, 'available', '0.85')
+    assert.deepEqual(customPriceRange2, [
+      {
+        date: `${year}-02-01`,
+        unavailable: false,
+        booked: false,
+        price: '0.85',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-02`,
+        unavailable: false,
+        booked: false,
+        price: '0.85',
+        customPrice: true
+      }
+    ])
+
+    const customPriceRange3 = instance.update(`${year}-02-04/${year}-02-05`, 'available', '1.25')
+    assert.deepEqual(customPriceRange3, [
+      {
+        date: `${year}-02-04`,
+        unavailable: false,
+        booked: false,
+        price: '1.25',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-05`,
+        unavailable: false,
+        booked: false,
+        price: '1.25',
+        customPrice: true
+      }
+    ])
+
+    const dates = instance.getAvailability(`${year}-02-01`, `${year}-02-05`)
+    assert.deepEqual(dates, [
+      {
+        date: `${year}-02-01`,
+        unavailable: false,
+        booked: false,
+        price: '0.85',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-02`,
+        unavailable: false,
+        booked: false,
+        price: '0.85',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-03`,
+        unavailable: false,
+        booked: false,
+        price: '1',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-04`,
+        unavailable: false,
+        booked: false,
+        price: '1.25',
+        customPrice: true
+      },
+      {
+        date: `${year}-02-05`,
+        unavailable: false,
+        booked: false,
+        price: '1.25',
+        customPrice: true
+      }
+    ])
+  })
 })

--- a/packages/graphql/test/availability-calculator.js
+++ b/packages/graphql/test/availability-calculator.js
@@ -84,7 +84,11 @@ describe('Availability Calculator', function() {
   })
 
   it('should allow a custom price to be set to a range of dates', function() {
-    const dates = instance.update(`${year}-02-01/${year}-02-04`, 'available', '1.5')
+    const dates = instance.update(
+      `${year}-02-01/${year}-02-04`,
+      'available',
+      '1.5'
+    )
     assert.deepEqual(dates, [
       {
         date: `${year}-02-01`,
@@ -118,7 +122,11 @@ describe('Availability Calculator', function() {
   })
 
   it('should allow different custom prices to be set over multiple range of dates', function() {
-    const customPriceRange1 = instance.update(`${year}-02-02/${year}-02-04`, 'available', '1')
+    const customPriceRange1 = instance.update(
+      `${year}-02-02/${year}-02-04`,
+      'available',
+      '1'
+    )
     assert.deepEqual(customPriceRange1, [
       {
         date: `${year}-02-02`,
@@ -143,7 +151,11 @@ describe('Availability Calculator', function() {
       }
     ])
 
-    const customPriceRange2 = instance.update(`${year}-02-01/${year}-02-02`, 'available', '0.85')
+    const customPriceRange2 = instance.update(
+      `${year}-02-01/${year}-02-02`,
+      'available',
+      '0.85'
+    )
     assert.deepEqual(customPriceRange2, [
       {
         date: `${year}-02-01`,
@@ -161,7 +173,11 @@ describe('Availability Calculator', function() {
       }
     ])
 
-    const customPriceRange3 = instance.update(`${year}-02-04/${year}-02-05`, 'available', '1.25')
+    const customPriceRange3 = instance.update(
+      `${year}-02-04/${year}-02-05`,
+      'available',
+      '1.25'
+    )
     assert.deepEqual(customPriceRange3, [
       {
         date: `${year}-02-04`,


### PR DESCRIPTION
Fixes #1735.

For some reasons, the existing code was allowing only one price to be set for all custom ranges. That caused the issue.