### PR TITLE
Fix for error when identity has no avatar

### DIFF
--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -149,6 +149,7 @@ export function identity({ id, ipfsHash }) {
     // We have 149 identity.avatarUrls missing the ipfs:// protocol.
     // Prepend ipfs:// if needed.
     if (
+      identity.avatarUrl &&
       identity.avatarUrl.length === 46 &&
       identity.avatarUrl.indexOf('://') === -1
     ) {


### PR DESCRIPTION
Fix foolish crashing bug for when an identity has no avatar. No idea how I missed this, must have tested on only identities with avatars. 
