### PR TITLE
Don't display warning on duplicate email or phone if first account

### DIFF
--- a/infra/bridge/test/utils.js
+++ b/infra/bridge/test/utils.js
@@ -10,7 +10,7 @@ const Identity = require('@origin/identity/src/models').Identity
 const app = require('../src/app')
 
 const baseIdentity = {
-  ethAddress: '0x000'
+  ethAddress: '0x000a'
 }
 
 const client = redis.createClient()
@@ -55,7 +55,39 @@ describe('identity exists', () => {
     expect(response.status).to.equal(204)
   })
 
-  it('should return 204 for non-existent phonen', async () => {
+  it('should return 204 for existing email that exists on first created identity', async () => {
+    const obj = { email: 'foobar@originprotocol.com' }
+
+    await Identity.create({ ...obj, ...baseIdentity })
+    await Identity.create({ ...obj, ethAddress: '0xabcd1234' })
+
+    const response = await request(app)
+      .post('/utils/exists')
+      .send({
+        email: 'foobar@originprotocol.com',
+        ethAddress: baseIdentity.ethAddress
+      })
+
+    expect(response.status).to.equal(204)
+  })
+
+  it('should return 200 for existing email that exists on second created identity', async () => {
+    const obj = { email: 'foobar@originprotocol.com' }
+
+    await Identity.create({ ...obj, ethAddress: '0xabcd1234' })
+    await Identity.create({ ...obj, ...baseIdentity })
+
+    const response = await request(app)
+      .post('/utils/exists')
+      .send({
+        email: 'foobar@originprotocol.com',
+        ethAddress: baseIdentity.ethAddress
+      })
+
+    expect(response.status).to.equal(200)
+  })
+
+  it('should return 204 for non-existent phone', async () => {
     const response = await request(app)
       .post('/utils/exists')
       .send({ phone: '1234567' })

--- a/mobile/src/screens/onboarding/email.js
+++ b/mobile/src/screens/onboarding/email.js
@@ -97,7 +97,8 @@ class EmailScreen extends Component {
       headers: { 'content-type': 'application/json' },
       method: 'POST',
       body: JSON.stringify({
-        email: this.state.emailValue
+        email: this.state.emailValue,
+        ethAddress: this.props.wallet.activeAccount.address
       })
     })
     // 200 status code indicates account was found

--- a/mobile/src/screens/onboarding/phone.js
+++ b/mobile/src/screens/onboarding/phone.js
@@ -142,7 +142,8 @@ class PhoneScreen extends Component {
       headers: { 'content-type': 'application/json' },
       method: 'POST',
       body: JSON.stringify({
-        phone: `${this.state.countryValue.prefix} ${this.state.phoneValue}`
+        phone: `${this.state.countryValue.prefix} ${this.state.phoneValue}`,
+        ethAddress: this.props.wallet.activeAccount.address
       })
     })
     // 200 status code indicates account was found


### PR DESCRIPTION
When doing duplicate checks for emails and phones we don't want to display the import warning in mobile if:

- the account found with the duplicate is the same account that was imported
- it was the first created account with that email/phone

This is because we consider the first created account to be OK but may take action against duplicate accounts created later.