### PR TITLE
Geth upgrade and byzantium fork

### DIFF
--- a/devops/kubernetes/charts/ethereum-network/templates/geth-genesis.configmap.yaml
+++ b/devops/kubernetes/charts/ethereum-network/templates/geth-genesis.configmap.yaml
@@ -16,7 +16,8 @@ data:
             "homesteadBlock": 0,
             "eip150Block": 0,
             "eip155Block": 0,
-            "eip158Block": 0
+            "eip158Block": 0,
+            "byzantiumBlock": 1200000
         },
         "difficulty":  {{ .Values.gethGenesisDifficulty | quote }},
         "gasLimit": {{ .Values.gethGenesisGasLimit | quote }},

--- a/devops/kubernetes/charts/ethereum-network/values.yaml
+++ b/devops/kubernetes/charts/ethereum-network/values.yaml
@@ -3,13 +3,13 @@ gethMinerReplicas: 2
 gethMinerCpuLimit: 0.5
 
 bootnodeImage: ethereum/client-go
-bootnodeImageTag: alltools-v1.8.23
+bootnodeImageTag: alltools-v1.8.27
 
 ethstatsImage: ethereumex/eth-stats-dashboard
 ethstatsImageTag: latest
 
 gethImage: ethereum/client-go
-gethImageTag: v1.8.23
+gethImageTag: v1.8.27
 
 gethGenesisNetworkId: 2222
 gethGenesisDifficulty: '0x400'


### PR DESCRIPTION
### Description:

This updates geth to v1.8.27, and makes an attempt at a byzantium fork.  

The fork is tricky as I can't find an authoritative source for how this goes down.  [This StackExchange answer](https://ethereum.stackexchange.com/a/29412/8492) might be the best idea.  I think if we bring up a 3rd miner node with that genesis block, maybe stop the other 2 miners and let this one do its thing, the other should fall in line.  Then maybe if we have to clear state on nodes 0 and 1 and re-sync(not clear if that's necessary).

Though there's also a chance of an incompatibility, and if nodes 0 and 1 come up and don't like the conflicting genesis hash, everything could come to a halt.  So, a bit of a gamble here.  Would be interested in your take on it, @tomlinton.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
