### PR TITLE
Mobile onboarding back arrows

### DIFF
--- a/mobile/src/components/back-arrow.js
+++ b/mobile/src/components/back-arrow.js
@@ -1,0 +1,14 @@
+'use strict'
+
+import React from 'react'
+import { Text, TouchableOpacity } from 'react-native'
+
+const BackArrow = ({ onClick, style }) => {
+  return (
+    <TouchableOpacity onPress={() => onClick()} style={style}>
+      <Text style={{ fontSize: 40, color: '#e7e6f1' }}>&lsaquo;</Text>
+    </TouchableOpacity>
+  )
+}
+
+export default BackArrow

--- a/mobile/src/screens/onboarding/email.js
+++ b/mobile/src/screens/onboarding/email.js
@@ -16,6 +16,7 @@ import { fbt } from 'fbt-runtime'
 import get from 'lodash.get'
 
 import { setEmailAttestation } from 'actions/Onboarding'
+import BackArrow from 'components/back-arrow'
 import Disclaimer from 'components/disclaimer'
 import OriginButton from 'components/origin-button'
 import PinInput from 'components/pin-input'
@@ -168,6 +169,10 @@ class EmailScreen extends Component {
     return (
       <>
         <View style={{ ...styles.container, justifyContent: 'flex-start' }}>
+          <BackArrow
+            onClick={() => this.props.navigation.goBack(null)}
+            style={styles.backArrow}
+          />
           <Text style={styles.title}>
             <fbt desc="EmailScreen.inputTitle">Let&apos;s get started</fbt>
           </Text>
@@ -225,6 +230,10 @@ class EmailScreen extends Component {
     return (
       <>
         <View style={{ ...styles.container, justifyContent: 'flex-start' }}>
+          <BackArrow
+            onClick={() => this.props.navigation.goBack(null)}
+            style={styles.backArrow}
+          />
           <Text style={styles.title}>
             <fbt desc="EmailScreen.verifyTitle">Verify your email</fbt>
           </Text>

--- a/mobile/src/screens/onboarding/growth-terms.js
+++ b/mobile/src/screens/onboarding/growth-terms.js
@@ -16,6 +16,7 @@ import get from 'lodash.get'
 import CheckBox from 'react-native-check-box'
 import DeviceInfo from 'react-native-device-info'
 
+import BackArrow from 'components/back-arrow'
 import OriginButton from 'components/origin-button'
 import withOnboardingSteps from 'hoc/withOnboardingSteps'
 import withOriginGraphql from 'hoc/withOriginGraphql'
@@ -178,6 +179,10 @@ class GrowthTermsScreen extends Component {
     return (
       <>
         <View style={{ ...styles.container, paddingTop: 20 }}>
+          <BackArrow
+            onClick={() => this.props.navigation.goBack(null)}
+            style={styles.backArrow}
+          />
           <Text style={styles.termsHeader}>
             <fbt desc="GrowthTermsScreen.termsHeader">
               Join Origin’s reward program to earn Origin tokens (OGN). Terms &
@@ -276,5 +281,30 @@ export default withOriginGraphql(
 
 const styles = StyleSheet.create({
   ...CommonStyles,
-  ...OnboardingStyles
+  ...OnboardingStyles,
+  termsHeader: {
+    fontWeight: '600',
+    fontSize: 18,
+    marginBottom: 20,
+    marginHorizontal: 20,
+    textAlign: 'center'
+  },
+  termsText: {
+    paddingHorizontal: 20,
+    marginBottom: 20,
+    color: '#111d28'
+  },
+  termsHighlightContainer: {
+    borderColor: '#98a7b4',
+    backgroundColor: 'rgba(152, 167, 180, 0.1)',
+    borderWidth: 1,
+    paddingVertical: 20,
+    paddingHorizontal: 20,
+    marginVertical: 20,
+    width: '90%',
+    borderRadius: 5
+  },
+  termsHighlightText: {
+    color: '#6f8294'
+  },
 })

--- a/mobile/src/screens/onboarding/growth-terms.js
+++ b/mobile/src/screens/onboarding/growth-terms.js
@@ -306,5 +306,5 @@ const styles = StyleSheet.create({
   },
   termsHighlightText: {
     color: '#6f8294'
-  },
+  }
 })

--- a/mobile/src/screens/onboarding/name.js
+++ b/mobile/src/screens/onboarding/name.js
@@ -15,6 +15,7 @@ import { fbt } from 'fbt-runtime'
 import SafeAreaView from 'react-native-safe-area-view'
 
 import { setName } from 'actions/Onboarding'
+import BackArrow from 'components/back-arrow'
 import OriginButton from 'components/origin-button'
 import VisibilityWarning from 'components/visibility-warning'
 import withOnboardingSteps from 'hoc/withOnboardingSteps'
@@ -64,6 +65,10 @@ class NameScreen extends Component {
             keyboardShouldPersistTaps={'always'}
           >
             <View style={{ ...styles.container, justifyContent: 'flex-start' }}>
+              <BackArrow
+                onClick={() => this.props.navigation.goBack(null)}
+                style={styles.backArrow}
+              />
               <Text style={styles.title}>
                 <fbt desc="NameScreen.title">Create a profile</fbt>
               </Text>

--- a/mobile/src/screens/onboarding/phone.js
+++ b/mobile/src/screens/onboarding/phone.js
@@ -18,6 +18,7 @@ import RNPickerSelect from 'react-native-picker-select'
 import * as RNLocalize from 'react-native-localize'
 
 import { setPhoneAttestation } from 'actions/Onboarding'
+import BackArrow from 'components/back-arrow'
 import Disclaimer from 'components/disclaimer'
 import OriginButton from 'components/origin-button'
 import PinInput from 'components/pin-input'
@@ -223,6 +224,10 @@ class PhoneScreen extends Component {
     return (
       <>
         <View style={{ ...styles.container, justifyContent: 'flex-start' }}>
+          <BackArrow
+            onClick={() => this.props.navigation.goBack(null)}
+            style={styles.backArrow}
+          />
           <Text style={styles.title}>
             <fbt desc="PhoneScreen.inputTitle">Enter phone number</fbt>
           </Text>
@@ -285,6 +290,10 @@ class PhoneScreen extends Component {
     return (
       <>
         <View style={{ ...styles.container, justifyContent: 'flex-start' }}>
+          <BackArrow
+            onClick={() => this.props.navigation.goBack(null)}
+            style={styles.backArrow}
+          />
           <Text style={styles.title}>
             <fbt desc="PhoneScreen.verifyTitle">Verify phone</fbt>
           </Text>

--- a/mobile/src/screens/onboarding/pin.js
+++ b/mobile/src/screens/onboarding/pin.js
@@ -14,6 +14,7 @@ import SafeAreaView from 'react-native-safe-area-view'
 import { fbt } from 'fbt-runtime'
 
 import { setPin } from 'actions/Settings'
+import BackArrow from 'components/back-arrow'
 import PinInput from 'components/pin-input'
 import CommonStyles from 'styles/common'
 import OnboardingStyles from 'styles/onboarding'
@@ -78,6 +79,10 @@ class PinScreen extends Component {
             keyboardShouldPersistTaps={'always'}
           >
             <View style={styles.container}>
+              <BackArrow
+                onClick={() => this.props.navigation.goBack(null)}
+                style={styles.backArrow}
+              />
               <Text style={styles.title}>{title}</Text>
               {this.state.isRetry === true && (
                 <Text style={styles.invalid}>

--- a/mobile/src/styles/onboarding.js
+++ b/mobile/src/styles/onboarding.js
@@ -24,30 +24,6 @@ export default StyleSheet.create({
     textAlign: 'center',
     width: '80%'
   },
-  termsHeader: {
-    fontWeight: '600',
-    fontSize: 18,
-    marginBottom: 20,
-    textAlign: 'center'
-  },
-  termsText: {
-    paddingHorizontal: 20,
-    marginBottom: 20,
-    color: '#111d28'
-  },
-  termsHighlightContainer: {
-    borderColor: '#98a7b4',
-    backgroundColor: 'rgba(152, 167, 180, 0.1)',
-    borderWidth: 1,
-    paddingVertical: 20,
-    paddingHorizontal: 20,
-    marginVertical: 20,
-    width: '90%',
-    borderRadius: 5
-  },
-  termsHighlightText: {
-    color: '#6f8294'
-  },
   backArrow: {
     position: 'absolute',
     left: -10,

--- a/mobile/src/styles/onboarding.js
+++ b/mobile/src/styles/onboarding.js
@@ -47,5 +47,10 @@ export default StyleSheet.create({
   },
   termsHighlightText: {
     color: '#6f8294'
+  },
+  backArrow: {
+    position: 'absolute',
+    left: -10,
+    top: 18
   }
 })


### PR DESCRIPTION
Adds back arrows where needed in the mobile onboarding process according to what is in Zeplin. Positioned them slightly differently (alongside titles) to try and save space.