### PR TITLE
Ability to prevent dapp start script from opening browser

### DIFF
--- a/dapps/marketplace/index.js
+++ b/dapps/marketplace/index.js
@@ -51,7 +51,9 @@ async function start() {
   const PORT = process.env.PORT || 3000
   app.listen(PORT, () => {
     console.log(`\nListening on port ${PORT}\n`)
-    setTimeout(() => opener(`http://${HOST}:${PORT}`), 2000)
+    if (!process.env.NOOPENER) {
+      setTimeout(() => opener(`http://${HOST}:${PORT}`), 2000)
+    }
   })
 }
 


### PR DESCRIPTION
### Description:

Adds `NOOPENER` env var to prevent the marketplace dapp start script from opening a browser.  The `opener()` call keeps destroying my browser profiles and it's driving me mad.  This should not change how people normally use the `start` script.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
