### PR TITLE
Fixes IPFS container issue

### DIFF
--- a/devops/kubernetes/charts/origin/templates/ipfs.statefulset.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.statefulset.yaml
@@ -37,7 +37,7 @@ spec:
             value: "http://127.0.0.1:8080"
       - name: {{ template "ipfs.fullname" . }}
         image: "{{ .Values.ipfsImage }}:{{ .Values.ipfsImageTag }}"
-        command: ["/usr/local/bin/start_ipfs"]
+        command: ["/usr/local/bin/start_ipfs", "daemon"]
         ports:
         - containerPort: 5001
           name: api

--- a/devops/kubernetes/charts/origin/templates/ipfs.statefulset.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.statefulset.yaml
@@ -37,7 +37,7 @@ spec:
             value: "http://127.0.0.1:8080"
       - name: {{ template "ipfs.fullname" . }}
         image: "{{ .Values.ipfsImage }}:{{ .Values.ipfsImageTag }}"
-        command: ["/usr/local/bin/start_ipfs", "daemon"]
+        command: ["/usr/local/bin/start_ipfs", "daemon", "--migrate=true"]
         ports:
         - containerPort: 5001
           name: api

--- a/devops/kubernetes/charts/origin/templates/ipfs.statefulset.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.statefulset.yaml
@@ -37,7 +37,7 @@ spec:
             value: "http://127.0.0.1:8080"
       - name: {{ template "ipfs.fullname" . }}
         image: "{{ .Values.ipfsImage }}:{{ .Values.ipfsImageTag }}"
-        command: ["/usr/local/bin/start_ipfs", "daemon", "--migrate=true"]
+        command: ["/usr/local/bin/start_ipfs", "daemon"]
         ports:
         - containerPort: 5001
           name: api


### PR DESCRIPTION
### Description:

Was difficult to test this locally, but created a Dockerfile with an `ENTRYPOINT` the same as this kube deployment `command` and the behavior was the same.  ~~Updating it to include the `daemon` subcommand and the option `--migrate=true`.  This is the same as the default docker implementation.  I don't think this upgrade requires migrations, but I've used this in the past without issue.~~

~~@tomlinton For the sake of time, I'd like to merge this now to get things working again, but if you'd like to remove the auto-migrate option in the future let me know.~~

EDIT: For now, I'm just going to be careful and remove the auto-migrate option and see how it goes.  It might be worth adding later, though, as it could cause future version upgrades to fail.

Ref: #2488

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
