### PR TITLE
App Display Name

### DIFF
--- a/mobile/ios/OriginCatcher/Info.plist
+++ b/mobile/ios/OriginCatcher/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>Origin Wallet</string>
+	<string>Origin Marketplace</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -31,8 +31,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>2</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>We will not be using the location</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -46,26 +46,28 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSFaceIDUsageDescription</key>
-	<string>Enabling Face ID allows you quick and secure access to your account</string>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>We will not be using music</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>We would like to use your photos to add photos of items you want to list for sale</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>We would like to add photos to your library of items you list for sale</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>We will not be using bluetooth</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>We will not be using the calendar</string>
 	<key>NSCameraUsageDescription</key>
 	<string>We would like to use your camera to photograph items you want to list for sale</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Enabling Face ID allows you quick and secure access to your account</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>We will not be using the location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>We will not be using the location</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>We will not be using microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>We will not be using motion</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>We would like to add photos to your library of items you list for sale</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>We would like to use your photos to add photos of items you want to list for sale</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>We will not be using speech recognition</string>
 	<key>UIAppFonts</key>
@@ -117,7 +119,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>LSApplicationQueriesSchemes</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This intends to change the display name under the app icon from "Origin Wallet" to "Origin Marketplace". I made the change using Xcode, which seems to have produced some other side effects in the `.plist`. I also wasn't able to test because of local build problems.