### PR TITLE
Fix Profile Page Bug

### DIFF
--- a/dapps/marketplace/src/pages/user/Profile.js
+++ b/dapps/marketplace/src/pages/user/Profile.js
@@ -524,17 +524,17 @@ class UserProfile extends Component {
         'avatarUrl'
       ])
 
+      const attestations = (this.state.verifiedAttestations || []).reduce(
+        (object, att) => ({
+          ...object,
+          [att.id]: att.rawData
+        }),
+        {}
+      )
+
       const newData = {
         profile,
-        attestations: (
-          this.state.verifiedAttestations || []
-        ).reduce(
-          (object, att) => ({
-            ...object,
-            [att.id]: att.rawData
-          }),
-          {}
-        )
+        attestations
       }
 
       this.storeData(newData)

--- a/dapps/marketplace/src/pages/user/Profile.js
+++ b/dapps/marketplace/src/pages/user/Profile.js
@@ -102,12 +102,11 @@ function attestationsUpdated(state, prevState) {
 }
 
 function hasDataExpired(data) {
-  if (!data) {
+  if (!data || !data.timestamp) {
     return true
   }
 
   // Local data is valid only for an hour
-
   return Date.now() - data.timestamp > 3600000
 }
 
@@ -517,19 +516,29 @@ class UserProfile extends Component {
     const key = `${this.props.walletProxy}-profile-data`
     const data = localStore.get(key)
 
-    const profile = pick(this.state, [
-      'firstName',
-      'lastName',
-      'description',
-      'avatarUrl'
-    ])
-
     if (hasDataExpired(data)) {
+      const profile = pick(this.state, [
+        'firstName',
+        'lastName',
+        'description',
+        'avatarUrl'
+      ])
+
       const newData = {
         profile,
-        attestations: this.state.attestation
+        attestations: (
+          this.state.verifiedAttestations || []
+        ).reduce(
+          (object, att) => ({
+            ...object,
+            [att.id]: att.rawData
+          }),
+          {}
+        )
       }
-      localStore.set(key, newData)
+
+      this.storeData(newData)
+
       return newData
     }
 


### PR DESCRIPTION
Fixes a bug where unpublished data in localStorage never expired.

It occurred most likely due to [this line](https://github.com/OriginProtocol/origin/compare/shahthepro/identity-bug-fix?expand=1#diff-909bfb587479776ba538c7dccd979214L532). I missed to include the timestamp while writing the data to localStorage, when there is none.

This made the `hasDataExpired()` function to always return `false`. (`Date.now() - undefined > 3600000` === `NaN > 3600000` === `false`).

I'm still unsure if this caused #2728 to happen. 