### PR TITLE
Fixes docker graphql config for proxy implementation

### DIFF
--- a/packages/graphql/src/configs/docker.js
+++ b/packages/graphql/src/configs/docker.js
@@ -39,6 +39,7 @@ const config = {
   DaiExchange: addresses.UniswapDaiExchange,
   ProxyFactory: addresses.ProxyFactory,
   ProxyFactory_Epoch: addresses.ProxyFactoryEpoch,
+  IdentityProxyImplementation: addresses.IdentityProxyImplementation,
   tokens: []
 }
 


### PR DESCRIPTION
### Description:

`IdentityProxyImplementation` address was missing in graphql config for docker network. 

ref #2869

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
