### PR TITLE
[SocialRewards] Fix tweet content bug

### DIFF
--- a/infra/bridge/src/controllers/promotions.js
+++ b/infra/bridge/src/controllers/promotions.js
@@ -158,7 +158,7 @@ const isEventValid = ({ socialNetwork, type, event, content }) => {
   // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
 
   const entities = (event.extended_tweet || event).entities
-  entities.entities.urls.forEach(entity => {
+  entities.urls.forEach(entity => {
     encodedContent = encodedContent.replace(entity.url, entity.expanded_url)
   })
 

--- a/infra/bridge/src/controllers/promotions.js
+++ b/infra/bridge/src/controllers/promotions.js
@@ -145,20 +145,20 @@ const isEventValid = ({ socialNetwork, type, event, content }) => {
   }
 
   // Note: `event.text` is truncated to 140chars, use `event.extended_tweet.full_text`, if it exists, to get whole tweet content
+  // Clone to avoid mutation
   let encodedContent = JSON.parse(
     JSON.stringify(
       event.extended_tweet ? event.extended_tweet.full_text : event.text
     )
   )
-  (
-    // Clone to avoid mutation
 
-    // IMPORTANT: Twitter shortens and replaces URLs
-    // we have revert that back to get the original content and to get the hash
-    // IMPORTANT: Twitter prepends 'http://' if it idenitifies a text as URL
-    // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
-    event.extended_tweet || event
-  ).entities.urls.forEach(entity => {
+  // IMPORTANT: Twitter shortens and replaces URLs
+  // we have revert that back to get the original content and to get the hash
+  // IMPORTANT: Twitter prepends 'http://' if it idenitifies a text as URL
+  // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
+
+  const entities = (event.extended_tweet || event).entities
+  entities.entities.urls.forEach(entity => {
     encodedContent = encodedContent.replace(entity.url, entity.expanded_url)
   })
 

--- a/infra/bridge/src/controllers/promotions.js
+++ b/infra/bridge/src/controllers/promotions.js
@@ -144,16 +144,21 @@ const isEventValid = ({ socialNetwork, type, event, content }) => {
     return true
   }
 
-  // Note: `event.text` is truncated to 140chars, use `event.extended_tweet.full_text` to get whole tweet content
+  // Note: `event.text` is truncated to 140chars, use `event.extended_tweet.full_text`, if it exists, to get whole tweet content
   let encodedContent = JSON.parse(
-    JSON.stringify(event.extended_tweet.full_text)
-  ) // Clone to avoid mutation
+    JSON.stringify(
+      event.extended_tweet ? event.extended_tweet.full_text : event.text
+    )
+  )
+  (
+    // Clone to avoid mutation
 
-  // IMPORTANT: Twitter shortens and replaces URLs
-  // we have revert that back to get the original content and to get the hash
-  // IMPORTANT: Twitter prepends 'http://' if it idenitifies a text as URL
-  // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
-  event.extended_tweet.entities.urls.forEach(entity => {
+    // IMPORTANT: Twitter shortens and replaces URLs
+    // we have revert that back to get the original content and to get the hash
+    // IMPORTANT: Twitter prepends 'http://' if it idenitifies a text as URL
+    // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
+    event.extended_tweet || event
+  ).entities.urls.forEach(entity => {
     encodedContent = encodedContent.replace(entity.url, entity.expanded_url)
   })
 

--- a/infra/bridge/src/controllers/promotions.js
+++ b/infra/bridge/src/controllers/promotions.js
@@ -144,13 +144,16 @@ const isEventValid = ({ socialNetwork, type, event, content }) => {
     return true
   }
 
-  let encodedContent = JSON.parse(JSON.stringify(event.text)) // Clone to avoid mutation
+  // Note: `event.text` is truncated to 140chars, use `event.extended_tweet.full_text` to get whole tweet content
+  let encodedContent = JSON.parse(
+    JSON.stringify(event.extended_tweet.full_text)
+  ) // Clone to avoid mutation
 
   // IMPORTANT: Twitter shortens and replaces URLs
   // we have revert that back to get the original content and to get the hash
   // IMPORTANT: Twitter prepends 'http://' if it idenitifies a text as URL
   // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
-  event.entities.urls.forEach(entity => {
+  event.extended_tweet.entities.urls.forEach(entity => {
     encodedContent = encodedContent.replace(entity.url, entity.expanded_url)
   })
 

--- a/infra/bridge/src/controllers/promotions.js
+++ b/infra/bridge/src/controllers/promotions.js
@@ -146,8 +146,10 @@ const isEventValid = ({ socialNetwork, type, event, content }) => {
 
   let encodedContent = JSON.parse(JSON.stringify(event.text)) // Clone to avoid mutation
 
-  // Important: Twitter shortens and replaces URLs
+  // IMPORTANT: Twitter shortens and replaces URLs
   // we have revert that back to get the original content and to get the hash
+  // IMPORTANT: Twitter prepends 'http://' if it idenitifies a text as URL
+  // It may result in a different content than expected, So always prepend URLs with `http://` in rule configs.
   event.entities.urls.forEach(entity => {
     encodedContent = encodedContent.replace(entity.url, entity.expanded_url)
   })

--- a/infra/growth/campaigns/README.md
+++ b/infra/growth/campaigns/README.md
@@ -1,0 +1,3 @@
+
+### Twitter and URL shortening
+Twitter prepends 'http://' if it idenitifies a text as URL. It may result in a different content than expected (which will result in a different content hash). So always prepend URLs with `http://` in rule configs.

--- a/infra/growth/campaigns/august.js
+++ b/infra/growth/campaigns/august.js
@@ -209,7 +209,7 @@ const augustConfig = {
               linkKey: 'growth.twitterShare.content1.link',
               post: {
                 text: {
-                  default: `Experience the decentralised global #marketplace of the future with @OriginProtocol's fresh new app. Secure transactions. Zero fees. Try it now: ogn.dev/mobile`,
+                  default: `Experience the decentralised global #marketplace of the future with @OriginProtocol's fresh new app. Secure transactions. Zero fees. Try it now: http://ogn.dev/mobile`,
                   translations: [
                     { locale: 'fr_FR', text: `Experience la decentralization avec l'appli de @OriginProtocol` },
                     { locale: 'zh_CN', text: `我不知道我在说什么 @OriginProtocol` }


### PR DESCRIPTION
- Twitter shortens and replaces all the text that it identifies as URLs. So, if we have a text like `ogn.dev/mobile`, it is shortened to `t.co/xxxxxx`. Twitter does give a mapping of shortened URL to original URL. But the original URL in the mapping prepends `http://`. So there will be a mismatch in content which will result in "Share" event not being resolved by `bridge`.

   The easiest way to overcome this will to manually prepend `http://` in growth campaign rules.

- Twitter also truncates the tweet content (if the content is longer than 140 chars, I guess) but also gives the full text along with a preview. Should prefer `event.extended_tweet.full_text` (if it exists) over `event.text`