### PR TITLE
Fix order of support messages

### DIFF
--- a/packages/graphql/src/resolvers/messaging/Conversation.js
+++ b/packages/graphql/src/resolvers/messaging/Conversation.js
@@ -25,7 +25,7 @@ export async function getAllMessages(conversationId) {
   const supportAccount = contracts.config.messagingAccount
   if (supportAccount && conversationId === supportAccount) {
     const created = messages.length
-      ? messages[messages.length - 1].msg.created + 1
+      ? messages[0].msg.created - 1
       : new Date('01-01-2017')
     if (isEnabled()) {
       messages.unshift({


### PR DESCRIPTION
I think the intention here was 1 second before the first message sent to the support account, not 1 second before the last message sent. 

Fixes #2952.