### PR TITLE
Makes sure setLatestBlock is called for ProxyFactory contract

### DIFF
--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -56,6 +56,7 @@ export function newBlock(blockHeaders) {
   lastBlock = blockHeaders.number
   context.marketplace.eventCache.setLatestBlock(lastBlock)
   context.identityEvents.eventCache.setLatestBlock(lastBlock)
+  context.ProxyFactory.eventCache.setLatestBlock(lastBlock)
   context.eventSource.resetCache()
   pubsub.publish('NEW_BLOCK', {
     newBlock: { ...blockHeaders, id: blockHeaders.hash }


### PR DESCRIPTION
### Description:

When `useLatestFromChain` is set to `false`, the `latestBlock` needs to be set by some external force.  In this case, `@origin/graphql`'s block header websocket listener.

Closes #2619 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
