### PR TITLE
Tomlinton/relayer enable

### DIFF
--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -430,6 +430,21 @@ class MarketplaceScreen extends Component {
     }
   }
 
+  injectEnableProxyAccounts = () => {
+    const injectedJavaScript = `
+      (function() {
+        if (window && window.localStorage && window.webViewBridge) {
+          window.localStorage.proxyAccountsEnabled = true;
+          window.localStorage.enableRelayer = true;
+        }
+      })();
+    `
+    if (this.dappWebView) {
+      console.debug('Injecting enable relayer')
+      this.dappWebView.injectJavaScript(injectedJavaScript)
+    }
+  }
+
   /* Send a response back to the DApp using postMessage in the webview
    */
   handleBridgeResponse = (msgData, result) => {
@@ -446,6 +461,8 @@ class MarketplaceScreen extends Component {
   }
 
   onWebViewLoad = async () => {
+    // Enable proxy accounts
+    this.injectEnableProxyAccounts()
     // Set the language in the DApp to the same as the mobile app
     this.injectLanguage()
     // Inject scroll handler for pull to refresh function

--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -343,9 +343,6 @@ function setMobileBridge() {
   const mobileBridgeProvider = context.mobileBridge.getProvider()
   context.web3Exec = applyWeb3Hack(new Web3(mobileBridgeProvider))
 
-  // Force enable proxy accounts
-  context.config.proxyAccountsEnabled = true
-
   // Replace all the contracts with versions that use our custom web3 provider
   // so that contract calls get routed through window.postMessage
   context.marketplaceExec = new context.web3Exec.eth.Contract(

--- a/packages/graphql/src/mutations/_txHelper.js
+++ b/packages/graphql/src/mutations/_txHelper.js
@@ -11,10 +11,6 @@ import relayer from './_relayer'
 
 const debug = createDebug('origin:tx-helper:')
 const formatAddr = address => (address ? address.substr(0, 8) : '')
-const isOriginMobile =
-  typeof window !== 'undefined' &&
-  window.ReactNativeWebView &&
-  contracts.web3Exec.currentProvider.isOrigin
 
 export async function checkMetaMask(from) {
   if (contracts.metaMask && contracts.metaMaskEnabled) {
@@ -44,10 +40,8 @@ const isServer = typeof window === 'undefined'
 function useRelayer({ mutation, value }) {
   if (isServer) return
 
-  const relayerEnabled = window.localStorage.enableRelayer || isOriginMobile
-
   let reason
-  if (!relayerEnabled) reason = 'disabled in localStorage and not mobile'
+  if (!window.localStorage.enableRelayer) reason = 'disabled in localStorage'
   if (!contracts.config.relayer) reason = 'relayer not configured'
   if (!mutation) reason = 'no mutation specified'
 


### PR DESCRIPTION
Remove relayer/proxy enable from graphql code and back into the mobile code. This means in new mobile versions we'll have to refresh to test after install. I'll look for a better solution later but for now this will allow deploying the new dapp to production.