### PR TITLE
fixes column name in migration

### DIFF
--- a/infra/messaging/migrations/20190625030841-add-content-hash.js
+++ b/infra/messaging/migrations/20190625030841-add-content-hash.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('msg_message', 'contentHash', {
+    return queryInterface.addColumn('msg_message', 'content_hash', {
       type: Sequelize.STRING(66)
     })
   },
 
   down: (queryInterface) => {
-    return queryInterface.removeColumn('msg_message', 'contentHash')
+    return queryInterface.removeColumn('msg_message', 'content_hash')
   }
 }


### PR DESCRIPTION
### Description:

Sequelize is cool.  Not really sure how I missed this in testing.  Maybe I had the DB disabled or something.  But @tomlinton renamed the columns in the DBs manually(which fixed the issue), and I'm changing this migration to match.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
