### PR TITLE
Child funding changes

### DIFF
--- a/infra/relayer/package.json
+++ b/infra/relayer/package.json
@@ -40,7 +40,7 @@
     "start": "per-env",
     "start:development": "nodemon src/app.js",
     "start:production": "node src/app.js",
-    "test": "NODE_ENV=test mocha --timeout 10000 --file test/setup --exit"
+    "test": "LOG_LEVEL=NONE NODE_ENV=test mocha --timeout 10000 --file test/setup --exit"
   },
   "prettier": {
     "semi": false,

--- a/infra/relayer/src/purse.js
+++ b/infra/relayer/src/purse.js
@@ -672,6 +672,9 @@ class Purse {
         const masterBalance = numberToBN(
           await this.web3.eth.getBalance(masterAddress)
         )
+        const masterBalanceLow = masterBalance.lt(
+          BASE_FUND_VALUE.mul(new BN(this.children.length))
+        )
         const balanceEther = this.web3.utils.fromWei(
           masterBalance.toString(),
           'ether'
@@ -680,18 +683,16 @@ class Purse {
           logger.error(
             `Master account needs funding! Send funds to ${masterAddress}`
           )
-        } else if (
-          masterBalance.lt(BASE_FUND_VALUE.mul(new BN(this.children.length)))
-        ) {
+        } else if (masterBalanceLow) {
           logger.warn(
-            `Master account is low @ ${balanceEther} Ether. Add funds soon!`
+            `Master account is low @ ${balanceEther} Ether. Will not be able to auto-fund child accounts!`
           )
         } else {
           logger.info(`Master account balance: ${balanceEther} Ether`)
         }
 
         // Check for child balances dropping below set minimum and fund if necessary
-        if (this.ready && this.autofundChildren) {
+        if (this.ready && this.autofundChildren && !masterBalanceLow) {
           for (let i = 0; i < this.children.length; i++) {
             const child = this.children[i]
             const childBalance = numberToBN(

--- a/infra/relayer/src/purse.js
+++ b/infra/relayer/src/purse.js
@@ -685,14 +685,16 @@ class Purse {
           )
         } else if (masterBalanceLow) {
           logger.warn(
-            `Master account is low @ ${balanceEther} Ether. Will not be able to auto-fund child accounts!`
+            `Master account is low @ ${balanceEther} Ether. Add funds soon!`
           )
         } else {
           logger.info(`Master account balance: ${balanceEther} Ether`)
         }
 
+        const childrenToFund = []
+
         // Check for child balances dropping below set minimum and fund if necessary
-        if (this.ready && this.autofundChildren && !masterBalanceLow) {
+        if (this.ready && this.autofundChildren) {
           for (let i = 0; i < this.children.length; i++) {
             const child = this.children[i]
             const childBalance = numberToBN(
@@ -703,11 +705,30 @@ class Purse {
               childBalance.lte(MIN_CHILD_BALANCE) &&
               !this.accounts[child].hasPendingFundingTx
             ) {
-              await this._fundChild(child)
+              childrenToFund.push(child)
             } else if (this.accounts[child].hasPendingFundingTx) {
               // Reset the flag
               this.accounts[child].hasPendingFundingTx = false
             }
+          }
+
+          let valueToSend = BASE_FUND_VALUE
+          const maxFee = MAX_GAS_PRICE.mul(new BN('21000')).mul(
+            new BN(childrenToFund.length)
+          )
+          if (
+            masterBalance.lt(
+              valueToSend.mul(new BN(childrenToFund.length)).add(maxFee)
+            )
+          ) {
+            valueToSend = masterBalance.sub(maxFee).div(childrenToFund.length)
+          }
+          if (valueToSend.gte(MIN_CHILD_BALANCE)) {
+            for (const child of childrenToFund) {
+              await this._fundChild(child, valueToSend)
+            }
+          } else {
+            logger.warn('Unable to fund children.  Balance too low.')
           }
         }
       }


### PR DESCRIPTION
### Description:

Initially this was setup so that individual child accounts could get funded when they need to.  This caused Purse to try and fund 3 accounts when the balance of the master could only afford to fund 2.  Not the end of the world, but it caused a tx to be forever-broadcast until I guess the master balance was satisfied enough to send it.  

In addition to this change, the values for baseFunding could be set differently if 0.5 Ether is too much, but I'm going by @franckc's suggested numbers here.  I lowered prod down to 2 children so things would run smoothly for now.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
