### PR TITLE
Fixes local docker config for ProxyFactor

### DIFF
--- a/packages/graphql/src/configs/docker.js
+++ b/packages/graphql/src/configs/docker.js
@@ -36,6 +36,8 @@ const config = {
   V00_Marketplace: addresses.Marketplace,
   IdentityEvents: addresses.IdentityEvents,
   DaiExchange: addresses.UniswapDaiExchange,
+  ProxyFactory: addresses.ProxyFactory,
+  ProxyFactory_Epoch: addresses.ProxyFactoryEpoch,
   tokens: []
 }
 


### PR DESCRIPTION
### Description:

Fixes an error reported by @DanielVF with local docker.  The listener would scream in pain because it didn't have the address for the ProxyFactory.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
