### PR TITLE
Enable the debug API over RPC for geth nodes

### DIFF
--- a/devops/kubernetes/charts/ethereum-nodes/templates/geth-tx.statefulset.yaml
+++ b/devops/kubernetes/charts/ethereum-nodes/templates/geth-tx.statefulset.yaml
@@ -40,6 +40,7 @@ spec:
             --wsaddr 0.0.0.0
             --wsport 8546
             --rpc
+            --rpcapi eth,web3,net,debug
             --rpcaddr 0.0.0.0
             --rpcport 8545
             --rpcvhosts=\"*\"


### PR DESCRIPTION
### Description:

Enables the debug API on geth nodes.  It should be noted that there's a potential for DoS with the debug API calls:

- `debug_setHead()`
- `debug_startGoTrace`

If we start using these for anything critical, we should disable `debug`.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
