### PR TITLE
[Social Sharing] Define 1 rule per shareable piece of content

### DIFF
--- a/infra/growth/campaigns/august.js
+++ b/infra/growth/campaigns/august.js
@@ -195,34 +195,65 @@ const augustConfig = {
           }
         },
         {
-          id: 'TwitterShare',
+          id: 'TwitterShare1',
           class: 'SocialShare',
           config: {
             eventType: 'SharedOnTwitter',
             additionalLockConditions: ['TwitterAttestation'],
-            contents: [
-              {
-                titleKey: 'growth.twitterShare.content1.title',
-                detailsKey: 'growth.twitterShare.content1.details',
-                image: 'images/growth/twitter-share-content1.png',
-                link: 'https://www.youtube.com/watch?v=VzLkShX9-VE',
-                linkKey: 'growth.twitterShare.content1.link',
-                post: {
-                  text: {
-                    default: '<insert english content>',
-                    translations: [
-                      { locale: 'fr_FR', text: '<insert french content>' },
-                      { locale: 'zh_CN', text: '<insert mandarin content>' }
-                    ]
-                  }
+            content: {
+              titleKey: 'growth.twitterShare.content1.title',
+              detailsKey: 'growth.twitterShare.content1.details',
+              image: 'images/growth/twitter-share-content1.png',
+              link: 'https://www.youtube.com/watch?v=VzLkShX9-VE',
+              linkKey: 'growth.twitterShare.content1.link',
+              post: {
+                text: {
+                  default: '<insert english content>',
+                  translations: [
+                    { locale: 'fr_FR', text: '<insert french content>' },
+                    { locale: 'zh_CN', text: '<insert mandarin content>' }
+                  ]
                 }
               }
-            ],
+            },
             reward: {
               amount: tokenToNaturalUnits(1),
               currency: 'OGN'
             },
-            limit: 5,
+            limit: 1,
+            visible: true,
+            nextLevelCondition: false,
+            scope: 'campaign',
+            statusScope: 'user'
+          }
+        },
+        {
+          id: 'TwitterShare2',
+          class: 'SocialShare',
+          config: {
+            eventType: 'SharedOnTwitter',
+            additionalLockConditions: ['TwitterAttestation'],
+            content: {
+              titleKey: 'growth.twitterShare.content2.title',
+              detailsKey: 'growth.twitterShare.content2.details',
+              image: 'images/growth/twitter-share-content2.png',
+              link: 'https://www.youtube.com/watch?v=VzLkShX9-VE',
+              linkKey: 'growth.twitterShare.content2.link',
+              post: {
+                text: {
+                  default: '<insert english content>',
+                  translations: [
+                    { locale: 'fr_FR', text: '<insert french content>' },
+                    { locale: 'zh_CN', text: '<insert mandarin content>' }
+                  ]
+                }
+              }
+            },
+            reward: {
+              amount: tokenToNaturalUnits(1),
+              currency: 'OGN'
+            },
+            limit: 1,
             visible: true,
             nextLevelCondition: false,
             scope: 'campaign',

--- a/infra/growth/src/apollo/adapter.js
+++ b/infra/growth/src/apollo/adapter.js
@@ -55,8 +55,7 @@ class ApolloAdapter {
       actionType = 'ListingIdPurchased'
     } else if (ruleId.match(/^TwitterShare[\d-]+$/)) {
       actionType = 'TwitterShare'
-    }
-    else {
+    } else {
       actionType = ruleIdToActionType[ruleId]
     }
     if (!actionType) {

--- a/infra/growth/src/apollo/adapter.js
+++ b/infra/growth/src/apollo/adapter.js
@@ -53,7 +53,10 @@ class ApolloAdapter {
     // otherwise use the ruleIdToActionType dictionary.
     if (ruleId.match(/^ListingPurchase[\d-]+$/)) {
       actionType = 'ListingIdPurchased'
-    } else {
+    } else if (ruleId.match(/^TwitterShare[\d-]+$/)) {
+      actionType = 'TwitterShare'
+    }
+    else {
       actionType = ruleIdToActionType[ruleId]
     }
     if (!actionType) {
@@ -127,7 +130,7 @@ class ApolloAdapter {
         action = { ...action, ...listingInfo }
         break
       case 'TwitterShare':
-        action.contents = data.contents
+        action.content = data.content
         break
     }
 

--- a/infra/growth/src/resources/rules.js
+++ b/infra/growth/src/resources/rules.js
@@ -613,7 +613,7 @@ class BaseRule {
       titleKey: this.titleKey,
       detailsKey: this.detailsKey,
       // Fields specific to the SocialShare rule
-      contents: this.contents
+      content: this.content
     }
     return adapter.process(data)
   }
@@ -719,17 +719,15 @@ class ListingIdPurchaseRule extends SingleEventRule {
 class SocialShareRule extends SingleEventRule {
   constructor(crules, levelId, config) {
     super(crules, levelId, config)
-    if (!this.config.contents || !Array.isArray(this.config.contents)) {
-      throw new Error(`${this.str()}: missing or non-array contents field`)
+    if (!this.config.content) {
+      throw new Error(`${this.str()}: missing content field`)
     }
-    this.contents = this.config.contents
+    this.content = this.config.content
     // Compute the hashes for the post content, in all the configured languages.
     this.contentHashes = []
-    for (const content of this.contents) {
-      this.contentHashes.push(this._hashContent(content.post.text.default))
-      for (const translation of Object.values(content.post.text.translations)) {
-        this.contentHashes.push(this._hashContent(translation.text))
-      }
+    this.contentHashes.push(this._hashContent(this.content.post.text.default))
+    for (const translation of Object.values(this.content.post.text.translations)) {
+      this.contentHashes.push(this._hashContent(translation.text))
     }
   }
 

--- a/infra/growth/src/resources/rules.js
+++ b/infra/growth/src/resources/rules.js
@@ -724,9 +724,8 @@ class SocialShareRule extends SingleEventRule {
     }
     this.content = this.config.content
     // Compute the hashes for the post content, in all the configured languages.
-    this.contentHashes = []
-    this.contentHashes.push(this._hashContent(this.content.post.text.default))
-    for (const translation of Object.values(this.content.post.text.translations)) {
+    this.contentHashes = [this._hashContent(this.content.post.text.default)]
+    for (const translation of this.content.post.text.translations) {
       this.contentHashes.push(this._hashContent(translation.text))
     }
   }

--- a/infra/growth/src/scripts/manageCampaign.js
+++ b/infra/growth/src/scripts/manageCampaign.js
@@ -102,11 +102,12 @@ async function createJulyProdCampaign() {
     rewardStatus: enums.GrowthCampaignRewardStatuses.NotReady
   })
 }
-async function updateAugProdRules() {
-  console.log('Updating June campaign rules in prod...')
+
+async function updateJulyProdRules() {
+  console.log('Updating August campaign rules in prod...')
 
   const campaign = await db.GrowthCampaign.findOne({ where: { id: 5 } })
-  await campaign.update({ rules: JSON.stringify(augustConfig) })
+  await campaign.update({ rules: JSON.stringify(julyConfig) })
 }
 
 async function createAugProdCampaign() {
@@ -129,11 +130,11 @@ async function createAugProdCampaign() {
   })
 }
 
-async function updateJulyProdRules() {
-  console.log('Updating August campaign rules in prod...')
+async function updateAugProdRules() {
+  console.log('Updating June campaign rules in prod...')
 
   const campaign = await db.GrowthCampaign.findOne({ where: { id: 6 } })
-  await campaign.update({ rules: JSON.stringify(julyConfig) })
+  await campaign.update({ rules: JSON.stringify(augustConfig) })
 }
 
 const args = {}

--- a/infra/growth/test/apollo-adapter-august.test.js
+++ b/infra/growth/test/apollo-adapter-august.test.js
@@ -11,7 +11,7 @@ const { tokenToNaturalUnits } = require('../src/util/token')
 
 function checkExpectedState(state, expectedState) {
   expect(state.rewardEarned).to.deep.equal(expectedState.rewardEarned)
-  expect(state.actions.length).to.equal(31)
+  expect(state.actions.length).to.equal(32)
 
   const actionByRuleId = {}
   for(const action of state.actions) {
@@ -95,11 +95,11 @@ describe('Apollo adapter - August campaign', () => {
     expect(this.crules).to.be.an('object')
     expect(this.crules.numLevels).to.equal(3)
     expect(this.crules.levels[0]).to.be.an('object')
-    expect(this.crules.levels[0].rules.length).to.equal(3)
+    expect(this.crules.levels[0].rules.length).to.equal(3) // Note: adjust based on number of rules.
     expect(this.crules.levels[1]).to.be.an('object')
-    expect(this.crules.levels[1].rules.length).to.equal(12)
+    expect(this.crules.levels[1].rules.length).to.equal(13) // Note: adjust based on number of rules.
     expect(this.crules.levels[2]).to.be.an('object')
-    expect(this.crules.levels[2].rules.length).to.equal(18) // TODO: adjust when adding new listings
+    expect(this.crules.levels[2].rules.length).to.equal(18) // Note: adjust based on number of rules.
 
     this.userA = '0xA123'
     this.userB = '0xB456'
@@ -198,7 +198,7 @@ describe('Apollo adapter - August campaign', () => {
         rewardEarned: { amount: '0', currency: 'OGN' },
         reward: { amount: tokenToNaturalUnits(150), currency: 'OGN' }
       },
-      TwitterShare: {
+      TwitterShare1: {
         type: 'TwitterShare',
         status: 'Inactive',
         rewardEarned: { amount: '0', currency: 'OGN' },
@@ -419,7 +419,7 @@ describe('Apollo adapter - August campaign', () => {
 
     // Level 2 should be unlocked.
     this.expectedState.Referral.status = 'Active'
-    this.expectedState.TwitterShare.status = 'Inactive'
+    this.expectedState.TwitterShare1.status = 'Inactive'
     this.expectedState.MobileAccountCreated.status = 'Active'
 
     // Unlock all ListingPurchase listings
@@ -603,7 +603,7 @@ describe('Apollo adapter - August campaign', () => {
         .levels['2']
         .rules
         .map(rule => {
-          if (rule.id === 'TwitterShare') {
+          if (rule.id === 'TwitterShare1') {
             modificationCallback(rule)
           }
           return rule
@@ -660,29 +660,24 @@ describe('Apollo adapter - August campaign', () => {
     this.expectedState.TwitterAttestation.rewardEarned = { amount: tokenToNaturalUnits(10), currency: 'OGN' }
 
     // Check Twitter Share/Follow got unlocked.
-    this.expectedState.TwitterShare.status = 'Active'
+    this.expectedState.TwitterShare1.status = 'Active'
     this.expectedState.TwitterFollow.status = 'Active'
 
-    // Find the TwitterShare action and check it includes expected fields.
-    let twitterShareAction
+    // Find the TwitterShare actions and check they include all expected fields.
     for (const action of state.actions) {
       if (action.type === 'TwitterShare') {
-        twitterShareAction = action
-        break
+        const twitterShareAction = action
+        expect(twitterShareAction).to.be.an('object')
+        expect(twitterShareAction.content).to.be.an('object')
+        expect(twitterShareAction.content.titleKey).to.be.a('string')
+        expect(twitterShareAction.content.link).to.be.a('string')
+        expect(twitterShareAction.content.linkKey).to.be.a('string')
+        expect(twitterShareAction.content.titleKey).to.be.a('string')
+        expect(twitterShareAction.content.post).to.be.an('object')
+        expect(twitterShareAction.content.post.text).to.be.an('object')
+        expect(twitterShareAction.content.post.text.default).to.be.a('string')
+        expect(twitterShareAction.content.post.text.translations).to.be.an('array')
       }
-    }
-    expect(twitterShareAction).to.be.an('object')
-    expect(twitterShareAction.contents).to.be.an('array')
-    expect(twitterShareAction.contents.length).to.equal(1) // Update if adding more content items.
-    for (const content of twitterShareAction.contents) {
-      expect(content.titleKey).to.be.a('string')
-      expect(content.link).to.be.a('string')
-      expect(content.linkKey).to.be.a('string')
-      expect(content.titleKey).to.be.a('string')
-      expect(content.post).to.be.an('object')
-      expect(content.post.text).to.be.an('object')
-      expect(content.post.text.default).to.be.a('string')
-      expect(content.post.text.translations).to.be.an('array')
     }
 
     checkExpectedState(state, this.expectedState)

--- a/infra/growth/test/rules-august.test.js
+++ b/infra/growth/test/rules-august.test.js
@@ -28,11 +28,11 @@ describe('August campaign rules', () => {
     expect(this.crules).to.be.an('object')
     expect(this.crules.numLevels).to.equal(3)
     expect(this.crules.levels[0]).to.be.an('object')
-    expect(this.crules.levels[0].rules.length).to.equal(3)
+    expect(this.crules.levels[0].rules.length).to.equal(3) // Note: adjust based on number of rules.
     expect(this.crules.levels[1]).to.be.an('object')
-    expect(this.crules.levels[1].rules.length).to.equal(12)
+    expect(this.crules.levels[1].rules.length).to.equal(13) // Note: adjust based on number of rules.
     expect(this.crules.levels[2]).to.be.an('object')
-    expect(this.crules.levels[2].rules.length).to.equal(18) // TODO: adjust as more listings get added to the rule.
+    expect(this.crules.levels[2].rules.length).to.equal(18) // Note: adjust based on number of rules.
 
     this.userA = '0x123'
     this.userB = '0x456' // User A is the referrer for user B.

--- a/packages/graphql/src/typeDefs/Growth.js
+++ b/packages/graphql/src/typeDefs/Growth.js
@@ -169,7 +169,7 @@ module.exports = `
     rewardEarned: GrowthPrice
     reward: GrowthPrice
     unlockConditions: [UnlockCondition]
-    contents: [SocialContent]
+    content: SocialContent
   }
 
   type GrowthCampaign {


### PR DESCRIPTION
### Description:
On the FE, we need to be able to show if the action of sharing a piece of content was completed or not. With the previous implementation it was not possible since all the contents were handled by a single rule.

This PR defines 1 rule per content that is shareable.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
