### PR TITLE
show ogn badnge when no web3 provider available

### DIFF
--- a/dapps/marketplace/src/hoc/withGrowthRewards.js
+++ b/dapps/marketplace/src/hoc/withGrowthRewards.js
@@ -5,7 +5,7 @@ export default function withGrowthRewards(WrappedComponent) {
     const ognListingRewards = {}
 
     const tokenDecimals = props.tokenDecimals || 18
-    if (props.growthCampaigns && tokenDecimals) {
+    if (props.growthCampaigns) {
       const activeCampaign = props.growthCampaigns.find(
         campaign => campaign.status === 'Active'
       )

--- a/dapps/marketplace/src/hoc/withGrowthRewards.js
+++ b/dapps/marketplace/src/hoc/withGrowthRewards.js
@@ -4,7 +4,8 @@ export default function withGrowthRewards(WrappedComponent) {
   const WithGrowthRewards = props => {
     const ognListingRewards = {}
 
-    if (props.growthCampaigns && props.tokenDecimals) {
+    const tokenDecimals = props.tokenDecimals || 18
+    if (props.growthCampaigns && tokenDecimals) {
       const activeCampaign = props.growthCampaigns.find(
         campaign => campaign.status === 'Active'
       )
@@ -12,7 +13,7 @@ export default function withGrowthRewards(WrappedComponent) {
       if (activeCampaign) {
         const decimalDivision = web3.utils
           .toBN(10)
-          .pow(web3.utils.toBN(props.tokenDecimals))
+          .pow(web3.utils.toBN(tokenDecimals))
 
         activeCampaign.actions.forEach(action => {
           if (action.type === 'ListingIdPurchased') {


### PR DESCRIPTION
### Description:
Provide growth Rewards information even when web3 account not present. Just assume that OGN has 18 token decimals. 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
