### PR TITLE
eth_blockNumber call reduction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           command: npm run start --prefix packages/graphql
           background: true
       - run: sleep 10
-      - run: apollo service:check --endpoint=http://localhost:4002/
+      - run: apollo service:check --endpoint=http://localhost:4007/
 
   GraphQLEngineSchemaUpload:
     <<: *defaults
@@ -92,7 +92,7 @@ jobs:
           command: npm run start --prefix packages/graphql
           background: true
       - run: sleep 5
-      - run: apollo service:push --tag=master --endpoint=http://localhost:4002
+      - run: apollo service:push --tag=master --endpoint=http://localhost:4007/
 
   EventCache:
     <<: *db

--- a/packages/graphql/server.js
+++ b/packages/graphql/server.js
@@ -10,7 +10,7 @@ server
       } else if (v && Number.isNaN(v)) {
         console.warn('GRAPHQL_SERVER_PORT is NaN.  Using default')
       }
-      return 4002
+      return 4007
     })()
   })
   .then(({ url }) => {

--- a/packages/graphql/src/resolvers/JSONRPC.js
+++ b/packages/graphql/src/resolvers/JSONRPC.js
@@ -1,0 +1,31 @@
+import contracts from '../contracts'
+import { cached } from '../utils/cached'
+
+const BLOCK_DURATION = 15000
+
+/**
+ * contracts.web3 is not availble at compile time, so we will define the
+ * functions at first call
+ */
+let getBlockNumber, version
+
+export default {
+  eth_blockNumber: () => {
+    if (!getBlockNumber)
+      getBlockNumber = cached(
+        contracts.web3.eth.getBlockNumber,
+        'eth_blockNumber',
+        BLOCK_DURATION
+      )
+    return getBlockNumber()
+  },
+  net_version: () => {
+    if (!version)
+      version = cached(
+        contracts.web3.eth.net.getId,
+        'net_version',
+        BLOCK_DURATION * 1000
+      )
+    return version()
+  }
+}

--- a/packages/graphql/src/resolvers/Query.js
+++ b/packages/graphql/src/resolvers/Query.js
@@ -126,5 +126,8 @@ export default {
       ids = ids.filter(c => args.tokens.indexOf(c) >= 0)
     }
     return await Promise.all(ids.map(id => currencies.get(id)))
-  }
+  },
+
+  // A hierarchical placeholder
+  JSONRPC: () => ({})
 }

--- a/packages/graphql/src/resolvers/index.js
+++ b/packages/graphql/src/resolvers/index.js
@@ -9,6 +9,7 @@ import Offer from './Offer'
 import TokenHolder from './TokenHolder'
 import Event from './Event'
 import Token from './Token'
+import JSONRPC from './JSONRPC'
 import Conversation from './messaging/Conversation'
 import Messaging from './messaging/Messaging'
 import IdentityEvents from './IdentityEvents'
@@ -53,5 +54,6 @@ export default {
   Messaging,
   IdentityEvents,
   Config,
-  CreatorConfig
+  CreatorConfig,
+  JSONRPC
 }

--- a/packages/graphql/src/resolvers/server.js
+++ b/packages/graphql/src/resolvers/server.js
@@ -9,6 +9,7 @@ import Offer from './Offer'
 import TokenHolder from './TokenHolder'
 import Event from './Event'
 import Token from './Token'
+import JSONRPC from './JSONRPC'
 import IdentityEvents from './IdentityEvents'
 import Conversation from './messaging/Conversation'
 import Mutation from '../mutations/index'
@@ -42,5 +43,6 @@ export default {
     __resolveType(obj) {
       return obj.id.indexOf('fiat-') === 0 ? 'FiatCurrency' : 'Token'
     }
-  }
+  },
+  JSONRPC
 }

--- a/packages/graphql/src/typeDefs/JSONRPC.js
+++ b/packages/graphql/src/typeDefs/JSONRPC.js
@@ -1,0 +1,10 @@
+module.exports = `
+  extend type Query {
+    JSONRPC: JSONRPC
+  }
+
+  type JSONRPC {
+    eth_blockNumber: Int
+    net_version: Int
+  }
+`

--- a/packages/graphql/src/typeDefs/index.js
+++ b/packages/graphql/src/typeDefs/index.js
@@ -10,6 +10,7 @@ import CreatorConfig from './CreatorConfig'
 import Currency from './Currency'
 import Uniswap from './Uniswap'
 import Promotions from './Promotions'
+import JSONRPC from './JSONRPC'
 
 export default [
   Common,
@@ -23,5 +24,6 @@ export default [
   CreatorConfig,
   Currency,
   Uniswap,
-  Promotions
+  Promotions,
+  JSONRPC
 ]

--- a/packages/graphql/src/typeDefs/remote.js
+++ b/packages/graphql/src/typeDefs/remote.js
@@ -5,6 +5,7 @@ import { types as Identity } from './Identity'
 import { types as Attestations } from './Attestations'
 import Notifications from './Notifications'
 import Currency from './Currency'
+import JSONRPC from './JSONRPC'
 
 export default [
   Web3Common,
@@ -13,5 +14,6 @@ export default [
   Marketplace,
   Notifications,
   Attestations,
-  Currency
+  Currency,
+  JSONRPC
 ]

--- a/packages/graphql/src/utils/cached.js
+++ b/packages/graphql/src/utils/cached.js
@@ -1,0 +1,91 @@
+import { get } from 'lodash'
+
+const CACHE = {}
+
+/**
+ * Creates a derivative function that caches a function call results for
+ * duration.
+ *
+ * NOTE: This does not work like memoize, you must provide a unique key for the
+ * results, it does not take into account arguments.
+ *
+ * @param {function} fn - function to wrap and cache its result
+ * @param {string} key - the cache key to use for the function
+ * @param {number} duration - the length of time to keep result cached
+ * @return {function} - The wrapped function
+ */
+export function cached(fn, key, duration) {
+  // no point in caching
+  if (typeof fn !== 'function') {
+    throw new TypeError('fn is not a function')
+  }
+  duration = typeof duration === 'number' ? duration : new Number(duration)
+
+  const cachedFunc = function() {
+    // Pull from cache if possible
+    const now = new Number(new Date())
+    const exp = get(CACHE, `${key}.exp`)
+    if (exp && exp >= now - duration) {
+      return get(CACHE, `${key}.data`)
+    }
+
+    const res = fn.apply(this, arguments)
+
+    // Set cache
+    CACHE[key] = {
+      exp: now + duration,
+      data: res
+    }
+
+    return res
+  }
+
+  return cachedFunc
+}
+
+/**
+ * Creates a derivative function that caches a function call results for
+ * duration.
+ *
+ * NOTE: This does not work like memoize, you must provide a unique key for the
+ * results, it does not take into account arguments.
+ *
+ * @param {function} fn - function to wrap and cache its result
+ * @param {string} key - the cache key to use for the function
+ * @param {number} duration - the length of time to keep result cached
+ * @return {function} - The wrapped function
+ */
+export function cachedAsync(fn, key, duration) {
+  // no point in caching
+  if (typeof fn !== 'function') {
+    throw new TypeError('fn is not a function')
+  }
+  duration = typeof duration === 'number' ? duration : new Number(duration)
+
+  const cachedFunc = async function() {
+    // Pull from cache if possible
+    const now = new Number(new Date())
+    const exp = get(CACHE, `${key}.exp`)
+    if (exp && exp >= now - duration) {
+      return get(CACHE, `${key}.data`)
+    }
+
+    const res = await fn.apply(this, arguments)
+
+    // Set cache
+    // TODO: eslint identified a race here but... alternatives?
+    CACHE[key] = {
+      exp: now + duration,
+      data: res
+    }
+
+    return res
+  }
+
+  return cachedFunc
+}
+
+export default {
+  cached,
+  cachedAsync
+}

--- a/packages/graphql/test/_queries.js
+++ b/packages/graphql/test/_queries.js
@@ -129,9 +129,19 @@ const GetListing = gql`
   }
 `
 
+const BlockNumber = gql`
+  query BlockNumber {
+    JSONRPC {
+      net_version
+      eth_blockNumber
+    }
+  }
+`
+
 export default {
   GetNodeAccounts,
   GetReceipt,
   GetAllOffers,
-  GetListing
+  GetListing,
+  BlockNumber
 }

--- a/packages/graphql/test/index.js
+++ b/packages/graphql/test/index.js
@@ -869,3 +869,22 @@ describe('Marketplace', function() {
     })
   })
 })
+
+describe('JSON-RPC', function() {
+  it('should get the network ID', async function() {
+    const res = await client.query({
+      query: queries.BlockNumber,
+      variables: {}
+    })
+    const netId = get(res, 'data.JSONRPC.net_version')
+    assert(netId === 999)
+  })
+  it('should get the current block number', async function() {
+    const res = await client.query({
+      query: queries.BlockNumber,
+      variables: {}
+    })
+    const blockNumber = get(res, 'data.JSONRPC.eth_blockNumber')
+    assert(blockNumber > 0)
+  })
+})

--- a/packages/graphql/test/utils.js
+++ b/packages/graphql/test/utils.js
@@ -1,0 +1,44 @@
+/**
+ * This file contains tests for @origin/graphql/utils, it does NOT include test
+ * utility functions functions!
+ */
+import assert from 'assert'
+
+import { cached, cachedAsync } from '../src/utils/cached'
+
+// random test functions
+function sumOrig(a, b) {
+  return a + b
+}
+async function subOrig(a, b) {
+  await (() => {
+    return new Promise(resolve => {
+      setTimeout(() => resolve(), 100)
+    })
+  })()
+  return a - b
+}
+
+describe('@origin/graphql utils', function() {
+  describe('@origin/graphql/utils/cached', function() {
+    it('should cache the results of a sync function', async function() {
+      const sum = cached(sumOrig, 'sum', 2000)
+      const result1 = sum(1, 2)
+      assert(result1 === 3)
+
+      // Try with an irrelevant function call
+      const result2 = sum(1, 200)
+      assert(result2 === 3, 'Results not pulled from cache')
+    })
+
+    it('should cache the results of an async function', async function() {
+      const sub = cachedAsync(subOrig, 'sub', 2000)
+      const result1 = await sub(2, 1)
+      assert(result1 === 1)
+
+      // Try with an irrelevant function call
+      const result2 = await sub(200, 1)
+      assert(result2 === 1, 'Results not pulled from cache')
+    })
+  })
+})


### PR DESCRIPTION
### Description:

When performance mode is enabled, graphql should poll the centralized graphql server for `eth_blockNumber` updates.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
