### PR TITLE
Check on blockNumber in receipt

### DIFF
--- a/infra/faucet/src/eth.js
+++ b/infra/faucet/src/eth.js
@@ -168,7 +168,7 @@ class TxnManager {
     for (let retries = 0; retries < 60; retries++) {
       try {
         const receipt = await this.web3.eth.getTransactionReceipt(this.txnHash)
-        if (receipt) {
+        if (receipt && receipt.blockNumber) {
           if (receipt.status) {
             return receipt
           } else {

--- a/packages/graphql/src/resolvers/web3/transactions.js
+++ b/packages/graphql/src/resolvers/web3/transactions.js
@@ -6,7 +6,9 @@ import contracts from '../../contracts'
 export async function getTransactionReceipt(id) {
   const rawReceipt = await contracts.web3.eth.getTransactionReceipt(id)
 
-  if (!rawReceipt) {
+  // Note: Check on the both receipt and receipt.blockNumber since Parity returns
+  // a receipt with no blockNumber if transaction is not yet mined (Geth does not).
+  if (!rawReceipt || !rawReceipt.blockNumber) {
     return null
   }
 


### PR DESCRIPTION
### Description:

Adds a check on the presence of blockNumber in the receipt to determine if tx was mined.
This is a difference in behavior between Geth (which Infura uses) vs Parity (used by Alchemy).

This may help solving #2623 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
