### PR TITLE
[Growth] Query events from owner and proxies

### DIFF
--- a/infra/growth/src/resources/rules.js
+++ b/infra/growth/src/resources/rules.js
@@ -1,6 +1,9 @@
 const Sequelize = require('sequelize')
 
-const db = require('../models')
+const _growthModels = require('../models')
+const _discoveryModels = require('@origin/discovery/src/models')
+const db = { ..._growthModels, ..._discoveryModels }
+
 const {
   GrowthEventTypes,
   GrowthEventStatuses,
@@ -71,7 +74,9 @@ class CampaignRules {
 
   /**
    * Reads events related to a user from the DB.
-   * @param {string} ethAddress - User's account.
+   * Events recorded from any of the proxies owned by that wallet are included.
+   *
+   * @param {string} ethAddress - User's wallet address..
    * @param {Object} Options:
    *   - duringCampaign - Restricts query to events that occurred during
    *  the campaign. By default all events since user signed up are returned.
@@ -85,9 +90,14 @@ class CampaignRules {
     if (opts.beforeCampaign && opts.duringCampaign) {
       throw new Error('beforeCampaign and duringCampaign args are incompatible')
     }
-    const whereClause = {
-      ethAddress: ethAddress.toLowerCase()
-    }
+
+    // Load any proxy associated with the wallet address.
+    const ownerAddress = ethAddress.toLowerCase()
+    const proxies = await db.Proxy.findAll({ where: { ownerAddress } })
+
+    // Query events from wallet and proxy(ies).
+    const addresses = [ownerAddress, ...proxies.map(proxy => proxy.address)]
+    const whereClause = { ethAddress: { [Sequelize.Op.in]: addresses } }
 
     const endDate = opts.beforeCampaign
       ? this.campaign.startDate
@@ -396,7 +406,7 @@ class BaseRule {
 
   /**
    * Counts events, grouped by types.
-   * @param {string} ethAddress - User's account.
+   * @param {string} ethAddress - User's wallet address.
    * @param {Array<models.GrowthEvent>} events
    * @param {function} customIdFn - Optional. Custom id filter function.
    * @returns {Dict{string:number}} - Dict with event type as key and count as value.
@@ -406,7 +416,6 @@ class BaseRule {
     events
       .filter(event => {
         return (
-          event.ethAddress.toLowerCase() === ethAddress.toLowerCase() &&
           eventTypes.includes(event.type) &&
           (!customIdFn || customIdFn(event.customId)) &&
           (event.status === GrowthEventStatuses.Logged ||

--- a/infra/growth/test/rules-april.test.js
+++ b/infra/growth/test/rules-april.test.js
@@ -40,7 +40,10 @@ describe('April campaign rules', () => {
 
     // Mock the rule's getEvent method.
     this.events = []
-    this.crules.getEvents = () => { return this.events }
+    this.crules.getEvents = (ethAddress) => {
+      return this.events
+        .filter(event => event.ethAddress === ethAddress)
+    }
 
     // Mock the _getReferees method of the Referral rule.
     this.crules.levels[2].rules[0]._getReferees = () => { return [] }

--- a/infra/growth/test/rules-june.test.js
+++ b/infra/growth/test/rules-june.test.js
@@ -43,7 +43,10 @@ describe('June campaign rules', () => {
     // Mock the getEvents method to use events from this.events.
     // When writing a test, be aware that this.events is global and shared with other tests.
     this.events = []
-    this.crules.getEvents = () => { return this.events }
+    this.crules.getEvents = (ethAddress) => {
+      return this.events
+        .filter(event => event.ethAddress === ethAddress)
+    }
 
     // Mock the _getReferees method of the Referral rule.
     this.crules.levels[2].rules[0]._getReferees = () => { return [] }

--- a/infra/growth/test/rules-may.test.js
+++ b/infra/growth/test/rules-may.test.js
@@ -40,7 +40,10 @@ describe('May campaign rules', () => {
 
     // Mock the rule's getEvent method.
     this.events = []
-    this.crules.getEvents = () => { return this.events }
+    this.crules.getEvents = (ethAddress) => {
+      return this.events
+        .filter(event => event.ethAddress === ethAddress)
+    }
 
     // Mock the _getReferees method of the Referral rule.
     this.crules.levels[2].rules[0]._getReferees = () => { return [] }

--- a/infra/growth/test/rules.test.js
+++ b/infra/growth/test/rules.test.js
@@ -494,7 +494,7 @@ describe('Growth Engine rules', () => {
       }
     })
 
-    it(`Events from proxy should be credit to owner`, async () => {
+    it(`Events from proxy should be credited to owner`, async () => {
       this.events = [
         {
           id: 1,


### PR DESCRIPTION
### Description:

With the launch of meta-txn, the listener back-end will be recording GrowthEvents (e.g. Identity updates, Listing Sold/Purchased, etc...) under the address of either the wallet (in case user paid for gas) or the proxy (in case relayer paid for gas).

This PR updates the rules logic so that it loads events recorder under the wallet and any proxies owned by it.

The DApp always queries the growth back-end using the wallet address regardless of the wallet having aproxy or not. As a result, the user should see rewards for actions performed by either wallet or proxies.

Note: the fraud and payout pipeline needs to be updated to take into account proxies. I'll handle that as a separate PR.



### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
