### PR TITLE
Upgrade crypto-random-string

### DIFF
--- a/packages/messaging-client/package.json
+++ b/packages/messaging-client/package.json
@@ -11,7 +11,7 @@
     "ajv": "^6.10.0",
     "bottleneck": "^2.19.1",
     "crypto-js": "^3.1.9-1",
-    "crypto-random-string": "1.0.0",
+    "crypto-random-string": "^3.0.0",
     "debug": "^4.1.1",
     "eth-ecies": "^1.0.3",
     "json-stable-stringify": "^1.0.1",

--- a/packages/messaging-client/src/Messaging.js
+++ b/packages/messaging-client/src/Messaging.js
@@ -688,7 +688,7 @@ class Messaging {
       // a conversation haven't even been started yet
       //
       const conversationIndex = convObj ? convObj.messageCount : 0
-      const encryptKey = cryptoRandomString(32).toString('hex')
+      const encryptKey = cryptoRandomString({ length: 32 }).toString('hex')
 
       const keysContent = {
         type: 'keys',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7917,7 +7917,7 @@ crypto-js@^3.1.9-1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
-crypto-random-string@1.0.0, crypto-random-string@^1.0.0:
+crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
@@ -7926,6 +7926,13 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
+crypto-random-string@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-3.0.1.tgz#29d7dc759d577a768afb3b7b2765dd9bd7ffe36a"
+  integrity sha512-dUL0cJ4PBLanJGJQBHQUkvZ3C4q13MXzl54oRqAIiJGiNkOZ4JDwkg/SBo7daGghzlJv16yW1p/4lIQukmbedA==
+  dependencies:
+    type-fest "^0.5.2"
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -26176,6 +26183,11 @@ type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
+
+type-fest@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
+  integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
 type-fest@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Upgrade crypto-random-string and fix code for breaking change:

`Breaking:

Move the length argument to an options-object 16a6364
cryptoRandomString(10); → cryptoRandomString({length: 10});
`

Fixes #3055.