### PR TITLE
Bridge server now requires Redis.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,6 +252,7 @@ services:
     volumes: *volumes
     environment:
       - DATABASE_URL=postgres://origin:origin@postgres/origin
+      - REDIS_URL=redis://redis-master:6379
       - FACEBOOK_CLIENT_ID=
       - FACEBOOK_CLIENT_SECRET=
       # Sendgrid settings for email attestations
@@ -266,6 +267,7 @@ services:
       - ENVKEY=
     depends_on:
       - postgres
+      - redis-master
     ports:
       - "5000:5000"
     command:


### PR DESCRIPTION
The bridge server now requires Redis, but the docker-compose.yml file wasn’t updated to configure the needed connection URL.

This fix lets the bridge server start again in our docker env.