### PR TITLE
Simple PR for a cleaner error message in Marketplace event handler

### DIFF
--- a/infra/discovery/src/listener/handler_marketplace.js
+++ b/infra/discovery/src/listener/handler_marketplace.js
@@ -284,6 +284,10 @@ class MarketplaceEventHandler {
 
     const details = await this._getDetails(block, event)
 
+    if (!details) {
+      throw new Error('Unable to find listing or offer details')
+    }
+
     // On both listing and offer event, index the listing.
     // Notes:
     //  - Reason for also re-indexing on offer event is that the listing data includes


### PR DESCRIPTION
### Description:

adds a defensive check with better/clearer error for when a listing/offer cannot be fetched.  The error shown in #2390 doesn't really explain anything and is more or less a side-effect.

Ref #2390

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
