### PR TITLE
[Search] Pin elasticsearch API version in the client

### DIFF
--- a/infra/discovery/src/lib/search.js
+++ b/infra/discovery/src/lib/search.js
@@ -5,7 +5,10 @@ const scoring = require('../lib/scoring')
 const logger = require('../listener/logger')
 
 const client = new elasticsearch.Client({
-  hosts: [process.env.ELASTICSEARCH_HOST || 'elasticsearch:9200']
+  hosts: [process.env.ELASTICSEARCH_HOST || 'elasticsearch:9200'],
+  // Pin the API version since we do not want to use the default as it changes
+  // upon upgrade of the elasticsearch npm package and that may break things.
+  apiVersion: '6.8'
 })
 
 // Elasticsearch index and type names for our data

--- a/infra/discovery/src/lib/search.js
+++ b/infra/discovery/src/lib/search.js
@@ -24,11 +24,11 @@ const LISTINGS_TYPE = 'listing'
  * @returns {Object} - Requested exchange rates, currency as key and rate as string value
  */
 const getExchangeRatesToUSD = async currencies => {
+  let exchangeRates = {}
   try {
     // lazy import to avoid event-listener depending on redis
     // this is only used in discovery
     const { getAsync } = require('../lib/redis')
-    const exchangeRates = {}
     // TODO use redis batch features instead of promise.All
     const promises = currencies.map(currency => {
       const splitCurrency = currency.split('-')
@@ -49,11 +49,25 @@ const getExchangeRatesToUSD = async currencies => {
         exchangeRates[currencies[i]] = r
       }
     })
-    logger.debug('Exchange Rates - ', exchangeRates)
-    return exchangeRates
   } catch (e) {
-    logger.error('Error retrieving exchange rates from redis', e)
+    logger.error(
+      'Error retrieving exchange rates from redis. Using defaults',
+      e
+    )
+    exchangeRates = {
+      'fiat-CNY': '0.14',
+      'fiat-EUR': '1.12',
+      'fiat-GBP': '1.22',
+      'fiat-JPY': '0.0094',
+      'fiat-KRW': '0.00082',
+      'fiat-SGD': '0.72',
+      'fiat-USD': '1.0',
+      'token-DAI': '1.0',
+      'token-ETH': '200.0'
+    }
   }
+  logger.debug('Exchange Rates - ', exchangeRates)
+  return exchangeRates
 }
 
 class Cluster {

--- a/infra/discovery/src/listener/handler_marketplace.js
+++ b/infra/discovery/src/listener/handler_marketplace.js
@@ -168,7 +168,7 @@ class MarketplaceEventHandler {
 
     if (this.config.elasticsearch) {
       logger.info(`Indexing listing in Elastic:  id=${listing.id}`)
-      search.Listing.index(
+      await search.Listing.index(
         removeListingIdBlockNumber(listing.id),
         userAddress,
         ipfsHash,


### PR DESCRIPTION
### Description:

 Pin API version rather than using the default in the client.
 
Other misc fixes:
- Await for listing to be indexed in listener
 - Use default exchange rate if we fail fetching from redis


### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
