### PR TITLE
Relayer: One tx per proxy

### DIFF
--- a/infra/relayer/src/purse.js
+++ b/infra/relayer/src/purse.js
@@ -476,7 +476,7 @@ class Purse {
    */
   async hasPendingTo(proxy) {
     proxy = this.web3.utils.toChecksumAddress(proxy)
-    for (const txHash of this.transactionObjects) {
+    for (const txHash of Object.keys(this.transactionObjects)) {
       if (this.transactionObjects[txHash].to === proxy) {
         return true
       }

--- a/infra/relayer/src/purse.js
+++ b/infra/relayer/src/purse.js
@@ -287,6 +287,7 @@ class Purse {
     // Set the from and nonce for the account
     tx = {
       ...tx,
+      to: this.web3.utils.toChecksumAddress(tx.to),
       from: address,
       nonce: await this.txCount(address)
     }
@@ -468,6 +469,19 @@ class Purse {
       }
       return JSON.parse(txObjStr)
     }
+  }
+
+  /**
+   * Check if there are any pending transactions to an account.
+   */
+  async hasPendingTo(proxy) {
+    proxy = this.web3.utils.toChecksumAddress(proxy)
+    for (const txHash of this.transactionObjects) {
+      if (this.transactionObjects[txHash].to === proxy) {
+        return true
+      }
+    }
+    return false
   }
 
   /**

--- a/infra/relayer/src/relayer.js
+++ b/infra/relayer/src/relayer.js
@@ -254,6 +254,19 @@ class Relayer {
         return res.status(400).send({ errors: ['Proxy exists'] })
       }
 
+      // Check if it already has pending
+      /**
+       * TODO: This is a temporary solution to prevent users from submitting a
+       * tx with a bad proxy nonce.  A more permanent solution will be required.
+       * See: https://github.com/OriginProtocol/origin/issues/2631
+       */
+      if (await this.purse.hasPendingTo(proxy)) {
+        logger.error(`Proxy ${proxy} already has a pending transaction`)
+        return res
+          .status(429)
+          .send({ errors: ['Proxy has pending transaction'] })
+      }
+
       nonce = await UserProxy.methods.nonce(from).call()
     } else {
       // Verify a proxy doesn't already exist


### PR DESCRIPTION
### Description:

This makes sure the relayer only accepts one pending transaction per proxy contract.  It's a short-term solution to prevent bad nonces for #2631.

I'm not really sure if this gels with the behavior of the dapp with profile updates. @nick?

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
