### PR TITLE
[Search] Catch exceptions in sorting script

### DIFF
--- a/infra/discovery/src/lib/search.js
+++ b/infra/discovery/src/lib/search.js
@@ -372,20 +372,14 @@ class Listing {
                     type: 'number',
                     script: {
                       lang: 'painless',
-                      // Note: Script is very defensive at checking existence and validity
-                      // of the data to be robust to possibly malformed listings that are on testing
-                      // environments and could also exist in production.
+                      // Note: Wrap calculation in a try/catch statement to be robust to possibly
+                      // malformed listings that exist on testing environments and could also exist in production.
                       source: `
-                        if (params._source.containsKey("price") &&
-                          params._source.price.containsKey("amount") &&
-                          params._source.price.amount != null &&
-                          params._source.price.containsKey("currency") &&
-                          params._source.price.currency.containsKey("id") &&
-                          params.exchangeRates.containsKey(params._source.price.currency.id)) {
-                            float amount = Float.parseFloat(params._source.price.amount);
-                            float rate = Float.parseFloat(params.exchangeRates[params._source.price.currency.id]);
-                            return amount * rate;
-                        } else {
+                        try {
+                          float amount = Float.parseFloat(params._source.price.amount);
+                          float rate = Float.parseFloat(params.exchangeRates[params._source.price.currency.id]);
+                          return amount * rate;
+                        } catch (Exception e) {
                           return params.order == "asc" ? 1000000000L : 0;
                         }`,
                       params: {


### PR DESCRIPTION

### Description:

Use a try/catch statement in search sorting script rather than trying to use defensive coding.
Thanks @sparrowDom for this suggestion, it is much cleaner and robust ! :)
I ran the query manually in prod and it seems to work well.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
