### PR TITLE
fixes Mutation refetch on Settings page in marketplace dapp.

### DIFF
--- a/dapps/marketplace/src/pages/settings/Settings.js
+++ b/dapps/marketplace/src/pages/settings/Settings.js
@@ -6,6 +6,7 @@ import { fbt } from 'fbt-runtime'
 import { formInput } from 'utils/formHelpers'
 import withConfig from 'hoc/withConfig'
 import SetNetwork from 'mutations/SetNetwork'
+import ConfigQuery from 'queries/Config'
 import LocaleDropdown from 'components/LocaleDropdown'
 import CurrencyDropdown from 'components/CurrencyDropdown'
 import DocumentTitle from 'components/DocumentTitle'
@@ -89,7 +90,16 @@ class Settings extends Component {
     const { locale, onLocale, currency, onCurrency } = this.props
 
     return (
-      <Mutation mutation={SetNetwork} refetchQueries="Config">
+      <Mutation
+        mutation={SetNetwork}
+        refetchQueries={() => {
+          return [
+            {
+              query: ConfigQuery
+            }
+          ]
+        }}
+      >
         {setNetwork => (
           <div className="container settings">
             <DocumentTitle


### PR DESCRIPTION
### Description:

This fixes the Mutation refetch on the settings page.  It was changed to a string in 8d548ba96af932a29ca0f82f36ba49b12f9f8f2c for some reason, but [the Apollo docs don't really explain what the string option is for or how it works](https://www.apollographql.com/docs/react/essentials/mutations#props).  @Nick?

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
