### PR TITLE
Fixes multi-units for UI and eventsource with ServiceListings

### DIFF
--- a/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
+++ b/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
@@ -25,6 +25,8 @@ import {
   FractionalHourlyPurchaseSummary
 } from './_BuyFractionalHourly'
 
+const MULTI_UNIT_TYPES = ['UnitListing', 'GiftCardListing', 'ServiceListing']
+
 const ConfirmPurchase = ({
   listing,
   quantity,
@@ -34,8 +36,10 @@ const ConfirmPurchase = ({
   shippingAddress,
   bookingRange
 }) => {
-  const singleUnit = !listing.multiUnit && listing.__typename === 'UnitListing'
-  const multiUnit = listing.multiUnit && listing.__typename === 'UnitListing'
+  const singleUnit =
+    !listing.multiUnit && MULTI_UNIT_TYPES.includes(listing.__typename)
+  const multiUnit =
+    listing.multiUnit && MULTI_UNIT_TYPES.includes(listing.__typename)
   const isFractional = listing.__typename === 'FractionalListing'
   const isFractionalHourly = listing.__typename === 'FractionalHourlyListing'
 

--- a/packages/eventsource/src/index.js
+++ b/packages/eventsource/src/index.js
@@ -8,7 +8,7 @@ const _get = require('lodash/get')
 const memoize = require('lodash/memoize')
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-const MULTI_UNIT_TYPES = ['UnitListing', 'GiftCardListing']
+const MULTI_UNIT_TYPES = ['UnitListing', 'GiftCardListing', 'ServiceListing']
 
 const getListingDirect = async (contract, listingId) =>
   await contract.methods.listings(listingId).call()


### PR DESCRIPTION
### Description:

This handles `ServiceListing` as multi-listing in event source, and adds support for non-`UnitListing` muti-unit types to `ConfirmPurchase` UI component.

Issue #3304

@nick, whenever you get some time, I think it would be good if you could check up on this work.  I think most of that eventsource is your stuff.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
