### PR TITLE
Proxy messaging bug

### DIFF
--- a/dapps/marketplace/src/components/SendMessage.js
+++ b/dapps/marketplace/src/components/SendMessage.js
@@ -76,9 +76,15 @@ class SendMessage extends Component {
                 ) {
                   return this.renderCannotConverse()
                 } else if (this.state.sent) {
-                  return this.renderSent()
+                  let to = account
+
+                  // If it's a proxy, we'll see a forwarding address
+                  const forwardTo = get(data, 'messaging.forwardTo')
+                  if (forwardTo) to = forwardTo
+
+                  return this.renderSent(to)
                 } else {
-                  let to = get(data, 'messaging.id')
+                  let to = account
 
                   // If it's a proxy, we'll see a forwarding address
                   const forwardTo = get(data, 'messaging.forwardTo')
@@ -156,8 +162,9 @@ class SendMessage extends Component {
     )
   }
 
-  renderSent() {
-    return <Redirect to={`/messages/${this.props.to}`} />
+  renderSent(to) {
+    to = to ? to : this.props.to
+    return <Redirect to={`/messages/${to}`} />
   }
 }
 


### PR DESCRIPTION
### Description:

This fixes a couple of issues:

- `messaging.id` from the graphql is the sending user, which apparently I did not expect for some reason, nor did it show up in my local tests(?)
- The forward after sending a message should send to the actual recipient and not the proxy address


### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
