### PR TITLE
[dApp] Fix Avatar display bug.

### DIFF
--- a/dapps/marketplace/src/components/Avatar.js
+++ b/dapps/marketplace/src/components/Avatar.js
@@ -6,6 +6,7 @@ const Avatar = ({
   size,
   avatar,
   avatarUrl,
+  avatarUrlExpanded,
   profile,
   config,
   className,
@@ -16,11 +17,19 @@ const Avatar = ({
     props.style = { width: size || 50, paddingTop: size || 50 }
   }
   let httpAvatar = undefined
-  if (avatarUrl && config) {
+
+  // If we have a profile, use its avatarUrl and avatarUrlExpanded if needed
+  if (profile) {
+    avatarUrl = avatarUrl || profile.avatarUrl
+    avatarUrlExpanded = avatarUrlExpanded || profile.avatarUrlExpanded
+  }
+
+  // Try expanded url first, since we don't have to wait to get a config object
+  if (avatarUrlExpanded) {
+    httpAvatar = avatarUrlExpanded
+  } else if (avatarUrl && config) {
     const { ipfsGateway } = config
     httpAvatar = makeGatewayUrl(ipfsGateway, avatarUrl)
-  } else if (profile && profile.avatarUrlExpanded) {
-    httpAvatar = profile.avatarUrlExpanded
   } else if (avatar) {
     httpAvatar = avatar
   }

--- a/dapps/marketplace/src/utils/makeGatewayUrl.js
+++ b/dapps/marketplace/src/utils/makeGatewayUrl.js
@@ -2,16 +2,22 @@
  * Takes an IPFS hash url (for example: ipfs://QmUwefhweuf...12322a) and
  * returns a url to that resource on the gateway.
  * Ensures that the IPFS hash does not contain anything evil and is the correct length.
+ *
+ * Also supports pure IPFS hash urls with no protocol, such as QmUwefh...
+ *
  * @param {string} gateway
  * @param {string} ipfsUrl
  * @returns {string}
  */
 export default function makeGatewayUrl(gateway, ipfsUrl) {
+  if (!gateway) {
+    return
+  }
   if (!ipfsUrl) {
     return
   }
-  const match = ipfsUrl.match(/^ipfs:\/\/([A-Za-z0-9]{46})$/)
+  const match = ipfsUrl.match(/^(ipfs:\/\/)?([A-Za-z0-9]{46})$/)
   if (match) {
-    return `${gateway}/ipfs/${match[1]}`
+    return `${gateway}/ipfs/${match[2]}`
   }
 }


### PR DESCRIPTION
If a profile was passed in, and did non contain an avatarUrlExpanded, then it would not show the avatar. It should have fallen back to using the profile’s avatarUrl.

I’ve cleaned up the code so that this condition no longer exists.