### PR TITLE
Move merging Identity updates to GraphQL 

### DIFF
--- a/packages/graphql/src/mutations/identity/deployIdentity.js
+++ b/packages/graphql/src/mutations/identity/deployIdentity.js
@@ -7,38 +7,70 @@ import validateAttestation from '../../utils/validateAttestation'
 import { hasProxy, proxyOwner, resetProxyCache } from '../../utils/proxy'
 import costs from '../_gasCost.js'
 
+import pick from 'lodash/pick'
+
+import { identity } from './../../resolvers/IdentityEvents'
+
+const deduplicateAttestations = attestations => {
+  // Note: sortAttestations() method under `packages/graphql/src/resolvers/IdentityEvent.js`
+  // will filter out multiple attestations for same provider
+
+  return Array.from(new Set(attestations))
+}
+
+const mapAttestations = (attestations, accounts) => {
+  return (
+    deduplicateAttestations(attestations)
+      .map(attestation => {
+        try {
+          return {
+            ...JSON.parse(attestation),
+            schemaId: 'https://schema.originprotocol.com/attestation_1.0.0.json'
+          }
+        } catch (e) {
+          console.log('Error parsing attestation', attestation)
+          return null
+        }
+      })
+      // TODO: Instead of silently filtering out invalid attestations,
+      // we should notify user about this
+      .filter(a => validateAttestation(accounts, a))
+  )
+}
+
 async function deployIdentity(
   _,
   { from = contracts.defaultMobileAccount, profile, attestations }
 ) {
   await checkMetaMask(from)
 
-  attestations = attestations || []
-  profile = {
-    firstName: '',
-    lastName: '',
-    description: '',
-    ...profile
-  }
-
   const proxy = await hasProxy(from)
   const owner = !proxy ? await proxyOwner(from) : null
   const wallet = proxy || from
   const accounts = owner ? [wallet, owner] : [wallet]
 
-  attestations = attestations
-    .map(a => {
-      try {
-        return {
-          ...JSON.parse(a),
-          schemaId: 'https://schema.originprotocol.com/attestation_1.0.0.json'
-        }
-      } catch (e) {
-        console.log('Error parsing attestation', a)
-        return null
-      }
-    })
-    .filter(a => validateAttestation(accounts, a))
+  attestations = mapAttestations(attestations, accounts)
+
+  // Note: DApp will send only the unpublished data
+  // Merge that with already published identity, if it exists
+  const oldIdentity = await identity({ id: from })
+  if (oldIdentity) {
+    // Upsert
+    profile = {
+      ...pick(oldIdentity, [
+        'firstName',
+        'lastName',
+        'description',
+        'avatarUrl'
+      ]),
+      ...profile
+    }
+
+    attestations = [
+      ...mapAttestations(oldIdentity.attestations, accounts),
+      ...attestations
+    ]
+  }
 
   profile.schemaId = 'https://schema.originprotocol.com/profile_2.0.0.json'
   profile.ethAddress = wallet

--- a/packages/validator/src/schemas/profile_2.0.0.json
+++ b/packages/validator/src/schemas/profile_2.0.0.json
@@ -14,7 +14,7 @@
           "type": "string"
         }
       },
-      "required": ["firstName", "lastName"]
+      "required": ["firstName"]
     },
     "organization": {
       "type": "object",


### PR DESCRIPTION
### Description:
As of now, DApp fetches, caches and sends all the data that'll be part of the user identity (to be deployed to IPFS). GraphQL just validates it and publishes the data.

I have updated this as follows:
1. DApp only sends changed fields or new/updated attestations. It caches them to localStorage for an hour
2. GraphQL combines these fields with last deployed identity, deduplicates and validates them before publishing to IPFS and the blockchain

This should fix #2728 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~[Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~~
- [ ] ~~If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~~
