### PR TITLE
Exclude undefined values when publishing profile

### DIFF
--- a/dapps/marketplace/src/pages/user/Profile.js
+++ b/dapps/marketplace/src/pages/user/Profile.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import pick from 'lodash/pick'
+import pickBy from 'lodash/pickBy'
 import get from 'lodash/get'
 import { fbt } from 'fbt-runtime'
 
@@ -373,11 +374,14 @@ class UserProfile extends Component {
       return null
     }
 
-    const profile = pick(
-      this.state.deployIdentity === 'profile'
-        ? this.state.unpublishedProfile
-        : this.state,
-      ['firstName', 'lastName', 'description', 'avatarUrl']
+    const profile = pickBy(
+      pick(
+        this.state.deployIdentity === 'profile'
+          ? this.state.unpublishedProfile
+          : this.state,
+        ['firstName', 'lastName', 'description', 'avatarUrl']
+      ),
+      x => x
     )
 
     return (


### PR DESCRIPTION
Should fix the following issue:

![Image](https://cdn.discordapp.com/attachments/562452603821359105/593304387020128276/image0.jpg)

### Steps to reproduce the issue

- Go through a onboarding flow on a new Ethereum account
- Try to do an attestation without setting a `description`

`description` will be `undefined`/`null`. GraphQL doesn't accept either as a string.
