### PR TITLE
Fix attestations on staging and production

### DIFF
--- a/packages/graphql/env.js
+++ b/packages/graphql/env.js
@@ -1,0 +1,8 @@
+import dotenv from 'dotenv'
+dotenv.config()
+
+try {
+  require('envkey')
+} catch (error) {
+  console.warn('EnvKey not configured')
+}

--- a/packages/graphql/server.js
+++ b/packages/graphql/server.js
@@ -1,12 +1,6 @@
+import 'envkey'
 import dotenv from 'dotenv'
 dotenv.config()
-
-// No conditional imports available yet
-try {
-  require('envkey')
-} catch (error) {
-  console.warn('EnvKey not configured')
-}
 
 import server from './src/server'
 

--- a/packages/graphql/server.js
+++ b/packages/graphql/server.js
@@ -1,7 +1,4 @@
-import 'envkey'
-import dotenv from 'dotenv'
-dotenv.config()
-
+import './env'
 import server from './src/server'
 
 server

--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -344,40 +344,40 @@ async function getAuthUrl(provider, args) {
   return authData.url
 }
 
-// The order of this list will affect the order of rendering in DApp
-const ATTESTATION_PROVIDERS = [
-  'email',
-  'phone',
-  'facebook',
-  'twitter',
-  'airbnb',
-  'google'
-]
-
-if (process.env.ENABLE_WEBSITE_ATTESTATION === 'true') {
-  ATTESTATION_PROVIDERS.push('website')
-}
-
-if (process.env.ENABLE_KAKAO_ATTESTATION === 'true') {
-  ATTESTATION_PROVIDERS.push('kakao')
-}
-
-if (process.env.ENABLE_GITHUB_ATTESTATION === 'true') {
-  ATTESTATION_PROVIDERS.push('github')
-}
-
-if (process.env.ENABLE_LINKEDIN_ATTESTATION === 'true') {
-  ATTESTATION_PROVIDERS.push('linkedin')
-}
-
-if (process.env.ENABLE_WECHAT_ATTESTATION === 'true') {
-  ATTESTATION_PROVIDERS.push('wechat')
-}
-
 /**
  * Returns a list of all supported attestation providers
  */
 function getAttestationProviders() {
+  // The order of this list will affect the order of rendering in DApp
+  const ATTESTATION_PROVIDERS = [
+    'email',
+    'phone',
+    'facebook',
+    'twitter',
+    'airbnb',
+    'google'
+  ]
+
+  if (process.env.ENABLE_WEBSITE_ATTESTATION === 'true') {
+    ATTESTATION_PROVIDERS.push('website')
+  }
+
+  if (process.env.ENABLE_KAKAO_ATTESTATION === 'true') {
+    ATTESTATION_PROVIDERS.push('kakao')
+  }
+
+  if (process.env.ENABLE_GITHUB_ATTESTATION === 'true') {
+    ATTESTATION_PROVIDERS.push('github')
+  }
+
+  if (process.env.ENABLE_LINKEDIN_ATTESTATION === 'true') {
+    ATTESTATION_PROVIDERS.push('linkedin')
+  }
+
+  if (process.env.ENABLE_WECHAT_ATTESTATION === 'true') {
+    ATTESTATION_PROVIDERS.push('wechat')
+  }
+
   return ATTESTATION_PROVIDERS
 }
 

--- a/packages/graphql/src/server.js
+++ b/packages/graphql/src/server.js
@@ -7,12 +7,6 @@ import typeDefs from './typeDefs/index'
 import resolvers from './resolvers/server'
 import { setNetwork, shutdown } from './contracts'
 
-try {
-  require('envkey')
-} catch (error) {
-  console.warn('EnvKey not configured')
-}
-
 setNetwork(process.env.NETWORK || 'test', {
   performanceMode: false,
   useMetricsProvider: process.env.USE_METRICS_PROVIDER === 'true',


### PR DESCRIPTION
For some reasons the IdentityResolver.js file was loaded even before loading the environment variables. Most likely has to do something with the order of require/import during babel transpilation. 