### PR TITLE
EthGasStationProvider not forwarding

### DIFF
--- a/packages/web3-provider/src/subproviders/EthGasStationProvider.js
+++ b/packages/web3-provider/src/subproviders/EthGasStationProvider.js
@@ -53,6 +53,8 @@ class EthGasStationProvider extends SubProvider {
           // Send to next subprovider
           return next()
         })
+    } else {
+      return next()
     }
   }
 }


### PR DESCRIPTION
### Description:

EthGasStationProviderwas not forwarding requets to the next subprovider when the methods were things it didn't care about.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
