### PR TITLE
Some caching tinkering

### DIFF
--- a/packages/eventsource/src/index.js
+++ b/packages/eventsource/src/index.js
@@ -80,8 +80,7 @@ class OriginEventSource {
     try {
       listing = await getListing(this.contract, listingId)
     } catch (e) {
-      console.log(`No such listing on contract ${listingId}`)
-      return null
+      throw new Error(`No such listing on contract ${listingId}`)
     }
 
     const events = await this.contract.eventCache.getEvents({

--- a/packages/graphql/src/resolvers/Listing.js
+++ b/packages/graphql/src/resolvers/Listing.js
@@ -9,7 +9,8 @@ export default {
   __resolveType() {
     return 'UnitListing'
   },
-  events: async listing => {
+  events: async (listing, args, context, info) => {
+    info.cacheControl.setCacheHint({ maxAge: 15 })
     const { listingId } = parseId(listing.id)
     return await listing.contract.eventCache.getEvents({
       listingID: String(listingId)


### PR DESCRIPTION
### Description:

- Sets graphql listing cache to 15s(block time)
- Throws an error on listing not found in eventsource

Ref: #2346 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
