### PR TITLE
[GraphQL] Log stack traces on server side

### DIFF
--- a/infra/discovery/src/apollo/app.js
+++ b/infra/discovery/src/apollo/app.js
@@ -15,6 +15,7 @@ const cors = require('cors')
 const express = require('express')
 const promBundle = require('express-prom-bundle')
 
+const logger = require('./logger')
 const resolvers = require('./resolvers')
 const typeDefs = require('./schema')
 
@@ -41,6 +42,13 @@ const server = new ApolloServer({
       context.discoveryAuthToken = headers['x-discovery-auth-token']
     }
     return context
+  },
+  // Enable debug regardless of NODE_ENV value in order to include stack traces in errors.
+  debug: true,
+  // Error handler that writes to the server logs.
+  formatError: err => {
+    logger.error(JSON.stringify(err, null, 4))
+    return err
   },
   // Always enable GraphQL playground and schema introspection, regardless of NODE_ENV value.
   introspection: true,

--- a/infra/growth/src/apollo/app.js
+++ b/infra/growth/src/apollo/app.js
@@ -42,6 +42,13 @@ app.use(bundle)
 const server = new ApolloServer({
   resolvers,
   typeDefs,
+  // Enable debug regardless of NODE_ENV value in order to include stack traces in errors.
+  debug: true,
+  // Error handler that writes to the server logs.
+  formatError: err => {
+    logger.error(JSON.stringify(err, null, 4))
+    return err
+  },
   // Always enable GraphQL playground and schema introspection, regardless of NODE_ENV value.
   introspection: true,
   playground: true,

--- a/packages/graphql/src/server.js
+++ b/packages/graphql/src/server.js
@@ -21,6 +21,13 @@ const schema = makeExecutableSchema({
 
 const options = {
   schema,
+  // Enable debug regardless of NODE_ENV value in order to include stack traces in errors.
+  debug: true,
+  // Error handler that writes to the server logs.
+  formatError: err => {
+    console.log('ERROR:', JSON.stringify(err, null, 4))
+    return err
+  },
   context: ({ req }) => {
     const operation = req.body
     if (operation && operation.query) {


### PR DESCRIPTION
### Description:

Enable debug and log stack traces on the server side for all our graphQL servers: graphql, discovery and growth.

We can discuss and implement in a separate PR our strategy for logging server side exceptions to Sentry.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
