### PR TITLE
Update OG tags to point to shoporigin.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Visit our [Developer's page](https://www.originprotocol.com/developers) to learn
 more about what we're building and how to get involved.
 
 You can see the Origin ecosystem in action
-[here](https://dapp.originprotocol.com).
+[here](https://www.shoporigin.com).
 
 ## Development
 

--- a/dapps/marketplace/public/template.html
+++ b/dapps/marketplace/public/template.html
@@ -7,11 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no, user-scalable=no">
     <meta http-equiv="Content-Language" content="en">
     <meta http-equiv="expires" content="0">
-    <meta property="og:url" content="https://dapp.originprotocol.com">
+    <meta property="og:url" content="https://www.shoporigin.com">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Origin Protocol Dapp">
     <meta property="og:description" content="Decentralized marketplace on the blockchain">
-    <meta property="og:image" content="https://dapp.originprotocol.com/images/join-origin-earn-tokens.png">
+    <meta property="og:image" content="https://www.shoporigin.com/images/join-origin-earn-tokens.png">
     <meta name="apple-itunes-app" content="app-id=1446091928">
     <link rel="icon" href="favicon.ico" />
     <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %><link rel="stylesheet" href="<%- file %>" /><% }); %>


### PR DESCRIPTION
This PR updates the OG tags for social sharing to link back to our new domain: shoporigin.com.