### PR TITLE
upgrades go-ipfs to v0.4.21

### DIFF
--- a/devops/kubernetes/charts/origin/values.yaml
+++ b/devops/kubernetes/charts/origin/values.yaml
@@ -4,7 +4,7 @@ clusterIssuer: letsencrypt-prod
 
 # ipfs
 ipfsImage: ipfs/go-ipfs
-ipfsImageTag: "v0.4.19"
+ipfsImageTag: "v0.4.21"
 
 # origin-bridge
 bridgeImage: origin-bridge


### PR DESCRIPTION
### Description:

Simple version bump for the ipfs container image.  I don't think there's any special migration work that needs to be done.  I did do a test update on my local from an even older version and it went clean.

Might be worth watching the dev+staging builds to make sure.  The base32 file hash encodings should currently be opt-in, but there's a chance their docker image could behave differently.

Ref: #2408 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
