### PR TITLE
[Search] Handle malformed listings with no price

### DIFF
--- a/infra/discovery/package.json
+++ b/infra/discovery/package.json
@@ -35,6 +35,7 @@
     "graphql-tag": "2.10.1",
     "graphql-type-json": "0.3.0",
     "http": "0.0.0",
+    "lodash-es": "^4.17.15",
     "logplease": "1.2.15",
     "p-limit": "2.2.0",
     "per-env": "1.0.2",

--- a/infra/discovery/src/lib/search.js
+++ b/infra/discovery/src/lib/search.js
@@ -1,9 +1,8 @@
 const elasticsearch = require('elasticsearch')
+const get = require('lodash/get')
+
 const scoring = require('../lib/scoring')
 const logger = require('../listener/logger')
-/*
-  Module to interface with ElasticSearch.
- */
 
 const client = new elasticsearch.Client({
   hosts: [process.env.ELASTICSEARCH_HOST || 'elasticsearch:9200']
@@ -373,9 +372,13 @@ class Listing {
                     type: 'number',
                     script: {
                       lang: 'painless',
+                      // Note: Script is very defensive at checking existence and validity
+                      // of the data to be robust to possibly malformed listings that are on testing
+                      // environments and could also exist in production.
                       source: `
                         if (params._source.containsKey("price") &&
                           params._source.price.containsKey("amount") &&
+                          params._source.price.amount != null &&
                           params._source.price.containsKey("currency") &&
                           params._source.price.currency.containsKey("id") &&
                           params.exchangeRates.containsKey(params._source.price.currency.id)) {
@@ -461,13 +464,9 @@ class Listing {
         category: hit._source.category,
         subCategory: hit._source.subCategory,
         description: hit._source.description,
-        priceAmount: (hit._source.price || {}).amount,
-        priceCurrency: (hit._source.price || {}).currency,
-        // added redundant fields below to match schema, maybe that
-        // should change to the above two fields
         price: {
-          amount: (hit._source.price || {}).amount,
-          currency: (hit._source.price || {}).currency.id
+          amount: get(hit, '_source.price.amount', '0'),
+          currency: get(hit, 'source.price.currency.id', 'fiat-USD')
         }
       })
     })

--- a/infra/discovery/src/lib/search.js
+++ b/infra/discovery/src/lib/search.js
@@ -466,7 +466,7 @@ class Listing {
         description: hit._source.description,
         price: {
           amount: get(hit, '_source.price.amount', '0'),
-          currency: get(hit, 'source.price.currency.id', 'fiat-USD')
+          currency: get(hit, '_source.price.currency.id', 'fiat-USD')
         }
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -16595,7 +16595,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@4.17.15, lodash-es@^4.17.11:
+lodash-es@4.17.15, lodash-es@^4.17.11, lodash-es@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==


### PR DESCRIPTION
### Description:

Some listings on staging are test data and are malformed. Their price.amount field is set to null.
It causes the sorting painless script to crash. This could also happen in prod due to bugs or malicious user writing directly listing data to IPFS rather than thru our code.

This PR adds some defensive code.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
