### PR TITLE
Fixes a relayer dupe issue causing all relays to 429

### DIFF
--- a/infra/relayer/src/relayer.js
+++ b/infra/relayer/src/relayer.js
@@ -208,7 +208,7 @@ class Relayer {
     // Check to prevent rapid-fire duplicate requests
     if (typeof this.seenSignatures[signature] !== 'undefined') {
       return res.status(429).send({ errors: ['Duplicate'] })
-    } else {
+    } else if (!preflight) {
       // Update seen signatures
       this.seenSignatures[signature] = new Date()
     }


### PR DESCRIPTION
### Description:

Relayer was adding signatures to memory for the dupe check even when the request was preflight.  So the followup real request would always fail.  This makes sure not to add the signature to memory on preflight checks..

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
