### PR TITLE
Lowers graphql cache to 15s for Marketplace.listing resolver

### DIFF
--- a/packages/graphql/src/resolvers/Marketplace.js
+++ b/packages/graphql/src/resolvers/Marketplace.js
@@ -17,7 +17,10 @@ export default {
     return contract.methods.totalListings().call()
   },
 
-  listing: async (contract, args) => {
+  listing: async (contract, args, context, info) => {
+    if (info && info.cacheControl) {
+      info.cacheControl.setCacheHint({ maxAge: 15 })
+    }
     const { listingId, blockNumber } = parseId(args.id)
     return await contracts.eventSource.getListing(listingId, blockNumber)
   },


### PR DESCRIPTION
### Description:

Changing graphql server caching to 15s in the Marketplace.listing resolver.

Ref #2346

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
