### PR TITLE
Google Analytics Improvements

### DIFF
--- a/dapps/marketplace/public/template.html
+++ b/dapps/marketplace/public/template.html
@@ -38,7 +38,6 @@
     }
     if (hostname !== 'localhost' && hostname !== '0.0.0.0') {
       gtag('js', new Date());
-      gtag('config', 'UA-106384880-2');
     }
   </script>
   <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %><script src="<%- file %>"></script><% }); %>

--- a/dapps/marketplace/src/components/Analytics.js
+++ b/dapps/marketplace/src/components/Analytics.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router-dom'
 
+/**
+ * Records routing path changes to Google Analytics.
+ */
 class Analytics extends Component {
   constructor(props) {
     super(props)
@@ -11,23 +14,35 @@ class Analytics extends Component {
     }
   }
 
-  /**
-   * Records routing path changes to Google Analytics.
-   *
-   * Uses setTimeout to wait until the intial page rendering is complete
-   * so that it can collect the correct document title.
-   */
-
   componentDidMount() {
     const { history } = this.props
-    this._unlisten = history.listen(location => {
-      clearTimeout(this._afterTitleTimeout)
-      this._afterTitleTimeout = setTimeout(() => {
-        const gaTrackingId = process.env.GA_TRACKING_ID || 'UA-106384880-2'
-        window.gtag('config', gaTrackingId, {
-          page_title: document.title,
-          page_path: location.pathname
-        })
+    // Record the current page
+    this.onPageview()
+    // history.listen will find future pages
+    this._unlisten = history.listen(() => {
+      this.onPageview()
+    })
+  }
+
+  onPageview() {
+    // We wait for react to render the page before capturing the page data
+    // so that we collect what we hope is the the actual page title.
+    // Many of our pages async load their data and don't get their real title
+    // until later, and we miss recording the real title. That's okay though -
+    // better to capture the page view.
+    clearTimeout(this._afterTitleTimeout)
+    this._afterTitleTimeout = setTimeout(() => {
+      const hostname = window.location.hostname
+      if (hostname === 'localhost' || hostname === '0.0.0.0') {
+        return // We don't want to record automated testing or developers
+      }
+      const gaTrackingId = process.env.GA_TRACKING_ID || 'UA-106384880-2'
+      const title = document.title
+      const location = this.props.location
+      const path = location.pathname + (location.search || '')
+      window.gtag('config', gaTrackingId, {
+        page_title: title,
+        page_path: path
       })
     })
   }


### PR DESCRIPTION
Closes #2319 - We now pass query strings on through to Google Analytics. This allows us to track the user's search queries in Google Analytics.

Closes #2832 - We now do not track page views from localhost. Before we were recording every automated CI run into our stats, and likely every developer action, making a very lopsided view of the actual activity on our Dapp.

For example, the "Create Listing" page is heavily biased to tests and developers.

![image](https://user-images.githubusercontent.com/837/62382899-9846cf80-b51c-11e9-9450-906f1614a656.png)

Finally, a bonus bug fix - we were always recording a users first page view on the Dapp as "/". This meant we didn't actually know which page a user actually arrived to the Dapp on.