### PR TITLE
[Discovery] Fix broken search

### DIFF
--- a/infra/discovery/src/apollo/resolvers.js
+++ b/infra/discovery/src/apollo/resolvers.js
@@ -13,7 +13,7 @@ const resolvers = {
     async listings(root, args) {
       // Get listing Ids from Elastic.
       const { listings, stats } = await search.Listing.search(
-        args.search,
+        args.searchQuery,
         args.sort,
         args.order,
         args.filters,
@@ -21,7 +21,7 @@ const resolvers = {
         args.page.offset
       )
       logger.info(
-        `Query: "${args.search}" returned ${listings.length} results.`
+        `Query: "${args.searchQuery}" returned ${listings.length} results.`
       )
       return {
         nodes: listings,


### PR DESCRIPTION
### Description:

The interface to the discovery server for searching listing was modified to use argument "search" rather than "searchQuery" in PR #2873. But the caller of this interface, the graphql server, was not updated. This caused searches in the DApp to always used empty search terms.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
