### PR TITLE
Adds WEB3_PROVIDER_URL env var

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -26,3 +26,4 @@ A GraphiQL demo is available [here](https://www.originadm.in/#/explorer)
 - `USE_METRICS_PROVIDER` [`"true"`, `undefined`] - Configure and use the Web3 provider that displays general metrics about usage
 - `APOLLO_METRICS_API_KEY` - API key to use for Apollo metrics.
 - `DISABLE_CACHE` - Disable caching (currently only caching in the `eventsource` package)
+- `PROVIDER_URL` - An explicit URL to use for a Web3 JSON-RPC provider

--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -138,7 +138,10 @@ export function setNetwork(net, customConfig) {
   }
   clearInterval(blockInterval)
 
-  web3 = applyWeb3Hack(new Web3(config.provider))
+  const provider = process.env.WEB3_PROVIDER_URL
+    ? process.env.WEB3_PROVIDER_URL
+    : config.provider
+  web3 = applyWeb3Hack(new Web3(provider))
 
   if (config.useMetricsProvider) {
     addMetricsProvider(web3, {

--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -138,8 +138,8 @@ export function setNetwork(net, customConfig) {
   }
   clearInterval(blockInterval)
 
-  const provider = process.env.WEB3_PROVIDER_URL
-    ? process.env.WEB3_PROVIDER_URL
+  const provider = process.env.PROVIDER_URL
+    ? process.env.PROVIDER_URL
     : config.provider
   web3 = applyWeb3Hack(new Web3(provider))
 


### PR DESCRIPTION
### Description:

Adds the ability to specify an explicit web3 JSON-RPC provider URL with `WEB3_PROVIDER_URL`

This an okay location to do it?  Wanted to keep the config files clean.  Could probably use `customConfig` for `setNetwork()` as well and do it just for graphql server?

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
