### PR TITLE
Remove extra dapp hosts from non-prod namespaces

### DIFF
--- a/devops/kubernetes/charts/origin/templates/dapp.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/dapp.ingress.yaml
@@ -22,6 +22,7 @@ spec:
     - secretName: {{ template "dapp.host" . }}
       hosts:
         - {{ template "dapp.host" . }}
+    {{- if eq .Release.Namespace "prod" }}
     - secretName: shoporigin.co
       hosts:
         - shoporigin.co
@@ -30,6 +31,7 @@ spec:
       hosts:
         - shoporigin.com
         - www.shoporigin.com
+    {{- end }}
   rules:
   - host: {{ template "dapp.host" . }}
     http:
@@ -38,6 +40,7 @@ spec:
           backend:
             serviceName: {{ template "dapp.fullname" . }}
             servicePort: 80
+  {{- if eq .Release.Namespace "prod" }}
   - host: shoporigin.co
     http:
       paths:
@@ -66,3 +69,4 @@ spec:
           backend:
             serviceName: {{ template "dapp.fullname" . }}
             servicePort: 80
+  {{- end }}


### PR DESCRIPTION
Only use the additional hosts we added on prod to avoid dev/staging trying to issue certs for these domains.