### PR TITLE
Purse: Fixes nonce recovery from redis type issues

### DIFF
--- a/infra/relayer/test/purse.test.js
+++ b/infra/relayer/test/purse.test.js
@@ -226,14 +226,30 @@ describe('Purse', () => {
     const purseTwo = new Purse({ web3, mnemonic: MNEMONIC_ONE, children: 2 })
     await purseTwo.init()
 
+    // Third instance should not have Redis
+    const purseThree = new Purse({
+      web3,
+      mnemonic: MNEMONIC_ONE,
+      children: 2,
+      redisHost: 'redis://localhost:666/999'
+    })
+    await purseThree.init()
+
     const firstTXCount = await purseOne.txCount(sentFrom)
     const secondTXCount = await purseTwo.txCount(sentFrom)
+    const thirdTXCount = await purseThree.txCount(sentFrom)
 
+    assert(typeof firstTXCount === 'number', 'txCount() should return a number')
+    assert(typeof secondTXCount === 'number', 'txCount() should return a number')
+    assert(typeof thirdTXCount === 'number', 'txCount() should return a number')
     assert(firstTXCount === secondTXCount)
+    assert(secondTXCount === thirdTXCount)
     assert(purseOne.accounts[sentFrom].txCount === purseTwo.accounts[sentFrom].txCount)
+    assert(purseTwo.accounts[sentFrom].txCount === purseThree.accounts[sentFrom].txCount)
 
     await purseOne.teardown(true)
     await purseTwo.teardown(true)
+    await purseThree.teardown(true)
   })
 
   // This is best tested with Redis, but not required


### PR DESCRIPTION
### Description:

When nonce was recovered from redis upon a service restart, the value stored for `txCount` would be a string.  This caused the increment operations `+=` to actually append a number to the end of the string value instead of actually doing a Number increment.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
