### PR TITLE
Sparrow dom/add growth to config

### DIFF
--- a/dapps/marketplace/src/pages/settings/Settings.js
+++ b/dapps/marketplace/src/pages/settings/Settings.js
@@ -19,6 +19,7 @@ const store = Store('sessionStorage')
 const configurableFields = [
   'bridge',
   'discovery',
+  'growth',
   'ipfsGateway',
   'ipfsRPC',
   'provider',
@@ -304,6 +305,24 @@ class Settings extends Component {
                             type="text"
                             name="discovery"
                             {...input('discovery')}
+                            onBlur={() => this.saveConfig(setNetwork)}
+                          />
+                        </div>
+                      </div>
+                      <div className="form-group row">
+                        <div className="col-sm">
+                          <label htmlFor="indexing">
+                            <fbt desc="settings.growthLabel">
+                              Growth Server
+                            </fbt>
+                          </label>
+                        </div>
+                        <div className="col-sm">
+                          <input
+                            className="form-control form-control-lg"
+                            type="text"
+                            name="growth"
+                            {...input('growth')}
                             onBlur={() => this.saveConfig(setNetwork)}
                           />
                         </div>

--- a/dapps/marketplace/src/pages/settings/Settings.js
+++ b/dapps/marketplace/src/pages/settings/Settings.js
@@ -312,9 +312,7 @@ class Settings extends Component {
                       <div className="form-group row">
                         <div className="col-sm">
                           <label htmlFor="indexing">
-                            <fbt desc="settings.growthLabel">
-                              Growth Server
-                            </fbt>
+                            <fbt desc="settings.growthLabel">Growth Server</fbt>
                           </label>
                         </div>
                         <div className="col-sm">

--- a/dapps/marketplace/src/queries/Config.js
+++ b/dapps/marketplace/src/queries/Config.js
@@ -7,6 +7,7 @@ export default gql`
       affiliate
       arbitrator
       discovery
+      growth
       bridge
       ipfsRPC
       ipfsGateway

--- a/packages/graphql/src/typeDefs/Web3.js
+++ b/packages/graphql/src/typeDefs/Web3.js
@@ -31,6 +31,7 @@ module.exports = `
 
   input ConfigInput {
     discovery: String
+    growth: String
     relayer: String
     bridge: String
     ipfsRPC: String
@@ -44,6 +45,7 @@ module.exports = `
     affiliate: String
     arbitrator: String
     discovery: String
+    growth: String
     bridge: String
     ipfsRPC: String
     ipfsGateway: String


### PR DESCRIPTION
### Description:

Adding growth server to **/#/settings** configuration page: 
<img width="787" alt="Screenshot 2019-07-29 16 33 30" src="https://user-images.githubusercontent.com/579910/62056834-bd86c580-b21e-11e9-912c-dee379eb5b83.png">


### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~[ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~
- ~[ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~
- ~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~
