### PR TITLE
Fix to ensure latest events available on initial load

### DIFF
--- a/packages/event-cache/src/EventCache.js
+++ b/packages/event-cache/src/EventCache.js
@@ -74,8 +74,6 @@ const getPastEvents = memoize(
     const numBlocks = toBlock - fromBlock + 1
     debug(`Get ${numBlocks} blocks in ${requests.length} requests`)
 
-    instance.lastQueriedBlock = toBlock
-
     if (!numBlocks) return
 
     const newEvents = flattenDeep(await Promise.all(requests))
@@ -89,6 +87,8 @@ const getPastEvents = memoize(
         debug('Error adding new events to backend', e)
       }
     }
+
+    instance.lastQueriedBlock = toBlock
   },
   (...args) => `${args[0].contract._address}-${args[1]}-${args[2]}`
 )


### PR DESCRIPTION
When IndexedDB is cleared out and you refresh a local instance of the dapp, events are not guaranteed to be loaded before they are returned from event-cache. This change attempts to fix it... really hope it doesn't have any unintended side effects!