### PR TITLE
async and non-async function mix issue

### DIFF
--- a/packages/event-cache/src/EventCache.js
+++ b/packages/event-cache/src/EventCache.js
@@ -312,8 +312,8 @@ class EventCache {
    * Returns the latest block number known by the backend
    * @returns {number} The latest known block number
    */
-  getBlockNumber() {
-    return this.backend.getLatestBlock()
+  async getBlockNumber() {
+    return await this.backend.getLatestBlock()
   }
 
   /**

--- a/packages/event-cache/src/backends/AbstractBackend.js
+++ b/packages/event-cache/src/backends/AbstractBackend.js
@@ -16,7 +16,7 @@ class AbstractBackend {
    * Returns the latest block number known by the backend
    * @returns {number} The latest known block number
    */
-  getLatestBlock() {
+  async getLatestBlock() {
     return this.latestBlock
   }
 

--- a/packages/eventsource/src/index.js
+++ b/packages/eventsource/src/index.js
@@ -376,7 +376,7 @@ class OriginEventSource {
 
   async _getOffer(listing, listingId, offerId, blockNumber) {
     if (blockNumber === undefined) {
-      blockNumber = this.contract.eventCache.getBlockNumber()
+      blockNumber = await this.contract.eventCache.getBlockNumber()
     }
     const cacheKey = `${listingId}-${offerId}-${blockNumber}`
     if (this.offerCache[cacheKey]) {

--- a/packages/graphql/test/index.js
+++ b/packages/graphql/test/index.js
@@ -122,7 +122,7 @@ describe('Marketplace', function() {
     })
 
     it('should retrieve the listing as of a specfic block', async function() {
-      const blockNumber = contracts.marketplace.eventCache.getBlockNumber()
+      const blockNumber = await contracts.marketplace.eventCache.getBlockNumber()
       const listingId = `999-000-0-${blockNumber}`
       const res = await client.query({
         query: queries.GetListing,


### PR DESCRIPTION
### Description:

`getLatestBlock` was changed to async for IndexedDBBackend but was not updated in AbstractBackend, which is used for the other backends(including memory, which was used for listener).  Not sure of JS's behavior in this case for certain, but I'm thinking `await`ing on a synchronous function is probably a bad idea.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
