### PR TITLE
fixes problem where lastIndexedBlock was trailing

### DIFF
--- a/packages/event-cache/src/EventCache.js
+++ b/packages/event-cache/src/EventCache.js
@@ -237,7 +237,10 @@ class EventCache {
       return
     }
 
-    this.latestIndexedBlock = await this.backend.getLatestBlock()
+    // Set if missing
+    if (this.latestIndexedBlock === 0) {
+      this.latestIndexedBlock = await this.backend.getLatestBlock()
+    }
 
     /**
      * Base fromBlock on the latest block number that had an event and was added
@@ -254,6 +257,9 @@ class EventCache {
     }
 
     await getPastEvents(this, fromBlock, toBlock, this.batchSize)
+
+    // Update latestIndexedBlock
+    this.latestIndexedBlock = await this.backend.getLatestBlock()
   }
 
   /**


### PR DESCRIPTION
### Description:

`lastIndexedBlock` was trailing with the block from the last getPastEvents request instead of being set after.  Since listener used this, it was reprocessing past events back to the previous request block number.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
