### PR TITLE
Fix IPFS Pinner by redoing parsing to match new formats.

### DIFF
--- a/devops/cloud-functions/gcf-pin-ipfs-hash/fixtures/listing-log.json
+++ b/devops/cloud-functions/gcf-pin-ipfs-hash/fixtures/listing-log.json
@@ -1,171 +1,146 @@
 {
-  "log": {
-    "logIndex": 0,
+  "event": {
+    "logIndex": 2,
     "transactionIndex": 0,
-    "transactionHash": "0xb483e7b699397c37c41fa9731a9d86a1cee611cfda2df3d37f8ba42015ce3dd8",
-    "blockHash": "0xe28f9a860209b4531e22bf11f17641c7b282a5f007e07eb725a035bb109c0ef9",
-    "blockNumber": 913,
-    "address": "0x73814E414B7744232Cc6C686E5d6E908D2C4e580",
-    "data": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86",
-    "topics": [
-      "0xec3d306143145322b45d2788d826e3b7b9ad062f16e1ec59a5eaba214f96ee3c",
-      "0x000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732",
-      "0x0000000000000000000000000000000000000000000000000000000000000003"
-    ],
+    "transactionHash": "0xe6b0bd5f9518d01c551a1c5417aaa6afa9cff40aa1156e5c464ca3e18990e72b",
+    "blockHash": "0xed15af1234a63cbdfc286e38438865edf74584840d0163c14dddba365a69f3cc",
+    "blockNumber": 57,
+    "address": "0xf25186B5081Ff5cE73482AD761DB0eB0d25abfBF",
     "type": "mined",
-    "id": "log_d3a957cd",
-    "decoded": {
+    "id": "log_92909768",
+    "returnValues": {
       "0": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-      "1": "3",
-      "2": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86",
-      "__length__": 3,
+      "1": "5",
+      "2": "0x173bee2a2c82356e57282bc0377091a62e9ee3222ba4d5ff0786637af32304e6",
       "party": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-      "listingID": "3",
-      "ipfsHash": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86"
+      "listingID": "5",
+      "ipfsHash": "0x173bee2a2c82356e57282bc0377091a62e9ee3222ba4d5ff0786637af32304e6"
     },
-    "contractName": "V00_Marketplace",
-    "eventName": "ListingCreated",
-    "contractVersionKey": "000",
-    "networkId": 999,
-    "timestamp": 1551229332,
-    "date": "2019-02-27T01:02:12.000Z"
+    "event": "ListingCreated",
+    "signature": "0xec3d306143145322b45d2788d826e3b7b9ad062f16e1ec59a5eaba214f96ee3c",
+    "raw": {
+      "data": "0x173bee2a2c82356e57282bc0377091a62e9ee3222ba4d5ff0786637af32304e6",
+      "topics": [
+        "0xec3d306143145322b45d2788d826e3b7b9ad062f16e1ec59a5eaba214f96ee3c",
+        "0x000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732",
+        "0x0000000000000000000000000000000000000000000000000000000000000005"
+      ]
+    }
   },
   "related": {
     "listing": {
-      "id": "999-000-3",
+      "id": "999-000-5-57",
+      "valid": true,
+      "validationError": null,
+      "status": "active",
+      "totalEvents": 1,
+      "seller": {
+        "id": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+        "identity": {
+          "firstName": "Stan",
+          "lastName": "James",
+          "fullName": "Stan James",
+          "owner": {
+            "id": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+            "proxy": {
+              "id": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+              "__typename": "Account"
+            },
+            "__typename": "Account"
+          },
+          "__typename": "Identity"
+        },
+        "__typename": "Account"
+      },
+      "arbitrator": {
+        "id": "0x821aEa9a577a9b44299B9c15c88cf3087F3b5544",
+        "__typename": "Account"
+      },
+      "deposit": "5000000000000000000",
+      "depositAvailable": "5000000000000000000",
+      "createdEvent": {
+        "timestamp": 1562089659,
+        "__typename": "Event"
+      },
+      "category": "schema.forSale",
+      "categoryStr": "For Sale",
+      "subCategory": "schema.tickets",
       "title": "Taylor Swift's Reputation Tour",
       "description": "Taylor Swift's Reputation Stadium Tour is the fifth world concert tour by American singer-songwriter Taylor Swift, in support of her sixth studio album, Reputation.",
-      "category": "schema.forSale",
-      "subCategory": "schema.tickets",
-      "status": "active",
-      "type": "unit",
-      "unitsTotal": 5,
-      "offers": [],
-      "events": [
+      "currencyId": null,
+      "price": {
+        "amount": "95",
+        "currency": {
+          "id": "fiat-USD",
+          "__typename": "FiatCurrency"
+        },
+        "__typename": "Price"
+      },
+      "acceptedTokens": [
         {
-          "logIndex": 0,
-          "transactionIndex": 0,
-          "transactionHash": "0xb483e7b699397c37c41fa9731a9d86a1cee611cfda2df3d37f8ba42015ce3dd8",
-          "blockHash": "0xe28f9a860209b4531e22bf11f17641c7b282a5f007e07eb725a035bb109c0ef9",
-          "blockNumber": 913,
-          "address": "0x73814E414B7744232Cc6C686E5d6E908D2C4e580",
-          "type": "mined",
-          "id": "log_d3a957cd",
-          "returnValues": {
-            "0": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-            "1": "3",
-            "2": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86",
-            "party": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-            "listingID": "3",
-            "ipfsHash": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86"
-          },
-          "event": "ListingCreated",
-          "signature": "0xec3d306143145322b45d2788d826e3b7b9ad062f16e1ec59a5eaba214f96ee3c",
-          "raw": {
-            "data": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86",
-            "topics": [
-              "0xec3d306143145322b45d2788d826e3b7b9ad062f16e1ec59a5eaba214f96ee3c",
-              "0x000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732",
-              "0x0000000000000000000000000000000000000000000000000000000000000003"
-            ]
-          }
+          "id": "token-ETH",
+          "__typename": "Token"
         }
       ],
-      "ipfs": {
-        "hash": "QmNyo8RCuhqDCgyQkVuihjTB1KJ3EXxkiTHmkzukFiw9Nd",
-        "data": {
-          "schemaId": "https://schema.originprotocol.com/listing_1.0.0.json",
-          "dappSchemaId": "https://dapp.originprotocol.com/schemas/forSale-tickets_1.0.0.json",
-          "listingType": "unit",
-          "category": "schema.forSale",
-          "subCategory": "schema.tickets",
-          "language": "en-US",
-          "title": "Taylor Swift's Reputation Tour",
-          "description": "Taylor Swift's Reputation Stadium Tour is the fifth world concert tour by American singer-songwriter Taylor Swift, in support of her sixth studio album, Reputation.",
-          "unitsTotal": 5,
-          "price": {
-            "currency": "ETH",
-            "amount": "0.3"
-          },
-          "commission": {
-            "currency": "OGN",
-            "amount": "28"
-          },
-          "commissionPerUnit": {
-            "currency": "OGN",
-            "amount": "10"
-          },
-          "media": [
-            {
-              "url": "http://origin-ipfs-proxy:9999/ipfs/QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M",
-              "contentType": "image/jpeg"
-            },
-            {
-              "url": "http://origin-ipfs-proxy:9999/ipfs/QmSXucmB6BHgFUW6wZyXknD3HrAtXvAy2t7JHMgXXNU79n",
-              "contentType": "image/jpeg"
-            },
-            {
-              "url": "http://origin-ipfs-proxy:9999/ipfs/QmZLxmJBPY3ae9PNqKZhWZX6oF764sxXAQw3y3fJu2xgw1",
-              "contentType": "image/jpeg"
-            },
-            {
-              "url": "http://origin-ipfs-proxy:9999/ipfs/QmQJymkfuCCPFnRDvi6jJALhBTqBRToJ5gGay2sPBEHFtY",
-              "contentType": "image/jpeg"
-            },
-            {
-              "url": "http://origin-ipfs-proxy:9999/ipfs/QmRPJzi5wDVkrwqGVDqVoYsJr6AonysisjszuMbEbJAD8w",
-              "contentType": "image/jpeg"
-            }
-          ]
-        }
-      },
-      "ipfsHash": "0x0984026f8ff653673a90028f434d5aa99def303087b7219c8c603462b64e6e86",
-      "language": "en-US",
-      "price": {
-        "currency": "ETH",
-        "amount": "0.3"
-      },
-      "seller": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-      "display": "normal",
       "media": [
         {
-          "url": "http://origin-ipfs-proxy:9999/ipfs/QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M",
-          "contentType": "image/jpeg"
+          "url": "ipfs://QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M",
+          "urlExpanded": "http://ipfs-proxy:9999/ipfs/QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M",
+          "contentType": "image/jpeg",
+          "__typename": "Media"
         },
         {
-          "url": "http://origin-ipfs-proxy:9999/ipfs/QmSXucmB6BHgFUW6wZyXknD3HrAtXvAy2t7JHMgXXNU79n",
-          "contentType": "image/jpeg"
+          "url": "ipfs://QmSXucmB6BHgFUW6wZyXknD3HrAtXvAy2t7JHMgXXNU79n",
+          "urlExpanded": "http://ipfs-proxy:9999/ipfs/QmSXucmB6BHgFUW6wZyXknD3HrAtXvAy2t7JHMgXXNU79n",
+          "contentType": "image/jpeg",
+          "__typename": "Media"
         },
         {
-          "url": "http://origin-ipfs-proxy:9999/ipfs/QmZLxmJBPY3ae9PNqKZhWZX6oF764sxXAQw3y3fJu2xgw1",
-          "contentType": "image/jpeg"
+          "url": "ipfs://QmZLxmJBPY3ae9PNqKZhWZX6oF764sxXAQw3y3fJu2xgw1",
+          "urlExpanded": "http://ipfs-proxy:9999/ipfs/QmZLxmJBPY3ae9PNqKZhWZX6oF764sxXAQw3y3fJu2xgw1",
+          "contentType": "image/jpeg",
+          "__typename": "Media"
         },
         {
-          "url": "http://origin-ipfs-proxy:9999/ipfs/QmQJymkfuCCPFnRDvi6jJALhBTqBRToJ5gGay2sPBEHFtY",
-          "contentType": "image/jpeg"
+          "url": "ipfs://QmQJymkfuCCPFnRDvi6jJALhBTqBRToJ5gGay2sPBEHFtY",
+          "urlExpanded": "http://ipfs-proxy:9999/ipfs/QmQJymkfuCCPFnRDvi6jJALhBTqBRToJ5gGay2sPBEHFtY",
+          "contentType": "image/jpeg",
+          "__typename": "Media"
         },
         {
-          "url": "http://origin-ipfs-proxy:9999/ipfs/QmRPJzi5wDVkrwqGVDqVoYsJr6AonysisjszuMbEbJAD8w",
-          "contentType": "image/jpeg"
+          "url": "ipfs://QmRPJzi5wDVkrwqGVDqVoYsJr6AonysisjszuMbEbJAD8w",
+          "urlExpanded": "http://ipfs-proxy:9999/ipfs/QmRPJzi5wDVkrwqGVDqVoYsJr6AonysisjszuMbEbJAD8w",
+          "contentType": "image/jpeg",
+          "__typename": "Media"
         }
       ],
-      "commission": {
-        "currency": "OGN",
-        "amount": "28"
-      },
-      "schemaId": "https://schema.originprotocol.com/listing_1.0.0.json",
-      "dappSchemaId": "https://dapp.originprotocol.com/schemas/forSale-tickets_1.0.0.json",
-      "deposit": "0",
-      "depositManager": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-      "commissionPerUnit": {
-        "currency": "OGN",
-        "amount": "10"
-      }
+      "commission": "10000000000000000000",
+      "commissionPerUnit": "2000000000000000000",
+      "marketplacePublisher": null,
+      "unitsTotal": 10,
+      "unitsAvailable": 10,
+      "unitsSold": 0,
+      "unitsPending": 0,
+      "multiUnit": true,
+      "__typename": "UnitListing",
+      "events": [
+        {
+          "id": "log_92909768",
+          "event": "ListingCreated",
+          "blockNumber": 57,
+          "logIndex": 2,
+          "returnValues": {
+            "ipfsHash": "0x173bee2a2c82356e57282bc0377091a62e9ee3222ba4d5ff0786637af32304e6",
+            "party": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+            "offerID": null,
+            "listingID": "5",
+            "__typename": "EventReturnValues"
+          },
+          "__typename": "Event"
+        }
+      ],
+      "scoreTags": []
     },
-    "seller": {
-      "address": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
-      "version": null
-    }
+    "__typename": "Marketplace"
   }
 }
-

--- a/devops/cloud-functions/gcf-pin-ipfs-hash/fixtures/profile-log.json
+++ b/devops/cloud-functions/gcf-pin-ipfs-hash/fixtures/profile-log.json
@@ -1,0 +1,48 @@
+{
+    "event": {
+      "logIndex": 0,
+      "transactionIndex": 0,
+      "transactionHash": "0xfa322f26a1673821211a4a956066094e6dbf7141239f04a3f2379243d9887a2b",
+      "blockHash": "0x18b3d681eba9d275e3ba4e7dae9148f5842f79ce5035ff6389c6e4e8afb4a6bf",
+      "blockNumber": 33,
+      "address": "0x0d8cc4b8d15D4c3eF1d70af0071376fb26B5669b",
+      "type": "mined",
+      "id": "log_95453a94",
+      "returnValues": {
+        "0": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+        "1": "0xe3528b94d86bc248c58b04fd9d0862cf8c41a4f852609f0c85472c1054a018ce",
+        "account": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+        "ipfsHash": "0xe3528b94d86bc248c58b04fd9d0862cf8c41a4f852609f0c85472c1054a018ce"
+      },
+      "event": "IdentityUpdated",
+      "signature": "0x8a49a94a170e0377e29de8e4b741993bed3dc902443fdc59d79e455137ecab18",
+      "raw": {
+        "data": "0xe3528b94d86bc248c58b04fd9d0862cf8c41a4f852609f0c85472c1054a018ce",
+        "topics": [
+          "0x8a49a94a170e0377e29de8e4b741993bed3dc902443fdc59d79e455137ecab18",
+          "0x000000000000000000000000f17f52151ebef6c7334fad080c5704d77216b732"
+        ]
+      }
+    },
+    "related": {
+      "identity": {
+        "id": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+        "firstName": "Stan",
+        "lastName": "James",
+        "fullName": "Stan James",
+        "description": "Hi from Stan",
+        "avatarUrl": "ipfs://QmfPuEBRpy97JrgbKdS842TeYb11UzJjASVoNp9HiwrDoB",
+        "strength": 30,
+        "attestations": [],
+        "verifiedAttestations": [],
+        "ipfsHash": "Qmde2G46g9NtKtA3bmqdwgGJc4PGdRqw3LfM1tqq6B2UTw",
+        "owner": {
+          "id": "0xf17f52151EbEF6C7334FAD080c5704D77216b732",
+          "__typename": "Account"
+        },
+        "__typename": "Identity",
+        "country": null
+      }
+    }
+  }
+  

--- a/devops/cloud-functions/gcf-pin-ipfs-hash/test.js
+++ b/devops/cloud-functions/gcf-pin-ipfs-hash/test.js
@@ -3,23 +3,35 @@ const expect = chai.expect
 const fs = require('fs')
 
 const listingLog = JSON.parse(fs.readFileSync('fixtures/listing-log.json'))
+const profileLog = JSON.parse(fs.readFileSync('fixtures/profile-log.json'))
 const { extractIpfsHashFromUrl, parseIncomingData } = require('./index.js')
 
-describe('parse', () => {
+describe('Parse', () => {
   it('should correctly parse listings', () => {
     const hashesToPin = parseIncomingData(listingLog)
-    expect(hashesToPin).to.be.an('array').to.have.members([
-      'QmNyo8RCuhqDCgyQkVuihjTB1KJ3EXxkiTHmkzukFiw9Nd',
-      'QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M',
-      'QmSXucmB6BHgFUW6wZyXknD3HrAtXvAy2t7JHMgXXNU79n',
-      'QmZLxmJBPY3ae9PNqKZhWZX6oF764sxXAQw3y3fJu2xgw1',
-      'QmQJymkfuCCPFnRDvi6jJALhBTqBRToJ5gGay2sPBEHFtY',
-      'QmRPJzi5wDVkrwqGVDqVoYsJr6AonysisjszuMbEbJAD8w'
-    ])
+    expect(hashesToPin)
+      .to.be.an('array')
+      .to.have.members([
+        'QmPuM68aFbWb9HRDi6wQzxebGgoRhcydyV2csbb6ZZ3wWm',
+        'QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M',
+        'QmSXucmB6BHgFUW6wZyXknD3HrAtXvAy2t7JHMgXXNU79n',
+        'QmZLxmJBPY3ae9PNqKZhWZX6oF764sxXAQw3y3fJu2xgw1',
+        'QmQJymkfuCCPFnRDvi6jJALhBTqBRToJ5gGay2sPBEHFtY',
+        'QmRPJzi5wDVkrwqGVDqVoYsJr6AonysisjszuMbEbJAD8w'
+      ])
+  })
+  it('should correctly parse identity profiles', () => {
+    const hashesToPin = parseIncomingData(profileLog)
+    expect(hashesToPin)
+      .to.be.an('array')
+      .to.have.members([
+        'Qmde2G46g9NtKtA3bmqdwgGJc4PGdRqw3LfM1tqq6B2UTw',
+        'QmfPuEBRpy97JrgbKdS842TeYb11UzJjASVoNp9HiwrDoB'
+      ])
   })
 })
 
-describe('extract ipfs hash from url', () => {
+describe('Extract ipfs hash from url', () => {
   it('should handle ipfs:// correctly', () => {
     const result = extractIpfsHashFromUrl(
       'ipfs://QmU2NeZjiJZ7TyFCwqHp2bd7MH1bSyZbSAgGxNSR2iUQ3M'

--- a/devops/cloud-functions/gcf-pin-ipfs-hash/util_base58.js
+++ b/devops/cloud-functions/gcf-pin-ipfs-hash/util_base58.js
@@ -1,0 +1,158 @@
+'use strict'
+// https://github.com/cryptocoinjs/base-x
+// base-x encoding / decoding
+// Copyright (c) 2018 base-x contributors
+// Copyright (c) 2014-2018 The Bitcoin Core developers (base58.cpp)
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+// @ts-ignore
+var _Buffer = require('safe-buffer').Buffer
+function base(ALPHABET) {
+  if (ALPHABET.length >= 255) {
+    throw new TypeError('Alphabet too long')
+  }
+  var BASE_MAP = new Uint8Array(256)
+  BASE_MAP.fill(255)
+  for (var i = 0; i < ALPHABET.length; i++) {
+    var x = ALPHABET.charAt(i)
+    var xc = x.charCodeAt(0)
+    if (BASE_MAP[xc] !== 255) {
+      throw new TypeError(x + ' is ambiguous')
+    }
+    BASE_MAP[xc] = i
+  }
+  var BASE = ALPHABET.length
+  var LEADER = ALPHABET.charAt(0)
+  var FACTOR = Math.log(BASE) / Math.log(256) // log(BASE) / log(256), rounded up
+  var iFACTOR = Math.log(256) / Math.log(BASE) // log(256) / log(BASE), rounded up
+  function encode(source) {
+    if (!_Buffer.isBuffer(source)) {
+      throw new TypeError('Expected Buffer')
+    }
+    if (source.length === 0) {
+      return ''
+    }
+    // Skip & count leading zeroes.
+    var zeroes = 0
+    var length = 0
+    var pbegin = 0
+    var pend = source.length
+    while (pbegin !== pend && source[pbegin] === 0) {
+      pbegin++
+      zeroes++
+    }
+    // Allocate enough space in big-endian base58 representation.
+    var size = ((pend - pbegin) * iFACTOR + 1) >>> 0
+    var b58 = new Uint8Array(size)
+    // Process the bytes.
+    while (pbegin !== pend) {
+      var carry = source[pbegin]
+      // Apply "b58 = b58 * 256 + ch".
+      var i = 0
+      for (
+        var it1 = size - 1;
+        (carry !== 0 || i < length) && it1 !== -1;
+        it1--, i++
+      ) {
+        carry += (256 * b58[it1]) >>> 0
+        b58[it1] = carry % BASE >>> 0
+        carry = (carry / BASE) >>> 0
+      }
+      if (carry !== 0) {
+        throw new Error('Non-zero carry')
+      }
+      length = i
+      pbegin++
+    }
+    // Skip leading zeroes in base58 result.
+    var it2 = size - length
+    while (it2 !== size && b58[it2] === 0) {
+      it2++
+    }
+    // Translate the result into a string.
+    var str = LEADER.repeat(zeroes)
+    for (; it2 < size; ++it2) {
+      str += ALPHABET.charAt(b58[it2])
+    }
+    return str
+  }
+  function decodeUnsafe(source) {
+    if (typeof source !== 'string') {
+      throw new TypeError('Expected String')
+    }
+    if (source.length === 0) {
+      return _Buffer.alloc(0)
+    }
+    var psz = 0
+    // Skip leading spaces.
+    if (source[psz] === ' ') {
+      return
+    }
+    // Skip and count leading '1's.
+    var zeroes = 0
+    var length = 0
+    while (source[psz] === LEADER) {
+      zeroes++
+      psz++
+    }
+    // Allocate enough space in big-endian base256 representation.
+    var size = ((source.length - psz) * FACTOR + 1) >>> 0 // log(58) / log(256), rounded up.
+    var b256 = new Uint8Array(size)
+    // Process the characters.
+    while (source[psz]) {
+      // Decode character
+      var carry = BASE_MAP[source.charCodeAt(psz)]
+      // Invalid character
+      if (carry === 255) {
+        return
+      }
+      var i = 0
+      for (
+        var it3 = size - 1;
+        (carry !== 0 || i < length) && it3 !== -1;
+        it3--, i++
+      ) {
+        carry += (BASE * b256[it3]) >>> 0
+        b256[it3] = carry % 256 >>> 0
+        carry = (carry / 256) >>> 0
+      }
+      if (carry !== 0) {
+        throw new Error('Non-zero carry')
+      }
+      length = i
+      psz++
+    }
+    // Skip trailing spaces.
+    if (source[psz] === ' ') {
+      return
+    }
+    // Skip leading zeroes in b256.
+    var it4 = size - length
+    while (it4 !== size && b256[it4] === 0) {
+      it4++
+    }
+    var vch = _Buffer.allocUnsafe(zeroes + (size - it4))
+    vch.fill(0x00, 0, zeroes)
+    var j = zeroes
+    while (it4 !== size) {
+      vch[j++] = b256[it4++]
+    }
+    return vch
+  }
+  function decode(string) {
+    var buffer = decodeUnsafe(string)
+    if (buffer) {
+      return buffer
+    }
+    throw new Error('Non-base' + BASE + ' character')
+  }
+  return {
+    encode: encode,
+    decodeUnsafe: decodeUnsafe,
+    decode: decode
+  }
+}
+
+var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+module.exports = base(ALPHABET)


### PR DESCRIPTION
This fixes the IPFS pinner to work with the new post-GraphQL data format.

Parsing tests are updated to check that it works.

I can't actually test the whole integration with google function, and the whole devops side. Let me know if there are any problems.