### PR TITLE
Consistent AvatarUrls

### DIFF
--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -149,7 +149,7 @@ export function identity({ id, ipfsHash }) {
     // We have 149 identity.avatarUrls missing the ipfs:// protocol.
     // Prepend ipfs:// if needed.
     if (
-      identity.avatarUrl.length == 46 &&
+      identity.avatarUrl.length === 46 &&
       identity.avatarUrl.indexOf('://') === -1
     ) {
       identity.avatarUrl = 'ipfs://' + identity.avatarUrl

--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -137,8 +137,8 @@ export function identity({ id, ipfsHash }) {
     ) {
       try {
         const avatarBinary = dataURItoBinary(identity.avatar)
-        identity.avatarUrl =
-          'ifps://' + (await IpfsHash.of(avatarBinary.buffer))
+        const avatarHash = await IpfsHash.of(avatarBinary.buffer)
+        identity.avatarUrl = 'ifps://' + avatarHash
       } catch {
         // If we can't translate an old avatar for any reason, don't worry about it.
         // We've already tested the backfill script, and not seen a problem

--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -137,12 +137,22 @@ export function identity({ id, ipfsHash }) {
     ) {
       try {
         const avatarBinary = dataURItoBinary(identity.avatar)
-        identity.avatarUrl = await IpfsHash.of(avatarBinary.buffer)
+        identity.avatarUrl =
+          'ifps://' + (await IpfsHash.of(avatarBinary.buffer))
       } catch {
         // If we can't translate an old avatar for any reason, don't worry about it.
         // We've already tested the backfill script, and not seen a problem
         // for all valid avatar images.
       }
+    }
+
+    // We have 149 identity.avatarUrls missing the ipfs:// protocol.
+    // Prepend ipfs:// if needed.
+    if (
+      identity.avatarUrl.length == 46 &&
+      identity.avatarUrl.indexOf('://') === -1
+    ) {
+      identity.avatarUrl = 'ipfs://' + identity.avatarUrl
     }
 
     if (identity.avatarUrl) {


### PR DESCRIPTION
I had overlooked that automatically "upgraded" `avatar` to `avatarUrl` fields were being set from GraphQL without an IPFS protocol in the URI (eg they looked like 'QmS4...', rather than 'ipfs://QmS4...'.) This is fixed in this PR and the correct format is now returned.

However, we also have 149 cases where a user profile was edited with an old style avatar data field and no change was made to the avatar image. If this happened, then the "ipfs://"-less url would be saved into the profile JSON. I've added a check to GraphQL that will fix data up, so that everything coming from out of the GraphQL avatarUrl field will be correct and consistent.

Fixes #2322