### PR TITLE
Fix escaped ›

### DIFF
--- a/dapps/marketplace/src/pages/transaction/_EscrowDetails.js
+++ b/dapps/marketplace/src/pages/transaction/_EscrowDetails.js
@@ -134,7 +134,7 @@ require('react-styl')(`
     font-weight: normal
     .btn-link
       &::after
-        content: " \\203A"
+        content: " ›"
       font-size: 14px
       font-weight: bold
     li

--- a/dapps/marketplace/src/pages/transaction/_OfferDetails.js
+++ b/dapps/marketplace/src/pages/transaction/_OfferDetails.js
@@ -125,7 +125,7 @@ require('react-styl')(`
     .btn-link
       > div
         &::after
-          content: " \\203A"
+          content: " ›"
         font-size: 14px
         font-weight: bold
     li

--- a/dapps/marketplace/src/pages/transaction/_Progress.js
+++ b/dapps/marketplace/src/pages/transaction/_Progress.js
@@ -364,7 +364,7 @@ require('react-styl')(`
         &.small
           font-size: 16px
       &::after
-        content: " \\203A"
+        content: " ›"
       &.withdraw
         font-size: 18px
         padding-top: 0


### PR DESCRIPTION
Fix > characters in CSS. The uglify/minify breaks the escaping so we end up with this:

<img width="545" alt="Screen Shot 2019-07-03 at 4 03 59 PM" src="https://user-images.githubusercontent.com/489202/60562609-5525ff00-9dac-11e9-979a-391a2e47c3c2.png">
