### PR TITLE
add offer withdrawn stages

### DIFF
--- a/dapps/marketplace/src/components/TransactionStages.js
+++ b/dapps/marketplace/src/components/TransactionStages.js
@@ -45,12 +45,8 @@ const CanceledStages = [
     event: 'createdEvent'
   },
   {
-    title: fbt('Offer Accepted', 'TransactionStages.offerAccepted'),
-    event: 'acceptedEvent'
-  },
-  {
-    title: fbt('Sale Completed', 'TransactionStages.saleCompleted'),
-    event: 'finalizedEvent'
+    title: fbt('Offer Withdrawn', 'TransactionStages.offerWithdrawn'),
+    event: 'withdrawnEvent'
   }
 ]
 


### PR DESCRIPTION
Add progress bar stages for offer rejected / offer declined. Before this fix it just showed an empty 3 stage progress bar. 

Result looks like this: 
<img width="781" alt="Screenshot 2019-09-09 00 30 56" src="https://user-images.githubusercontent.com/579910/64495389-9a2d4c80-d299-11e9-91f5-577b298495c0.png">

**Related issue:** https://github.com/OriginProtocol/origin/issues/3306

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
