### PR TITLE
Better mobile profile publishing feedback

### DIFF
--- a/mobile/src/graphql/queries.js
+++ b/mobile/src/graphql/queries.js
@@ -90,3 +90,29 @@ export const growthEligible = gql`
     }
   }
 `
+
+export const transactionReceipt = gql`
+  query TransactionReceipt($id: ID!) {
+    web3 {
+      blockNumber
+      transactionReceipt(id: $id) {
+        id
+        blockNumber
+        events {
+          id
+          event
+          returnValues {
+            listingID
+            offerID
+            party
+            ipfsHash
+          }
+          returnValuesArr {
+            field
+            value
+          }
+        }
+      }
+    }
+  }
+`

--- a/mobile/src/hoc/withOriginGraphql.js
+++ b/mobile/src/hoc/withOriginGraphql.js
@@ -17,6 +17,7 @@ import {
   growthEligible,
   identity,
   tokenBalance,
+  transactionReceipt,
   wallet
 } from 'graphql/queries'
 import { growthEnroll, deployIdentity } from 'graphql/mutations'
@@ -32,9 +33,15 @@ const withOriginGraphql = WrappedComponent => {
       DeviceEventEmitter.addListener('graphqlError', this._handleGraphqlError)
     }
 
-    _sendGraphqlQuery = (query, variables) => {
+    _sendGraphqlQuery = (query, variables, fetchPolicy) => {
       const { promiseId, promise } = this._generatePromise()
-      DeviceEventEmitter.emit('graphqlQuery', promiseId, query, variables)
+      DeviceEventEmitter.emit(
+        'graphqlQuery',
+        promiseId,
+        query,
+        variables,
+        fetchPolicy
+      )
       return promise
     }
 
@@ -102,6 +109,10 @@ const withOriginGraphql = WrappedComponent => {
       return this._sendGraphqlQuery(identity, { id: identityAddress })
     }
 
+    getTransactionReceipt = async id => {
+      return this._sendGraphqlQuery(transactionReceipt, { id }, 'no-cache')
+    }
+
     getWallet = () => {
       return this._sendGraphqlQuery(wallet)
     }
@@ -129,6 +140,7 @@ const withOriginGraphql = WrappedComponent => {
           getGrowthEligibility={this.getGrowthEligibility}
           getIdentity={this.getIdentity}
           getTokenBalance={this.getTokenBalance}
+          getTransactionReceipt={this.getTransactionReceipt}
           getWallet={this.getWallet}
           publishIdentity={this.publishIdentity}
           growthEnroll={this.growthEnroll}

--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -406,12 +406,18 @@ class MarketplaceScreen extends Component {
     this.setState({ enablePullToRefresh: scrollTop === 0 })
   }
 
-  injectGraphqlQuery = (id, query, variables = {}) => {
+  injectGraphqlQuery = (
+    id,
+    query,
+    variables = {},
+    fetchPolicy = 'cache-first'
+  ) => {
     const injectedJavaScript = `
       (function() {
         window.gql.query({
           query: ${JSON.stringify(query)},
-          variables: ${JSON.stringify(variables)}
+          variables: ${JSON.stringify(variables)},
+          fetchPolicy: '${fetchPolicy}'
         }).then((response) => {
           window.webViewBridge.send('handleGraphqlResult', {
             id: '${id}',

--- a/mobile/src/screens/onboarding/ready.js
+++ b/mobile/src/screens/onboarding/ready.js
@@ -18,7 +18,8 @@ class ReadyScreen extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      loading: true
+      loading: true,
+      error: false
     }
   }
 
@@ -51,6 +52,7 @@ class ReadyScreen extends Component {
       )
     } catch (error) {
       console.warn('Identity publication failed: ', error)
+      this.setState({ error: true })
     }
 
     this.props.setOnboardingComplete(true)
@@ -79,6 +81,11 @@ class ReadyScreen extends Component {
           <Text style={styles.title}>
             <fbt desc="ReadyScreen.title">
               You&apos;re ready to start buying and selling on Origin
+            </fbt>
+          </Text>
+          <Text style={styles.subtitle}>
+            <fbt desc="ReadyScreen.error">
+              Unfortunately we could not publish your identity on your behalf.
             </fbt>
           </Text>
         </View>


### PR DESCRIPTION
- Adds a (subtle) error if identity didn't publish via relayer for whatever reason.
- Blocks on the last screen of the onboarding process until the identity is actually ready. I know we talked about a spinner inside the profile dropdown of the DApp @micahalcorn, but at this point it is a lot of complexity in both the DApp and mobile and this is relatively simple. I think we should do this and revisit later if we want something nicer.