### PR TITLE
Change `DEL *` to `FLUSHALL`

### DIFF
--- a/infra/bridge/test/email.js
+++ b/infra/bridge/test/email.js
@@ -18,7 +18,7 @@ describe('email attestations', () => {
     process.env.ATTESTATION_SIGNING_KEY = '0xc1912'
 
     // Clear out redis-mock
-    await new Promise(resolve => client.del('*', resolve))
+    await new Promise(resolve => client.flushall(resolve))
 
     await Attestation.destroy({
       where: {},

--- a/infra/bridge/test/exchange-rate.js
+++ b/infra/bridge/test/exchange-rate.js
@@ -13,7 +13,7 @@ const client = redis.createClient()
 describe('exchange rate poller', () => {
   beforeEach(async () => {
     // Clear out redis-mock
-    await new Promise(resolve => client.del('*', resolve))
+    await new Promise(resolve => client.flushall(resolve))
   })
 
   it('should return exchange rate from redis', async () => {

--- a/infra/bridge/test/hooks.js
+++ b/infra/bridge/test/hooks.js
@@ -27,7 +27,7 @@ describe('twitter webhooks', () => {
     process.env.TWITTER_ORIGINPROTOCOL_USERNAME = 'OriginProtocol'
 
     // Clear out redis-mock
-    await new Promise(resolve => client.del('*', resolve))
+    await new Promise(resolve => client.flushall(resolve))
   })
 
   it('should return response token', async () => {

--- a/infra/bridge/test/promotions.js
+++ b/infra/bridge/test/promotions.js
@@ -20,7 +20,7 @@ describe('promotion verifications', () => {
     process.env.VERIFICATION_MAX_TRIES = 3
 
     // Clear out redis-mock
-    await new Promise(resolve => client.del('*', resolve))
+    await new Promise(resolve => client.flushall(resolve))
 
     await Attestation.destroy({
       where: {},


### PR DESCRIPTION
`DEL *` isn't a valid redis command. So switching to `FLUSHALL` command to clean out all keys before each test