### PR TITLE
Configure dapp.originprotocol.com to redirect to shoporigin.com

### DIFF
--- a/devops/kubernetes/charts/origin/templates/_helpers.tpl
+++ b/devops/kubernetes/charts/origin/templates/_helpers.tpl
@@ -37,7 +37,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{- if ne .Release.Namespace "prod" -}}
 {{- printf "dapp.%s.originprotocol.com" .Release.Namespace -}}
 {{- else -}}
-{{- printf "dapp.originprotocol.com" -}}
+{{- printf "shoporigin.com" -}}
 {{- end -}}
 {{- end -}}
 

--- a/devops/kubernetes/charts/origin/templates/dapp-shoporigin-redirect.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/dapp-shoporigin-redirect.ingress.yaml
@@ -1,0 +1,35 @@
+{{- if eq .Release.Namespace "prod" }}
+# Permanent redirect for dapp.originprotocol.com
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dapp-originprotocol-redirect
+  labels:
+    app: {{ template "dapp.fullname" . }}
+    app.kubernetes.io/name: origin
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: origin-dapp
+  annotations:
+    kubernetes.io/ingress.class: {{ .Release.Namespace }}-ingress
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: {{ .Values.clusterIssuer }}
+    # Disable SSL redirect to prevent double redirect
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://shoporigin.com"
+spec:
+  tls:
+    - secretName: dapp.originprotocol.com
+      hosts:
+        - dapp.originprotocol.com
+  rules:
+  - host: dapp.originprotocol.com
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "dapp.fullname" . }}
+          servicePort: 80
+{{- end }}

--- a/devops/kubernetes/charts/origin/templates/dapp.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/dapp.ingress.yaml
@@ -22,12 +22,9 @@ spec:
     - secretName: {{ template "dapp.host" . }}
       hosts:
         - {{ template "dapp.host" . }}
-    {{- if eq .Release.Namespace "prod" }}
-    - secretName: shoporigin.com
-      hosts:
-        - shoporigin.com
-        - www.shoporigin.com
-    {{- end }}
+        {{- if eq .Release.Namespace "prod" }}
+        - www.{{ template "dapp.host". }}
+        {{- end }}
   rules:
   - host: {{ template "dapp.host" . }}
     http:
@@ -37,14 +34,7 @@ spec:
             serviceName: {{ template "dapp.fullname" . }}
             servicePort: 80
   {{- if eq .Release.Namespace "prod" }}
-  - host: shoporigin.com
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ template "dapp.fullname" . }}
-            servicePort: 80
-  - host: www.shoporigin.com
+  - host: www.{{ template "dapp.host" . }}
     http:
       paths:
         - path: /


### PR DESCRIPTION
- Removes dapp.originprotocol.com from the dapp ingress and replaces it with shoporigin.com
- Adds another ingress for dapp.originprotocol.com with a permanent redirect to shoporigin.com

Deployed this on `prod` to make sure it works so it is already configured.