### PR TITLE
Fix dropdown width in Settings Page

### DIFF
--- a/dapps/marketplace/src/pages/settings/Settings.js
+++ b/dapps/marketplace/src/pages/settings/Settings.js
@@ -532,6 +532,7 @@ require('react-styl')(`
       margin-top: 1rem
 
     .dropdown
+      width: auto
       .dropdown-menu
         position: absolute
         left: 16px


### PR DESCRIPTION
A very minor fix for the dropdown.

<img width="809" alt="Screenshot 2019-08-19 at 3 24 23 PM" src="https://user-images.githubusercontent.com/10547529/63256998-76787700-c296-11e9-83c7-bff9181c2016.png">

Probably broken when #2938 got merged [because of this line](https://github.com/OriginProtocol/origin/blob/master/dapps/marketplace/src/pages/listings/SortMenu.js#L206)