### PR TITLE
Fixes multi-unit for ConfirmPurchase

### DIFF
--- a/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
+++ b/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
@@ -34,8 +34,9 @@ const ConfirmPurchase = ({
   shippingAddress,
   bookingRange
 }) => {
-  const singleUnit = !listing.multiUnit && listing.__typename === 'UnitListing'
-  const multiUnit = listing.multiUnit && listing.__typename === 'UnitListing'
+  const singleUnit =
+    listing.__typename === 'UnitListing' && listing.unitsTotal === 1
+  const multiUnit = listing.multiUnit
   const isFractional = listing.__typename === 'FractionalListing'
   const isFractionalHourly = listing.__typename === 'FractionalHourlyListing'
   const isService = listing.__typename === 'ServiceListing'

--- a/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
+++ b/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
@@ -47,8 +47,8 @@ const ConfirmPurchase = ({
   switch (true) {
     case multiUnit:
     case isService:
-      BuyMutationComponent = BuySingleUnitMutation
-      SummaryComponent = SingleUnitPurchaseSummary
+      BuyMutationComponent = BuyMultiUnitMutation
+      SummaryComponent = MultiUnitPurchaseSummary
       break
 
     case isFractional:
@@ -63,8 +63,8 @@ const ConfirmPurchase = ({
 
     case singleUnit:
     default:
-      BuyMutationComponent = BuyMultiUnitMutation
-      SummaryComponent = MultiUnitPurchaseSummary
+      BuyMutationComponent = BuySingleUnitMutation
+      SummaryComponent = SingleUnitPurchaseSummary
       break
   }
 

--- a/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
+++ b/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
@@ -38,13 +38,15 @@ const ConfirmPurchase = ({
   const multiUnit = listing.multiUnit && listing.__typename === 'UnitListing'
   const isFractional = listing.__typename === 'FractionalListing'
   const isFractionalHourly = listing.__typename === 'FractionalHourlyListing'
+  const isService = listing.__typename === 'ServiceListing'
 
   let BuyMutationComponent, SummaryComponent
 
   const availability = getAvailabilityCalculator(listing)
 
   switch (true) {
-    case singleUnit:
+    case multiUnit:
+    case isService:
       BuyMutationComponent = BuySingleUnitMutation
       SummaryComponent = SingleUnitPurchaseSummary
       break
@@ -59,7 +61,7 @@ const ConfirmPurchase = ({
       SummaryComponent = FractionalHourlyPurchaseSummary
       break
 
-    case multiUnit:
+    case singleUnit:
     default:
       BuyMutationComponent = BuyMultiUnitMutation
       SummaryComponent = MultiUnitPurchaseSummary

--- a/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
+++ b/dapps/marketplace/src/pages/listing/ConfirmPuchase.js
@@ -44,9 +44,9 @@ const ConfirmPurchase = ({
   const availability = getAvailabilityCalculator(listing)
 
   switch (true) {
-    case multiUnit:
-      BuyMutationComponent = BuyMultiUnitMutation
-      SummaryComponent = MultiUnitPurchaseSummary
+    case singleUnit:
+      BuyMutationComponent = BuySingleUnitMutation
+      SummaryComponent = SingleUnitPurchaseSummary
       break
 
     case isFractional:
@@ -59,10 +59,10 @@ const ConfirmPurchase = ({
       SummaryComponent = FractionalHourlyPurchaseSummary
       break
 
-    case singleUnit:
+    case multiUnit:
     default:
-      BuyMutationComponent = BuySingleUnitMutation
-      SummaryComponent = SingleUnitPurchaseSummary
+      BuyMutationComponent = BuyMultiUnitMutation
+      SummaryComponent = MultiUnitPurchaseSummary
       break
   }
 


### PR DESCRIPTION
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/guides/getting_started/contributing.html)

### Description:

Set multiUnit display as default for UI in `ConfirmPurchase` component.  Issue #3304

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
