### PR TITLE
Pass message directly to `web3.eth.accounts.recover()`

### DIFF
--- a/packages/graphql/src/utils/validateAttestation.js
+++ b/packages/graphql/src/utils/validateAttestation.js
@@ -27,11 +27,10 @@ export default function validateAttestation(accounts, attestation) {
       web3.utils.toChecksumAddress(account),
       web3.utils.sha3(attestationJson)
     )
-    const messageHash = web3.eth.accounts.hashMessage(message)
+
     const signerAddress = web3.eth.accounts.recover(
-      messageHash,
-      attestation.signature.bytes,
-      true
+      message,
+      attestation.signature.bytes
     )
     if (signerAddress.toLowerCase() !== issuer) {
       errors.push(


### PR DESCRIPTION
[As per web3's docs, passing `message` directly as string is supported](https://github.com/ethereum/web3.js/blob/1.x/docs/web3-eth-accounts.rst#L373-L387). We don't have to hash it separately.

We can either pass the `message` and `signature` or just an object with `{messageHash, v, r, s}`.

In all other places, we pass the `message` and are not hashing it. So just for consistency.
 

 