### PR TITLE
Sparrow dom/fix growth admin override

### DIFF
--- a/infra/growth/src/apollo/app.js
+++ b/infra/growth/src/apollo/app.js
@@ -49,7 +49,9 @@ const server = new ApolloServer({
     const headers = context.req.headers
 
     let authStatus = enums.GrowthParticipantAuthenticationStatus.NotEnrolled
-    let authToken, walletAddress, identityOverriden = false
+    let authToken,
+      walletAddress,
+      identityOverriden = false
 
     if (headers['x-growth-secret'] && headers['x-growth-wallet']) {
       if (headers['x-growth-secret'] === process.env.GROWTH_ADMIN_SECRET) {

--- a/infra/growth/src/apollo/app.js
+++ b/infra/growth/src/apollo/app.js
@@ -49,12 +49,13 @@ const server = new ApolloServer({
     const headers = context.req.headers
 
     let authStatus = enums.GrowthParticipantAuthenticationStatus.NotEnrolled
-    let authToken, walletAddress
+    let authToken, walletAddress, identityOverriden = false
 
     if (headers['x-growth-secret'] && headers['x-growth-wallet']) {
       if (headers['x-growth-secret'] === process.env.GROWTH_ADMIN_SECRET) {
         // Grant admin access.
         authToken = 'AdminToken'
+        identityOverriden = true
         walletAddress = headers['x-growth-wallet'].toLowerCase()
         authStatus = enums.GrowthParticipantAuthenticationStatus.Enrolled
       } else {
@@ -78,6 +79,7 @@ const server = new ApolloServer({
     return {
       ...context,
       authToken,
+      identityOverriden,
       walletAddress,
       authentication: authStatus
     }

--- a/infra/growth/src/apollo/resolvers.js
+++ b/infra/growth/src/apollo/resolvers.js
@@ -116,10 +116,10 @@ const resolvers = {
       if (context.identityOverriden) {
         return enums.GrowthParticipantAuthenticationStatus.Enrolled
       } else {
-      /* otherwise we need to query the enrolment status again to match the current
-       * walletAddress and authentication token. In case user switches the wallet account
-       * an otherwise valid authentication token needs to be invalidated.
-       */
+        /* otherwise we need to query the enrolment status again to match the current
+         * walletAddress and authentication token. In case user switches the wallet account
+         * an otherwise valid authentication token needs to be invalidated.
+         */
         return await getUserAuthenticationStatus(
           context.authToken,
           args.walletAddress

--- a/infra/growth/src/apollo/resolvers.js
+++ b/infra/growth/src/apollo/resolvers.js
@@ -115,12 +115,11 @@ const resolvers = {
       // if identity overriden with admin_secret always show as enrolled
       if (context.identityOverriden) {
         return enums.GrowthParticipantAuthenticationStatus.Enrolled
-      }
+      } else {
       /* otherwise we need to query the enrolment status again to match the current
        * walletAddress and authentication token. In case user switches the wallet account
        * an otherwise valid authentication token needs to be invalidated.
        */
-      else {
         return await getUserAuthenticationStatus(
           context.authToken,
           args.walletAddress


### PR DESCRIPTION
### Description:
Fix a bug that was introduced with origin admin inspector where a user would not be signed out of Origin Rewards when he changes current wallet. 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~[ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~
- ~[ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~
- ~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~
