### PR TITLE
Mo' DApp Cleanup

### DIFF
--- a/dapps/marketplace/src/components/DownloadApp.js
+++ b/dapps/marketplace/src/components/DownloadApp.js
@@ -1,13 +1,7 @@
 import React from 'react'
 import { fbt } from 'fbt-runtime'
 
-import withWallet from 'hoc/withWallet'
-
-const DownloadApp = ({ walletType }) => {
-  if (walletType === 'Origin Wallet') {
-    return null
-  }
-
+const DownloadApp = () => {
   return (
     <div className="onboard-help origin-wallet">
       <div className="app-image mb-3">
@@ -35,7 +29,7 @@ const DownloadApp = ({ walletType }) => {
   )
 }
 
-export default withWallet(DownloadApp)
+export default DownloadApp
 
 require('react-styl')(`
   .onboard-help.origin-wallet

--- a/dapps/marketplace/src/components/ImagePicker.js
+++ b/dapps/marketplace/src/components/ImagePicker.js
@@ -215,7 +215,7 @@ require('react-styl')(`
       .img
         background-position: center
         width: 100%
-        padding-top: 66%
+        padding-top: 75%
         background-size: contain
         background-repeat: no-repeat
 

--- a/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
@@ -6,6 +6,7 @@ import Categories from '@origin/graphql/src/constants/Categories'
 import Link from 'components/Link'
 import Redirect from 'components/Redirect'
 import DownloadApp from 'components/DownloadApp'
+import withIsMobile from 'hoc/withIsMobile'
 
 const CategoriesEnum = require('Categories$FbtEnum') // Localized category names
 
@@ -68,7 +69,7 @@ function propsForType(category, subCategory) {
   return { __typename, category, subCategory }
 }
 
-const ChooseListingCategory = ({ listing, prev, next, onChange }) => {
+const ChooseListingCategory = ({ isMobileApp, listing, prev, next, onChange }) => {
   const [valid, setValid] = useState(false)
   const categoryId = get(listing, 'category')
   const categoryShortId = categoryId.split('.')[1]
@@ -125,17 +126,19 @@ const ChooseListingCategory = ({ listing, prev, next, onChange }) => {
             </div>
           </div>
         </div>
-        <div className="col-md-4">
-          <div className="gray-box">
-            <DownloadApp />
+        {isMobileApp &&
+          <div className="col-md-4">
+            <div className="gray-box">
+              <DownloadApp />
+            </div>
           </div>
-        </div>
+        }
       </div>
     </>
   )
 }
 
-export default ChooseListingCategory
+export default withIsMobile(ChooseListingCategory)
 
 require('react-styl')(`
   .create-listing

--- a/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
@@ -24,6 +24,7 @@ const hourlyFractional = [
   'schema.tools'
 ]
 const nightlyFractional = [
+  'schema.appliances',
   'schema.babyKidStuff',
   'schema.cellPhones',
   'schema.clothingAccessories',

--- a/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
@@ -70,7 +70,13 @@ function propsForType(category, subCategory) {
   return { __typename, category, subCategory }
 }
 
-const ChooseListingCategory = ({ isMobileApp, listing, prev, next, onChange }) => {
+const ChooseListingCategory = ({
+  isMobileApp,
+  listing,
+  prev,
+  next,
+  onChange
+}) => {
   const [valid, setValid] = useState(false)
   const categoryId = get(listing, 'category')
   const categoryShortId = categoryId.split('.')[1]
@@ -127,13 +133,13 @@ const ChooseListingCategory = ({ isMobileApp, listing, prev, next, onChange }) =
             </div>
           </div>
         </div>
-        {!isMobileApp &&
+        {!isMobileApp && (
           <div className="col-md-4">
             <div className="gray-box">
               <DownloadApp />
             </div>
           </div>
-        }
+        )}
       </div>
     </>
   )

--- a/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
@@ -6,7 +6,7 @@ import Categories from '@origin/graphql/src/constants/Categories'
 import Link from 'components/Link'
 import Redirect from 'components/Redirect'
 import DownloadApp from 'components/DownloadApp'
-import withIsMobile from 'hoc/withIsMobile'
+import withWallet from 'hoc/withWallet'
 
 const CategoriesEnum = require('Categories$FbtEnum') // Localized category names
 
@@ -71,10 +71,10 @@ function propsForType(category, subCategory) {
 }
 
 const ChooseListingCategory = ({
-  isMobileApp,
   listing,
   prev,
   next,
+  walletType,
   onChange
 }) => {
   const [valid, setValid] = useState(false)
@@ -133,7 +133,7 @@ const ChooseListingCategory = ({
             </div>
           </div>
         </div>
-        {!isMobileApp && (
+        {walletType !== 'Mobile' && walletType !== 'Origin Wallet' && (
           <div className="col-md-4">
             <div className="gray-box">
               <DownloadApp />
@@ -145,7 +145,7 @@ const ChooseListingCategory = ({
   )
 }
 
-export default withIsMobile(ChooseListingCategory)
+export default withWallet(ChooseListingCategory)
 
 require('react-styl')(`
   .create-listing

--- a/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseCategory.js
@@ -127,7 +127,7 @@ const ChooseListingCategory = ({ isMobileApp, listing, prev, next, onChange }) =
             </div>
           </div>
         </div>
-        {isMobileApp &&
+        {!isMobileApp &&
           <div className="col-md-4">
             <div className="gray-box">
               <DownloadApp />

--- a/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
@@ -6,7 +6,7 @@ import Categories from '@origin/graphql/src/constants/Categories'
 import Redirect from 'components/Redirect'
 import DownloadApp from 'components/DownloadApp'
 import withCreatorConfig from 'hoc/withCreatorConfig'
-import withIsMobile from 'hoc/withIsMobile'
+import withWallet from 'hoc/withWallet'
 
 const CategoriesEnum = require('Categories$FbtEnum') // Localized category names
 
@@ -61,7 +61,7 @@ const ChooseListingType = props => {
             ))}
           </div>
         </div>
-        {!props.isMobileApp && (
+        {props.walletType !== 'Mobile' && props.walletType !== 'Origin Wallet' && (
           <div className="col-md-4">
             <div className="gray-box d-none d-md-block">
               <DownloadApp />
@@ -73,7 +73,7 @@ const ChooseListingType = props => {
   )
 }
 
-export default withCreatorConfig(withIsMobile(ChooseListingType))
+export default withCreatorConfig(withWallet(ChooseListingType))
 
 require('react-styl')(`
   .category-ico

--- a/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
@@ -61,7 +61,7 @@ const ChooseListingType = props => {
             ))}
           </div>
         </div>
-        {props.isMobileApp &&
+        {!props.isMobileApp &&
           <div className="col-md-4">
             <div className="gray-box d-none d-md-block">
               <DownloadApp />

--- a/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
@@ -61,21 +61,19 @@ const ChooseListingType = props => {
             ))}
           </div>
         </div>
-        {!props.isMobileApp &&
+        {!props.isMobileApp && (
           <div className="col-md-4">
             <div className="gray-box d-none d-md-block">
               <DownloadApp />
             </div>
           </div>
-        }
+        )}
       </div>
     </>
   )
 }
 
-export default withCreatorConfig(
-  withIsMobile(ChooseListingType)
-)
+export default withCreatorConfig(withIsMobile(ChooseListingType))
 
 require('react-styl')(`
   .category-ico

--- a/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
@@ -6,6 +6,7 @@ import Categories from '@origin/graphql/src/constants/Categories'
 import Redirect from 'components/Redirect'
 import DownloadApp from 'components/DownloadApp'
 import withCreatorConfig from 'hoc/withCreatorConfig'
+import withIsMobile from 'hoc/withIsMobile'
 
 const CategoriesEnum = require('Categories$FbtEnum') // Localized category names
 
@@ -60,17 +61,21 @@ const ChooseListingType = props => {
             ))}
           </div>
         </div>
-        <div className="col-md-4">
-          <div className="gray-box d-none d-md-block">
-            <DownloadApp />
+        {props.isMobileApp &&
+          <div className="col-md-4">
+            <div className="gray-box d-none d-md-block">
+              <DownloadApp />
+            </div>
           </div>
-        </div>
+        }
       </div>
     </>
   )
 }
 
-export default withCreatorConfig(ChooseListingType)
+export default withCreatorConfig(
+  withIsMobile(ChooseListingType)
+)
 
 require('react-styl')(`
   .category-ico

--- a/dapps/marketplace/src/pages/listing/ListingDetail.js
+++ b/dapps/marketplace/src/pages/listing/ListingDetail.js
@@ -432,7 +432,7 @@ require('react-styl')(`
     .gallery
       margin-bottom: 1rem
       .main-pic
-        padding-top: 100%
+        padding-top: 75%
         background-size: contain
         background-repeat: no-repeat
         background-position: center

--- a/dapps/marketplace/src/pages/listings/ListingCards.js
+++ b/dapps/marketplace/src/pages/listings/ListingCards.js
@@ -133,7 +133,7 @@ require('react-styl')(`
     cursor: pointer
 
     .main-pic
-      padding-top: 66.6%
+      padding-top: 75%
       background-size: cover
       background-repeat: no-repeat
       background-position: center

--- a/dapps/marketplace/src/pages/nav/Profile.js
+++ b/dapps/marketplace/src/pages/nav/Profile.js
@@ -154,15 +154,17 @@ const Identity = ({
         </Link>
         <Attestations profile={identity} />
       </div>
-      <div className="strength">
-        <div className="progress">
-          <div className="progress-bar" style={{ width: strengthPct }} />
+      <Link onClick={() => onClose()} to="/profile">
+        <div className="strength">
+          <div className="progress">
+            <div className="progress-bar" style={{ width: strengthPct }} />
+          </div>
+          <fbt desc="nav.profile.ProfileStrength">
+            {'Profile Strength - '}
+            <fbt:param name="percent">{strengthPct}</fbt:param>
+          </fbt>
         </div>
-        <fbt desc="nav.profile.ProfileStrength">
-          {'Profile Strength - '}
-          <fbt:param name="percent">{strengthPct}</fbt:param>
-        </fbt>
-      </div>
+      </Link>
       <EarnTokens
         className="btn btn-outline-primary earn-ogn"
         onClick={onRewardsClick}

--- a/dapps/marketplace/src/pages/nav/Profile.js
+++ b/dapps/marketplace/src/pages/nav/Profile.js
@@ -322,9 +322,13 @@ require('react-styl')(`
               margin-bottom: 0.5rem
         .earn-ogn
           border-radius: 3rem
+          color: var(--clear-blue)
+          cursor: pointer
           margin: 1.5rem 0 1.25rem 0
           padding-left: 3rem
           padding-right: 3rem
+          &:hover
+            color: white
         .balances
           border-top: 1px solid #dde6ea
           h5

--- a/dapps/marketplace/src/pages/settings/Settings.js
+++ b/dapps/marketplace/src/pages/settings/Settings.js
@@ -384,11 +384,13 @@ class Settings extends Component {
                     </div>
                   </div>
                 </div>
-                {this.state.developerMode &&
+                {this.state.developerMode && (
                   <div className="text-center test-builds">
-                    <a href="https://originprotocol.github.io/test-builds/">Test Builds</a>
+                    <a href="https://originprotocol.github.io/test-builds/">
+                      Test Builds
+                    </a>
                   </div>
-                }
+                )}
               </div>
             </div>
             {/* TODO: See #2320

--- a/dapps/marketplace/src/pages/settings/Settings.js
+++ b/dapps/marketplace/src/pages/settings/Settings.js
@@ -384,6 +384,11 @@ class Settings extends Component {
                     </div>
                   </div>
                 </div>
+                {this.state.developerMode &&
+                  <div className="text-center test-builds">
+                    <a href="https://originprotocol.github.io/test-builds/">Test Builds</a>
+                  </div>
+                }
               </div>
             </div>
             {/* TODO: See #2320
@@ -517,6 +522,8 @@ require('react-styl')(`
 
     .restore
       color: var(--clear-blue)
+  .test-builds
+    font-size: 0.875rem
 
   @media (max-width: 767.98px)
     .settings


### PR DESCRIPTION
- Removes the mobile app CTA from listing creation when in our app
- Uses the aspect ratio that we recommend to users (4:3) on desktop
- Makes appliances listing creation use the hourly fractional steps
- Causes the strenth meter to link to the profile screen
- Adds a link to the test builds buried in developer mode settings

[Deployed to test build](https://originprotocol.github.io/test-builds/micah/#/) ☑️