### PR TITLE
 GiftCardListing should be multiUnit

### DIFF
--- a/packages/eventsource/src/index.js
+++ b/packages/eventsource/src/index.js
@@ -6,7 +6,9 @@ const startCase = require('lodash/startCase')
 const pick = require('lodash/pick')
 const _get = require('lodash/get')
 const memoize = require('lodash/memoize')
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const MULTI_UNIT_TYPES = ['UnitListing', 'GiftCardListing']
 
 const getListingDirect = async (contract, listingId) =>
   await contract.methods.listings(listingId).call()
@@ -272,7 +274,7 @@ class OriginEventSource {
       contract: this.contract,
       status,
       events,
-      multiUnit: __typename === 'UnitListing' && data.unitsTotal > 1,
+      multiUnit: MULTI_UNIT_TYPES.indexOf(__typename) > -1 && data.unitsTotal > 1,
       commissionPerUnit,
       commission
     })

--- a/packages/eventsource/src/index.js
+++ b/packages/eventsource/src/index.js
@@ -274,7 +274,8 @@ class OriginEventSource {
       contract: this.contract,
       status,
       events,
-      multiUnit: MULTI_UNIT_TYPES.indexOf(__typename) > -1 && data.unitsTotal > 1,
+      multiUnit:
+        MULTI_UNIT_TYPES.indexOf(__typename) > -1 && data.unitsTotal > 1,
       commissionPerUnit,
       commission
     })


### PR DESCRIPTION
### Description:

Reported by a user to @AustinVirts. User wanted to buy multiple gift cards without having to do individual transactions for each.  This allows the gift card to be multi-unit.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
