### PR TITLE
Checks for blockNumber when waiting on tx to be mined

### DIFF
--- a/dapps/marketplace/src/components/WaitForTransaction.js
+++ b/dapps/marketplace/src/components/WaitForTransaction.js
@@ -122,7 +122,7 @@ class WaitForTransaction extends Component {
           if (error) {
             console.error(error)
             content = <Error />
-          } else if (!receipt) {
+          } else if (!receipt || !confirmedBlock) {
             content = <WaitForFirstBlock />
           } else if (!event) {
             console.error('Expected event not found')


### PR DESCRIPTION
### Description:

Ref: #2434

Checks for `blockNumber` in a tx receipt, as Parity will return receipts for pending transactions.  Currently, the `WaitForTransaction` component's logic would make the user think the tx has been mined and confirmed when in fact, neither are true.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
