### PR TITLE
Fix to debug and disables graphql cache for the listener

### DIFF
--- a/infra/discovery/src/listener/handler.js
+++ b/infra/discovery/src/listener/handler.js
@@ -1,5 +1,6 @@
 const esmImport = require('esm')(module)
-const graphqlClient = esmImport('@origin/graphql').default
+const ApolloClient = esmImport('apollo-client').default
+const { link, cache } = esmImport('@origin/graphql')
 
 const logger = require('./logger')
 const { withRetrys } = require('./utils')
@@ -33,6 +34,20 @@ const EVENT_TO_HANDLER_MAP = {
   IdentityUpdated: IdentityEventHandler
   // TODO(franck): handle IdentityDeleted
 }
+
+// Initializing a new ApolloClient so cache can be disabled
+const graphqlClient = new ApolloClient({
+  link,
+  cache,
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache'
+    },
+    query: {
+      fetchPolicy: 'no-cache'
+    }
+  }
+})
 
 /**
  *  Main entry point for processing events.

--- a/infra/discovery/src/listener/handler_identity.js
+++ b/infra/discovery/src/listener/handler_identity.js
@@ -305,6 +305,21 @@ class IdentityEventHandler {
     }
 
     if (event.returnValues.ipfsHash) {
+      if (event.returnValues.ipfsHash !== identity.ipfsHash) {
+        /**
+         * GraphQL and the listener use two different instances of contracts,
+         * with two different instances of EventCache.  It's possible, this is
+         * also a JSON-RPC node sync issue...  They also use two different
+         * EC queries (allEvents() vs getEvents({ account: '0x...' })), which
+         * has a slight chance of causing this.  Be on the lookout for the
+         * following log message:
+         */
+        logger.warn(
+          `GraphQL IPFS hash does not match event IPFS hash. This is probably \
+           a bug! (event: ${event.returnValues.ipfsHash}, GraphQL: \
+           ${identity.ipfsHash}`
+        )
+      }
       identity.ipfsHash = bytes32ToIpfsHash(event.returnValues.ipfsHash)
     }
 

--- a/infra/discovery/src/listener/queries/Identity.js
+++ b/infra/discovery/src/listener/queries/Identity.js
@@ -20,6 +20,7 @@ const identityQuery = gql`
           phoneVerified
           emailVerified
           googleVerified
+          ipfsHash
         }
       }
     }

--- a/packages/graphql/src/index.js
+++ b/packages/graphql/src/index.js
@@ -15,3 +15,5 @@ if (typeof window !== 'undefined') {
 }
 
 export default client
+
+export { link, cache }


### PR DESCRIPTION
### Description:

- fixes an issue with the debug statment in PR #2225, due to missing data in the GraphQL query
- Disables the GraphQL cache for the discovery listener handler because it's not strictly necessary here

This *might* resolve ||don't auto close GitHub|| #2163 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
