### PR TITLE
Sign moderation logins with our GraphQL signing code.

### DIFF
--- a/dapps/admin/src/pages/listings/_EnsureModerator.js
+++ b/dapps/admin/src/pages/listings/_EnsureModerator.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
+import Web3 from 'web3'
+import gqlClient from '@origin/graphql'
+import { SignMessageMutation } from '../../queries/Mutations'
 import { AnchorButton } from '@blueprintjs/core'
 import { query, timeRemaining, persistAccessToken } from '../../utils/discovery'
-import Web3 from 'web3'
 
 const AUTH_TOKEN_MUTATION = `
 mutation($message: String!, $signature: String!, $ethAddress: String!) {
@@ -38,7 +40,11 @@ class EnsureModerator extends Component {
     // Create message
     const nonce = Web3.utils.randomHex(12)
     const message = `\x19Ethereum Signed Message:\nOrigin Moderation Login\nNonce: ${nonce}`
-    const signature = await window.web3.eth.sign(message, ethAddress)
+    const signResponse = await gqlClient.mutate({
+      mutation: SignMessageMutation,
+      variables: { message, address: ethAddress }
+    })
+    const signature = signResponse.data.signMessage
 
     // Post to discovery server
     const data = await query(AUTH_TOKEN_MUTATION, {

--- a/dapps/admin/src/queries/Mutations.js
+++ b/dapps/admin/src/queries/Mutations.js
@@ -418,6 +418,12 @@ export const DeployIdentityViaProxyMutation = gql`
   }
 `
 
+export const SignMessageMutation = gql`
+  mutation SignMessage($address: ID!, $message: String!) {
+    signMessage(address: $address, message: $message)
+  }
+`
+
 // await originJS.createListing({
 //   deposit: '2',
 //   arbitrator: '0x9d42726D0Aa33984c55a1076DBc68a42f2509684',


### PR DESCRIPTION
I was calling MetaMask directly for signing moderator logins, but it turns out I was doing so in a way that only worked for local unlocked accounts. I've updated the code to use our standard origin GraphQL mutation for signing this message.

Thanks to @nick for the cleaner way to call a GraphQL mutation.