### PR TITLE
Make graphql wait on services container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,10 @@ services:
       - discovery
     ports:
       - "4002:4002"
-    command: npm run start --prefix packages/graphql
+    command:
+      >
+      /bin/bash -c "wait-for.sh -t 0 -q services:1111 --
+      npm run start --prefix packages/graphql"
 
   notifications:
     container_name: notifications


### PR DESCRIPTION
### Description:

Fixes a race between graphql and the Ethereum JSON-RPC service.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
