### PR TITLE
Fixes issue with Alchemy and web3-provider-engine's eth_getBlockByNumber requests

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -58,7 +58,7 @@
     "rlp": "^2.2.2",
     "subscriptions-transport-ws": "^0.9.16",
     "web3": "1.0.0-beta.34",
-    "web3-provider-engine": "mikeshultz/web3-provider-engine#too-many-requests"
+    "web3-provider-engine": "mikeshultz/web3-provider-engine#origin-protocol"
   },
   "prettier": {
     "semi": false,

--- a/packages/graphql/src/utils/metricsProvider.js
+++ b/packages/graphql/src/utils/metricsProvider.js
@@ -1,3 +1,4 @@
+import EthBlockTracker from 'eth-block-tracker'
 import ProviderEngine from 'web3-provider-engine'
 import SubProvider from 'web3-provider-engine/subproviders/subprovider'
 import RpcSubprovider from 'web3-provider-engine/subproviders/rpc'
@@ -144,8 +145,25 @@ function convertWeb3Provider(provider) {
  * @returns {object} - An initialized web3 instance with the altered providers
  */
 function addMetricsProvider(web3Inst, options) {
-  const engine = new ProviderEngine()
+
+  // Our new shiny subproviders
+  const convertedProvider = convertWeb3Provider(web3Inst.currentProvider)
   const metricsProvider = new MetricsProvider(options)
+
+  /**
+   * The blockTracker seems be a default function of web3-provider-engine, but
+   * it's not completely clear if it's necessary(emits the 'latest' event).  It
+   * has an internal currentBlock tracker.  Perhaps we should bolt onto it.
+   * Right now, we're specifically initializing the block tracker so we can
+   * disable the `skipConfig` parameter that it sends which breaks Alchemy
+   */
+  const engine = new ProviderEngine({
+    blockTracker: new EthBlockTracker({
+      provider: convertedProvider,
+      pollingInterval: 15000,
+      setSkipCacheFlag: false,
+    })
+  })
 
   /**
    * IF YOU REMOVE THIS, EVERYTHING WITH EXPLODE
@@ -163,7 +181,7 @@ function addMetricsProvider(web3Inst, options) {
   engine.setMaxListeners(50)
 
   engine.addProvider(metricsProvider)
-  engine.addProvider(convertWeb3Provider(web3Inst.currentProvider))
+  engine.addProvider(convertedProvider)
 
   web3Inst.setProvider(engine)
 

--- a/packages/graphql/src/utils/metricsProvider.js
+++ b/packages/graphql/src/utils/metricsProvider.js
@@ -145,7 +145,6 @@ function convertWeb3Provider(provider) {
  * @returns {object} - An initialized web3 instance with the altered providers
  */
 function addMetricsProvider(web3Inst, options) {
-
   // Our new shiny subproviders
   const convertedProvider = convertWeb3Provider(web3Inst.currentProvider)
   const metricsProvider = new MetricsProvider(options)
@@ -161,7 +160,7 @@ function addMetricsProvider(web3Inst, options) {
     blockTracker: new EthBlockTracker({
       provider: convertedProvider,
       pollingInterval: 15000,
-      setSkipCacheFlag: false,
+      setSkipCacheFlag: false
     })
   })
 

--- a/packages/graphql/src/utils/metricsProvider.js
+++ b/packages/graphql/src/utils/metricsProvider.js
@@ -1,4 +1,3 @@
-import EthBlockTracker from 'eth-block-tracker'
 import ProviderEngine from 'web3-provider-engine'
 import SubProvider from 'web3-provider-engine/subproviders/subprovider'
 import RpcSubprovider from 'web3-provider-engine/subproviders/rpc'
@@ -156,13 +155,7 @@ function addMetricsProvider(web3Inst, options) {
    * Right now, we're specifically initializing the block tracker so we can
    * disable the `skipConfig` parameter that it sends which breaks Alchemy
    */
-  const engine = new ProviderEngine({
-    blockTracker: new EthBlockTracker({
-      provider: convertedProvider,
-      pollingInterval: 15000,
-      setSkipCacheFlag: false
-    })
-  })
+  const engine = new ProviderEngine({ useSkipCache: false })
 
   /**
    * IF YOU REMOVE THIS, EVERYTHING WITH EXPLODE

--- a/yarn.lock
+++ b/yarn.lock
@@ -24681,9 +24681,9 @@ web3-provider-engine@^15.0.0:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3-provider-engine@mikeshultz/web3-provider-engine#too-many-requests:
+web3-provider-engine@mikeshultz/web3-provider-engine#origin-protocol:
   version "15.0.0"
-  resolved "https://codeload.github.com/mikeshultz/web3-provider-engine/tar.gz/c2bbd7483ca13b57a088f542bce3760356a217bd"
+  resolved "https://codeload.github.com/mikeshultz/web3-provider-engine/tar.gz/f3dd07a5720e7b8eb3df57cb41e053655427fc1a"
   dependencies:
     async "^2.5.0"
     backoff "^2.5.0"


### PR DESCRIPTION
### Description:

It was reported to us by Alchemy that our invalid `eth_getBlockByNumber` requests were actually due to a parameter tacked on by web3-provider-engine[1].  They also explicitly use this parameter in their `latest` event handler[2].

This also required another PR to web3-provider-engine(https://github.com/MetaMask/web3-provider-engine/pull/316), and has been reported (https://github.com/MetaMask/web3-provider-engine/issues/311). So, now there's two outstanding PRs and this adjusts the dependency to use another branch of my fork[3] that combines both.

[1] https://github.com/MetaMask/web3-provider-engine/blob/a17a32fab2717e5c6d600c5a8c25f9591c085aff/index.js#L30
[2] https://github.com/MetaMask/web3-provider-engine/blob/a17a32fab2717e5c6d600c5a8c25f9591c085aff/index.js#L130
[3] https://github.com/mikeshultz/web3-provider-engine/tree/origin-protocol

Ref: #2388 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
