### PR TITLE
[Token package] Replace truffle-privatekey-provider with web3

### DIFF
--- a/infra/growth/src/util/tokenDistributor.js
+++ b/infra/growth/src/util/tokenDistributor.js
@@ -18,6 +18,23 @@ class TokenDistributor {
     this.token = new Token({ providers: createProviders([networkId]) })
     this.supplier = await this.token.defaultAccount(networkId)
     this.web3 = this.token.web3(networkId)
+
+    await this.info()
+  }
+
+  /**
+   * Prints out info about the distributor.
+   * @returns {Promise<void>}
+   */
+  async info() {
+    const balance = await this.token.balance(this.networkId, this.supplier)
+
+    logger.info('TokenDistributor:')
+    logger.info(`  Network id: ${this.networkId}`)
+    logger.info(`  Provider URL: ${this.web3.currentProvider.host}`)
+    logger.info(`  Address: ${this.supplier}`)
+    logger.info(`  Balance: ${this.token.toTokenUnit(balance)} OGN`)
+    logger.info(`  Gas price multiplier: ${this.gasPriceMultiplier}`)
   }
 
   /**

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -24,7 +24,6 @@
     "@origin/contracts": "^0.8.6",
     "bignumber.js": "8.0.2",
     "truffle-hdwallet-provider": "0.0.6",
-    "truffle-privatekey-provider": "^0.1.0",
     "web3": "1.0.0-beta.34"
   },
   "devDependencies": {

--- a/packages/token/src/config.js
+++ b/packages/token/src/config.js
@@ -96,7 +96,11 @@ function createProviders(networkIds) {
       web3.eth.defaultAccount = account.address
       providers[networkId] = web3
       if (process.env.NODE_ENV !== 'test') {
-        console.log(`Network=${networkId} URL=${providerUrl} Using private key for account ${account.address}`)
+        console.log(
+          `Network=${networkId} URL=${providerUrl} Using private key for account ${
+            account.address
+          }`
+        )
       }
     } else {
       if (process.env.NODE_ENV !== 'test') {
@@ -106,7 +110,9 @@ function createProviders(networkIds) {
           `Network=${networkId} Url=${providerUrl} Mnemonic=${displayMnemonic}`
         )
       }
-      providers[networkId] = new Web3(new HDWalletProvider(mnemonic, providerUrl))
+      providers[networkId] = new Web3(
+        new HDWalletProvider(mnemonic, providerUrl)
+      )
     }
   }
   return providers

--- a/packages/token/src/config.js
+++ b/packages/token/src/config.js
@@ -1,5 +1,5 @@
 const HDWalletProvider = require('truffle-hdwallet-provider')
-const PrivateKeyProvider = require('truffle-privatekey-provider')
+const Web3 = require('web3')
 
 const MAINNET_NETWORK_ID = 1
 const ROPSTEN_NETWORK_ID = 3
@@ -90,10 +90,14 @@ function createProviders(networkIds) {
     }
     // Private key takes precedence
     if (privateKey) {
+      const web3 = new Web3(providerUrl)
+      const account = web3.eth.accounts.privateKeyToAccount('0x' + privateKey)
+      web3.eth.accounts.wallet.add(account)
+      web3.eth.defaultAccount = account.address
+      providers[networkId] = web3
       if (process.env.NODE_ENV !== 'test') {
-        console.log(`Network=${networkId} URL=${providerUrl} Using private key`)
+        console.log(`Network=${networkId} URL=${providerUrl} Using private key for account ${account.address}`)
       }
-      providers[networkId] = new PrivateKeyProvider(privateKey, providerUrl)
     } else {
       if (process.env.NODE_ENV !== 'test') {
         const displayMnemonic =
@@ -102,7 +106,7 @@ function createProviders(networkIds) {
           `Network=${networkId} Url=${providerUrl} Mnemonic=${displayMnemonic}`
         )
       }
-      providers[networkId] = new HDWalletProvider(mnemonic, providerUrl)
+      providers[networkId] = new Web3(new HDWalletProvider(mnemonic, providerUrl))
     }
   }
   return providers

--- a/packages/token/src/contractHelper.js
+++ b/packages/token/src/contractHelper.js
@@ -1,5 +1,3 @@
-const Web3 = require('web3')
-
 const { withRetries } = require('./util')
 
 class ContractHelper {
@@ -13,8 +11,7 @@ class ContractHelper {
    * @returns {object} - Promise that resolves to contract object.
    */
   web3(networkId) {
-    const provider = this.config.providers[networkId]
-    return new Web3(provider)
+    return this.config.providers[networkId]
   }
 
   /**

--- a/packages/token/src/contractHelper.js
+++ b/packages/token/src/contractHelper.js
@@ -100,8 +100,7 @@ class ContractHelper {
    * @returns {string} - Address of default of first unlocked account.
    */
   async defaultAccount(networkId) {
-    const accounts = await this.web3(networkId).eth.getAccounts()
-    return accounts[0]
+    return this.web3(networkId).eth.defaultAccount
   }
 }
 

--- a/packages/token/test/token.js
+++ b/packages/token/test/token.js
@@ -25,14 +25,14 @@ describe('Token CLI Library', async function() {
     nonOwner = accounts[1]
     OriginToken = await deploy('OriginToken', {
       from: owner,
-      path: `${__dirname}/../../origin-contracts/contracts/token/`,
+      path: `${__dirname}/../../contracts/contracts/token/`,
       args: [supply]
     })
     TokenLib = new Token({
       networkId,
       verbose: false,
       providers: {
-        '999': web3.currentProvider
+        '999': web3
       },
       contractAddress: OriginToken._address
     })


### PR DESCRIPTION
### Description:

The truffle-privatekey-provider package was causing the OGN payout script to error out due to incompatible changes made in recent versions of web3-provider-engine.
This PR replaces it with plain web3 calls.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
