### PR TITLE
Ignore JSON-RPC errors when waiting on a transaction

### DIFF
--- a/dapps/marketplace/src/components/WaitForTransaction.js
+++ b/dapps/marketplace/src/components/WaitForTransaction.js
@@ -10,6 +10,8 @@ import withWallet from 'hoc/withWallet'
 import withConfig from 'hoc/withConfig'
 import Sentry from 'utils/sentry'
 
+const INVALID_JSON_RPC = 'Invalid JSON RPC response'
+
 const WaitForFirstBlock = () => (
   <div className="make-offer-modal">
     <div className="spinner light" />
@@ -127,7 +129,11 @@ class WaitForTransaction extends Component {
             events.find(e => e.event === this.props.event) || events[0]
 
           let content
-          if (error) {
+          // Catch errors, but ignore one-off JSON-RPC errors
+          if (
+            error &&
+            (error.message && !error.message.indexOf(INVALID_JSON_RPC))
+          ) {
             console.error(error)
             Sentry.captureException(error)
             content = <Error />


### PR DESCRIPTION
### Description:

This is my quick and dirty solution for #3284.  I don't think this should be the long-term solution, but I think it'll work here.  This straight up ignores Invalid JSON-RPC errors in WaitForTransaction. When they happen with `eth_getTransactionReceipt`, there's no reason to suspect they aren't just a one-off.

This is untested, because testing it would require me rigging up some insane fake JSON-RPC interface, so beware.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
