### PR TITLE
[SocialSharing] Fix for verification

### DIFF
--- a/infra/bridge/src/controllers/hooks/index.js
+++ b/infra/bridge/src/controllers/hooks/index.js
@@ -157,7 +157,7 @@ router.post('/twitter', (req, res) => {
         process.env.TWITTER_ORIGINPROTOCOL_USERNAME.toLowerCase()
       ) {
         followCount++
-        const key = `twitter/follow/${event.source.id}`
+        const key = `twitter/follow/${event.source.id_str}`
         redisBatch.set(key, JSON.stringify(event), 'EX', 60 * 30)
         logger.info(
           `Pushing twitter follow event for ${event.source.screen_name} at ${key}...`
@@ -182,7 +182,7 @@ router.post('/twitter', (req, res) => {
       })
       .forEach(event => {
         mentionCount++
-        const key = `twitter/share/${event.user.id}`
+        const key = `twitter/share/${event.user.id_str}`
         redisBatch.set(key, JSON.stringify(event), 'EX', 60 * 30)
         logger.info(
           `Pushing twitter mention event for ${event.user.screen_name} at ${key}...`

--- a/infra/bridge/src/controllers/promotions.js
+++ b/infra/bridge/src/controllers/promotions.js
@@ -190,15 +190,23 @@ router.post('/verify', verifyPromotions, async (req, res) => {
     socialNetwork
   })
 
-  if (!attestation) {
+  if (!attestation || !attestation.profileData) {
+    logger.error(`No attestation or profile data found for ${identity}`)
     return res.status(400).send({
       success: false,
       errors: [`Attestation missing`]
     })
   }
+  if (!attestation.profileData.id_str) {
+    logger.error(`Missing id_str field in profile data for ${identity}`)
+    return res.status(400).send({
+      success: false,
+      errors: [`Profile data missing`]
+    })
+  }
 
   const redisKey = `${socialNetwork.toLowerCase()}/${type.toLowerCase()}/${
-    attestation.value
+    attestation.profileData.id_str
   }`
   const maxTries = process.env.VERIFICATION_MAX_TRIES || 60
   let tries = 0

--- a/infra/bridge/test/hooks.js
+++ b/infra/bridge/test/hooks.js
@@ -54,7 +54,7 @@ describe('promotion verifications', () => {
               screen_name: 'originprotocol'
             },
             source: {
-              id: '12345'
+              id_str: '12345'
             }
           }
         ]
@@ -73,7 +73,7 @@ describe('promotion verifications', () => {
           {
             id: 'abcd',
             user: {
-              id: '123456',
+              id_str: '123456',
               screen_name: 'someuser'
             },
             entities: {
@@ -97,7 +97,7 @@ describe('promotion verifications', () => {
             id: 'abcd',
             retweeted: true,
             user: {
-              id: '9876',
+              id_str: '9876',
               screen_name: 'someuser'
             },
             entities: {
@@ -108,7 +108,7 @@ describe('promotion verifications', () => {
             id: 'abcd',
             favorited: true,
             user: {
-              id: '9876',
+              id_str: '9876',
               screen_name: 'someuser'
             },
             entities: {
@@ -118,7 +118,7 @@ describe('promotion verifications', () => {
           {
             id: 'abcd',
             user: {
-              id: '9876',
+              id_str: '9876',
               screen_name: 'originprotocol'
             },
             entities: {


### PR DESCRIPTION
### Description:

Fix for #2847 

Use id_str rather than id to avoid JS big number issue. See [this doc](https://developer.twitter.com/en/docs/basics/twitter-ids.html).

Note: this won't fix the data we store in attestation.value - it has the wrong rounded id. This will be addresses in a separate PR.


### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
