### PR TITLE
[SocialRewards] Add signature validation to webhook controllers

### DIFF
--- a/infra/bridge/test/hooks.js
+++ b/infra/bridge/test/hooks.js
@@ -46,6 +46,12 @@ describe('twitter webhooks', () => {
   it('should push follow events to redis', async () => {
     await request(app)
       .post('/hooks/twitter')
+      .set({
+        // Note: These signs have been hard-coded in the test
+        // Don't forget to update it, if you make any change to the body
+        'x-twitter-webhooks-signature':
+          'rOlK2y3cO0EnsVh2JrVqglj75zStF4mcN5HmyWvqMlQ='
+      })
       .send({
         follow_events: [
           {
@@ -69,6 +75,12 @@ describe('twitter webhooks', () => {
   it('should push mention events to redis', async () => {
     await request(app)
       .post('/hooks/twitter')
+      .set({
+        // Note: These signs have been hard-coded in the test
+        // Don't forget to update it, if you make any change to the body
+        'x-twitter-webhooks-signature':
+          'aMPAoi2EHMNU6/rL0TtAtbBx0R1ZoNbYL72Gbin3X0o='
+      })
       .send({
         tweet_create_events: [
           {
@@ -92,6 +104,12 @@ describe('twitter webhooks', () => {
   it('should not push retweets/favorites/own tweet events to redis', async () => {
     await request(app)
       .post('/hooks/twitter')
+      .set({
+        // Note: These signs have been hard-coded in the test
+        // Don't forget to update it, if you make any change to the body
+        'x-twitter-webhooks-signature':
+          'ht8B0jY6QyEl1t2qbPs0jul3lRexDD5TCQN/L9MfykA='
+      })
       .send({
         tweet_create_events: [
           {
@@ -134,5 +152,28 @@ describe('twitter webhooks', () => {
     expect(event).to.equal(null)
     event = await getAsync('twitter/share/originprotocol')
     expect(event).to.equal(null)
+  })
+
+  it('should fail on invalid signature', async () => {
+    await request(app)
+      .post('/hooks/twitter')
+      .set({
+        // Note: These signs have been hard-coded in the test
+        // Don't forget to update it, if you make any change to the body
+        'x-twitter-webhooks-signature':
+          'aMPAoi2EHMNU6/rL0TtAtbBx0R1ZoNbYL72Gbin3X0o='
+      })
+      .send({
+        tweet_create_events: [
+          {
+            id: 'abcd',
+            user: {
+              id_str: '123456',
+              screen_name: 'someuser'
+            }
+          }
+        ]
+      })
+      .expect(403)
   })
 })


### PR DESCRIPTION
We don't have signature validation for webhook endpoints at present. This means anyone can post any events to the webhook endpoints. This PR should fix that.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~[Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~~
- [ ] ~~If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~~
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
