### PR TITLE
Add title and back arrow to growth ineligible screen on mobile

### DIFF
--- a/mobile/src/screens/onboarding/growth-terms.js
+++ b/mobile/src/screens/onboarding/growth-terms.js
@@ -94,7 +94,16 @@ class GrowthTermsScreen extends Component {
   renderIneligible() {
     return (
       <>
-        <View style={{ ...styles.container, marginTop: 50 }}>
+        <View style={{ ...styles.container, justifyContent: 'flex-start' }}>
+          <BackArrow
+            onClick={() => this.props.navigation.goBack(null)}
+            style={styles.backArrow}
+          />
+          <Text style={styles.title}>
+            <fbt desc="GrowthTermsScreen.ineligibleTitle">Origin Rewards</fbt>
+          </Text>
+        </View>
+        <View style={styles.container}>
           <Image
             style={styles.image}
             source={require(IMAGES_PATH + 'not-eligible-graphic.png')}


### PR DESCRIPTION
Adds a page title and back arrow to the growth ineligibility screen on mobile. Different to what is in Zeplin. But it sounds like we wanted this from chatting with @micahalcorn.