### PR TITLE
Lowering event listener's assumptions

### DIFF
--- a/infra/discovery/src/listener/listener.js
+++ b/infra/discovery/src/listener/listener.js
@@ -201,10 +201,17 @@ async function main() {
 
     // Record state of processing
     logger.debug(`Updating last processed block to ${toBlock}`)
-    await setLastBlock(context.config, toBlock)
-    processedToBlock = toBlock
+    /**
+     * Don't assume it's the latest block known above, but use the one from
+     * event-cache
+     */
+    processedToBlock = Math.min(
+      contractsContext.marketplace.eventCache.lastQueriedBlock,
+      contractsContext.identityEvents.eventCache.lastQueriedBlock
+    )
+    await setLastBlock(context.config, processedToBlock)
     if (context.config.enableMetrics) {
-      blockGauge.set(toBlock)
+      blockGauge.set(processedToBlock)
     }
   } while (await nextTick())
 }


### PR DESCRIPTION
### Description:

Make sure the event-listener uses the latest processed block for `processedToBlock` instead of assuming the latest block number it requested is the same that event-cache gets.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
