### PR TITLE
Docker Compose repair work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,6 +218,8 @@ services:
     volumes: *volumes
     depends_on:
       - postgres
+      # This is a migration dependency:
+      - event-listener
     environment:
       - APNS_BUNDLE_ID=com.originprotocol.catcher
       - APNS_KEY_FILE=
@@ -271,6 +273,8 @@ services:
     depends_on:
       - postgres
       - redis-master
+      # This is a migration dependency:
+      - event-listener
     ports:
       - "5000:5000"
     command:


### PR DESCRIPTION
### Description:

`@origin/notifications` and `@origin/bridge` require `@origin/growth-event` and `@origin/identity` migrations to be run before starting.  This is a quick and dirty fix, but not really sold on it.

@tomlinton, what do you think about having the services container run all migrations?

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
