### PR TITLE
Close dropdown when rewards icon is clicked

### DIFF
--- a/dapps/marketplace/src/components/Balances.js
+++ b/dapps/marketplace/src/components/Balances.js
@@ -6,7 +6,7 @@ import Price from 'components/Price'
 import withEthBalance from 'hoc/withEthBalance'
 import withEnrolmentModal from 'pages/growth/WithEnrolmentModal'
 
-const Balances = ({ ethBalance, account }) => {
+const Balances = ({ ethBalance, account, onClose }) => {
   const EnrollButton = withEnrolmentModal('button')
   const enableGrowth = process.env.ENABLE_GROWTH === 'true'
 
@@ -53,7 +53,7 @@ const Balances = ({ ethBalance, account }) => {
           </div>
         </div>
         {!enableGrowth ? null : (
-          <EnrollButton className="btn get-ogn d-flex" skipjoincampaign="false">
+          <EnrollButton className="btn get-ogn d-flex" skipjoincampaign="false" onClick={onClose}>
             <img src="images/growth/blue-add-icon.svg" />
           </EnrollButton>
         )}

--- a/dapps/marketplace/src/components/Balances.js
+++ b/dapps/marketplace/src/components/Balances.js
@@ -53,7 +53,11 @@ const Balances = ({ ethBalance, account, onClose }) => {
           </div>
         </div>
         {!enableGrowth ? null : (
-          <EnrollButton className="btn get-ogn d-flex" skipjoincampaign="false" onClick={onClose}>
+          <EnrollButton
+            className="btn get-ogn d-flex"
+            skipjoincampaign="false"
+            onClick={onClose}
+          >
             <img src="images/growth/blue-add-icon.svg" />
           </EnrollButton>
         )}

--- a/dapps/marketplace/src/pages/nav/Profile.js
+++ b/dapps/marketplace/src/pages/nav/Profile.js
@@ -91,7 +91,7 @@ const ProfileDropdown = ({ data, onClose }) => {
           <Identicon size={50} address={checksumAddress} />
         </div>
       </div>
-      <Balances account={id} />
+      <Balances account={id} onClose={onClose} />
       <Identity id={id} />
       <Link onClick={() => onClose()} to="/profile">
         <fbt desc="nav.profile.editProfile">Edit Profile</fbt>


### PR DESCRIPTION
### Description:

This attempts to solve two confusing states that were reported by @jonhearty. First is when a user clicks the ➕ to sign up for Origin Rewards and is presented with a full-screen modal. Once the process is completed and the modal closes, the dropdown remains. This causes the user to be unaware of the component state change behind the dropdown. The second occurs if the user clicks the ➕ again after having already navigated to the campaign dashboard. Since the ➕ effectively links to that route, there is no feedback provided by the interface.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything 🤷‍♂
- [ ] ~[Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~
- [ ] ~If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~
- [ ] ~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~