### PR TITLE
[Listener] Fix avatarUrl persistence in DB

### DIFF
--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -138,7 +138,7 @@ export function identity({ id, ipfsHash }) {
       try {
         const avatarBinary = dataURItoBinary(identity.avatar)
         identity.avatarUrl = await IpfsHash.of(avatarBinary.buffer)
-      } catch (e) {
+      } catch {
         // If we can't translate an old avatar for any reason, don't worry about it.
         // We've already tested the backfill script, and not seen a problem
         // for all valid avatar images.

--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -130,11 +130,15 @@ export function identity({ id, ipfsHash }) {
       .join(' ')
 
     // Make old style embedded avatars access by their IPFS hash.
-    if (identity.avatarUrl === undefined && identity.avatar !== undefined) {
+    if (
+      identity.avatarUrl === undefined &&
+      identity.avatar !== undefined &&
+      identity.avatar.length > 0
+    ) {
       try {
         const avatarBinary = dataURItoBinary(identity.avatar)
-        identity.avatarUrl = await IpfsHash.of(Buffer.from(avatarBinary.buffer))
-      } catch {
+        identity.avatarUrl = await IpfsHash.of(avatarBinary.buffer)
+      } catch (e) {
         // If we can't translate an old avatar for any reason, don't worry about it.
         // We've already tested the backfill script, and not seen a problem
         // for all valid avatar images.
@@ -158,18 +162,17 @@ export function identity({ id, ipfsHash }) {
   })
 }
 
+/**
+ * Extracts binary data and mime type from a data URI.
+ *
+ * @param dataURI
+ * @returns {{buffer: Buffer, mimeType: string}}
+ */
 function dataURItoBinary(dataURI) {
-  // From https://stackoverflow.com/questions/12168909/blob-from-dataurl
   const parts = dataURI.split(',')
-  const byteString = atob(parts[1])
-  const mimeString = parts[0].split(':')[1].split(';')[0]
-  const ab = new ArrayBuffer(byteString.length)
-  const ia = new Uint8Array(ab)
-  for (let i = 0; i < byteString.length; i++) {
-    ia[i] = byteString.charCodeAt(i)
-  }
-  const blob = new Blob([ab], { type: mimeString })
-  return { blob, buffer: ab }
+  const mimeType = parts[0].split(':')[1].split(';')[0]
+  const buffer = new Buffer(parts[1], 'base64')
+  return { buffer, mimeType }
 }
 
 export async function identities(


### PR DESCRIPTION
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/guides/getting_started/contributing.html)

### Description:

The avatarUrl column was not populated by the listener because the graphql code handling avatar binary was calling atob which is not supported by node. Replaced with calls to Buffer which is supported in node and is magically converted to something that works in the browser by babel/polyfill.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
