### PR TITLE
Pared down web3-provider-engine

### DIFF
--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -231,7 +231,7 @@ export function setNetwork(net, customConfig) {
       qps,
       ethGasStation: ['mainnet', 'rinkeby'].includes(net)
     })
-  } else if (!isBrowser && !isWebView && net !== 'test') {
+  } else if (!isBrowser && !isWebView) {
     // TODO: Allow for browser?
     createEngine(web3, { qps, maxConcurrent })
   }

--- a/packages/web3-provider/package.json
+++ b/packages/web3-provider/package.json
@@ -16,9 +16,9 @@
     "prettier:check": "prettier -c *.js \"src/**/*.js\""
   },
   "dependencies": {
+    "async": "^3.1.0",
     "bottleneck": "^2.19.1",
-    "web3": "1.0.0-beta.34",
-    "web3-provider-engine": "mikeshultz/web3-provider-engine#origin-protocol"
+    "web3": "1.0.0-beta.34"
   },
   "devDependencies": {
     "@origin/contracts": "^0.8.6",

--- a/packages/web3-provider/src/ProviderEngine.js
+++ b/packages/web3-provider/src/ProviderEngine.js
@@ -1,0 +1,115 @@
+const map = require('async/map')
+const eachSeries = require('async/eachSeries')
+
+module.exports = Web3ProviderEngine
+
+function Web3ProviderEngine() {
+  const self = this
+  self._providers = []
+}
+
+Web3ProviderEngine.prototype.addProvider = function(source, index) {
+  const self = this
+  if (typeof index === 'number') {
+    self._providers.splice(index, 0, source)
+  } else {
+    self._providers.push(source)
+  }
+  source.setEngine(this)
+}
+
+Web3ProviderEngine.prototype.removeProvider = function(source) {
+  const self = this
+  const index = self._providers.indexOf(source)
+  if (index < 0) throw new Error('Provider not found.')
+  self._providers.splice(index, 1)
+}
+
+Web3ProviderEngine.prototype.send = function() {
+  throw new Error('Web3ProviderEngine does not support synchronous requests.')
+}
+
+Web3ProviderEngine.prototype.sendAsync = function(payload, cb) {
+  const self = this
+  if (Array.isArray(payload)) {
+    // handle batch
+    map(payload, self._handleAsync.bind(self), cb)
+  } else {
+    // handle single
+    self._handleAsync(payload, cb)
+  }
+}
+
+// private
+
+Web3ProviderEngine.prototype._handleAsync = function(payload, finished) {
+  const self = this
+  let currentProvider = -1
+  let result = null
+  let error = null
+
+  const stack = []
+
+  next()
+
+  function next(after) {
+    currentProvider += 1
+    stack.unshift(after)
+
+    // Bubbled down as far as we could go, and the request wasn't
+    // handled. Return an error.
+    if (currentProvider >= self._providers.length) {
+      end(
+        new Error(
+          'Request for method "' +
+            payload.method +
+            '" not handled by any subprovider. Please check your subprovider configuration to ensure this method is handled.'
+        )
+      )
+    } else {
+      try {
+        const provider = self._providers[currentProvider]
+        provider.handleRequest(payload, next, end)
+      } catch (e) {
+        end(e)
+      }
+    }
+  }
+
+  function end(_error, _result) {
+    error = _error
+    result = _result
+
+    eachSeries(
+      stack,
+      function(fn, callback) {
+        if (fn) {
+          fn(error, result, callback)
+        } else {
+          callback()
+        }
+      },
+      function() {
+        // console.log('COMPLETED:', payload)
+        // console.log('RESULT: ', result)
+
+        const resultObj = {
+          id: payload.id,
+          jsonrpc: payload.jsonrpc,
+          result: result
+        }
+
+        if (error != null) {
+          resultObj.error = {
+            message: error.stack || error.message || error,
+            code: -32000
+          }
+          // respond with both error formats
+          finished(error, resultObj)
+        } else {
+          finished(null, resultObj)
+        }
+      }
+    )
+  }
+}

--- a/packages/web3-provider/src/subproviders/EthGasStationProvider.js
+++ b/packages/web3-provider/src/subproviders/EthGasStationProvider.js
@@ -1,5 +1,5 @@
 const fetch = require('cross-fetch')
-const SubProvider = require('web3-provider-engine/subproviders/subprovider')
+const SubProvider = require('./Subprovider')
 
 const CACHE_TIME = 15000
 const GAS_STATION_URL = 'https://ethgasstation.info/json/ethgasAPI.json'

--- a/packages/web3-provider/src/subproviders/MetricsProvider.js
+++ b/packages/web3-provider/src/subproviders/MetricsProvider.js
@@ -1,4 +1,4 @@
-const SubProvider = require('web3-provider-engine/subproviders/subprovider')
+const SubProvider = require('./Subprovider')
 
 /**
  * A web3-provider-engine subprovider to gether metrics on JSON-RPC calls

--- a/packages/web3-provider/src/subproviders/Subprovider.js
+++ b/packages/web3-provider/src/subproviders/Subprovider.js
@@ -1,0 +1,22 @@
+const createPayload = require('./createPayload')
+
+module.exports = SubProvider
+
+// this is the base class for a subprovider -- mostly helpers
+
+function SubProvider() {}
+
+SubProvider.prototype.setEngine = function(engine) {
+  const self = this
+  if (self.engine) return
+  self.engine = engine
+}
+
+SubProvider.prototype.handleRequest = function() {
+  throw new Error('Subproviders should override `handleRequest`.')
+}
+
+SubProvider.prototype.emitPayload = function(payload, cb) {
+  const self = this
+  self.engine.sendAsync(createPayload(payload), cb)
+}

--- a/packages/web3-provider/src/subproviders/ThrottleRPCProvider.js
+++ b/packages/web3-provider/src/subproviders/ThrottleRPCProvider.js
@@ -7,8 +7,8 @@
 const fetch = require('cross-fetch')
 const Bottleneck = require('bottleneck/es5')
 const JsonRpcError = require('json-rpc-error')
-const createPayload = require('web3-provider-engine/util/create-payload')
-const SubProvider = require('web3-provider-engine/subproviders/subprovider')
+const createPayload = require('./createPayload')
+const SubProvider = require('./Subprovider')
 
 const MAX_RETRIES = 3
 const BUFFER_MS = 5

--- a/packages/web3-provider/src/subproviders/ThrottleRPCProvider.js
+++ b/packages/web3-provider/src/subproviders/ThrottleRPCProvider.js
@@ -112,9 +112,7 @@ class ThrottleRPCProvider extends SubProvider {
     const self = this
     const targetUrl = self.rpcUrl
     const { method } = payload
-    const priority = METHOD_PRIORITY.hasOwnProperty(method)
-      ? METHOD_PRIORITY[method]
-      : 5
+    const priority = METHOD_PRIORITY[method] || 5
 
     // overwrite id to conflict with other concurrent users
     const newPayload = createPayload(payload)

--- a/packages/web3-provider/src/subproviders/createPayload.js
+++ b/packages/web3-provider/src/subproviders/createPayload.js
@@ -1,0 +1,24 @@
+// gotta keep it within MAX_SAFE_INTEGER
+const extraDigits = 3
+
+function createRandomId() {
+  // 13 time digits
+  const datePart = new Date().getTime() * Math.pow(10, extraDigits)
+  // 3 random digits
+  const extraPart = Math.floor(Math.random() * Math.pow(10, extraDigits))
+  // 16 digits
+  return datePart + extraPart
+}
+
+function createPayload(data) {
+  return {
+    // defaults
+    id: createRandomId(),
+    jsonrpc: '2.0',
+    params: [],
+    // user-specified
+    ...data
+  }
+}
+
+module.exports = createPayload

--- a/packages/web3-provider/src/subproviders/createPayload.js
+++ b/packages/web3-provider/src/subproviders/createPayload.js
@@ -1,24 +1,14 @@
-// gotta keep it within MAX_SAFE_INTEGER
-const extraDigits = 3
-
 function createRandomId() {
-  // 13 time digits
-  const datePart = new Date().getTime() * Math.pow(10, extraDigits)
-  // 3 random digits
-  const extraPart = Math.floor(Math.random() * Math.pow(10, extraDigits))
-  // 16 digits
+  const datePart = new Date().getTime() * 1000
+  const extraPart = Math.floor(Math.random() * 1000)
   return datePart + extraPart
 }
 
-function createPayload(data) {
-  return {
-    // defaults
-    id: createRandomId(),
-    jsonrpc: '2.0',
-    params: [],
-    // user-specified
-    ...data
-  }
-}
+const createPayload = data => ({
+  id: createRandomId(),
+  jsonrpc: '2.0',
+  params: [],
+  ...data
+})
 
 module.exports = createPayload

--- a/packages/web3-provider/test/index.js
+++ b/packages/web3-provider/test/index.js
@@ -1,6 +1,9 @@
 const Web3 = require('web3')
 const fetch = require('cross-fetch')
-const { createEngine, initStandardSubproviders } = require('@origin/web3-provider')
+const {
+  createEngine,
+  initStandardSubproviders
+} = require('@origin/web3-provider')
 const assert = require('assert')
 
 const TEST_PROVIDER_URL = 'http://localhost:8545'
@@ -27,11 +30,6 @@ describe('web3-provider', function() {
     ;[admin, bob] = await web3.eth.getAccounts()
   })
 
-  after(() => {
-    // Stop its block poller so the test suite can wrap up
-    web3.currentProvider.stop()
-  })
-
   it('sends a basic transaction', async () => {
     createEngine(web3, {
       rpcUrl: TEST_PROVIDER_URL
@@ -51,7 +49,7 @@ describe('web3-provider', function() {
 
   /**
    * Too often EGS updates the gas price between the test grabbing data and
-   * the subprovider grabbing data, so this test has a fairly high chance of 
+   * the subprovider grabbing data, so this test has a fairly high chance of
    * faiure, especially during high volume times...
    */
   it.skip('gets gas price from ethgasstation', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -27725,33 +27725,6 @@ web3-provider-engine@^15.0.0:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3-provider-engine@mikeshultz/web3-provider-engine#origin-protocol:
-  version "15.0.0"
-  resolved "https://codeload.github.com/mikeshultz/web3-provider-engine/tar.gz/f3dd07a5720e7b8eb3df57cb41e053655427fc1a"
-  dependencies:
-    async "^2.5.0"
-    backoff "^2.5.0"
-    clone "^2.0.0"
-    cross-fetch "^2.1.0"
-    eth-block-tracker "^4.2.0"
-    eth-json-rpc-filters "^4.0.2"
-    eth-json-rpc-infura "^3.1.0"
-    eth-json-rpc-middleware "^4.1.1"
-    eth-sig-util "^1.4.2"
-    ethereumjs-block "^1.2.2"
-    ethereumjs-tx "^1.2.0"
-    ethereumjs-util "^5.1.5"
-    ethereumjs-vm "^2.3.4"
-    json-rpc-error "^2.0.0"
-    json-stable-stringify "^1.0.1"
-    promise-to-callback "^1.0.0"
-    readable-stream "^2.2.9"
-    request "^2.85.0"
-    semaphore "^1.0.3"
-    ws "^5.1.1"
-    xhr "^2.2.0"
-    xtend "^4.0.1"
-
 web3-providers-http@1.0.0-beta.34:
   version "1.0.0-beta.34"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz#e561b52bbb43766282007d40285bfe3550c27e7a"


### PR DESCRIPTION
Stripped down web3-provider-engine to the bare bones.

The original web3-provider-engine had it's own block tracker, event emitter and a bunch of other stuff we don't need. This PR gives us a bare bones web3-provider-engine for our Metrics, ThrottleRPC and EthGasStation providers.

Will hopefully reduce blockNumber calls significantly...