### PR TITLE
fixes clean-package-locks.sh for new package structure

### DIFF
--- a/scripts/clean-package-locks.sh
+++ b/scripts/clean-package-locks.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-find . -maxdepth 2 -name package-lock.json -type f -delete
+find . -maxdepth 3 -name package-lock.json -type f -delete


### PR DESCRIPTION
I assume this changed with the package restructuring.  Tested and works as expected.