### PR TITLE
Adds IPFS swarm port to ipfs Kubernetes Service

### DIFF
--- a/devops/kubernetes/charts/origin/templates/ipfs.service.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.service.yaml
@@ -17,6 +17,8 @@ spec:
     app: {{ template "ipfs.fullname" . }}
   ports:
     # Most external usage is through ipfs-proxy, but ipns uses 8080
+    - name: swarm
+      port: 4001
     - name: api
       port: 5001
     - name: gateway


### PR DESCRIPTION
### Description:

I think the swarm port might be missing from the Kubernetes IPFS Service here.  @tomlinton ?

Ref: #2588
CC: @nick 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
