### PR TITLE
[Relayer] Use bigint rather than integer to store gasprice

### DIFF
--- a/infra/relayer/migrations/20190707034049-add-relayer-txn-gas-price.js
+++ b/infra/relayer/migrations/20190707034049-add-relayer-txn-gas-price.js
@@ -7,7 +7,7 @@ module.exports = {
     return queryInterface.addColumn(
       tableName,
       'gas_price',
-      { type: Sequelize.Sequelize.INTEGER }
+      { type: Sequelize.Sequelize.BIGINT }
     )
   },
   down: (queryInterface) => {

--- a/infra/relayer/src/models/relayer_txn.js
+++ b/infra/relayer/src/models/relayer_txn.js
@@ -12,7 +12,7 @@ module.exports = (sequelize, DataTypes) => {
       method: DataTypes.STRING, // Contract method called.
       forwarder: DataTypes.STRING, // Address of the hot wallet used to forward the transaction.
       gas: DataTypes.INTEGER, // Units of gas used.
-      gasPrice: DataTypes.INTEGER, // Gas price, in wei.
+      gasPrice: DataTypes.BIGINT, // Gas price, in wei.
       txHash: DataTypes.STRING, // Blockchain transaction hash.
       data: DataTypes.JSONB // Stores various metadata.
     },


### PR DESCRIPTION

### Description:

Note: as opposed to creating yet another migration, I'll run some sql directly on DB to fix the type.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
