### PR TITLE
Adds the ability to disable cache for proxy utils

### DIFF
--- a/packages/graphql/src/utils/proxy.js
+++ b/packages/graphql/src/utils/proxy.js
@@ -5,7 +5,10 @@ async function isContractRaw(address) {
   const code = await contracts.web3.eth.getCode(address)
   return code && code.length > 2
 }
-export const isContract = memoize(isContractRaw, address => address)
+export const isContract =
+  process.env.DISABLE_CACHE === 'true'
+    ? isContractRaw
+    : memoize(isContractRaw, address => address)
 
 // Get the creation code for the deployed Proxy implementation
 const proxyCreationCode = memoize(async () => {
@@ -85,9 +88,18 @@ async function proxyOwnerRaw(address) {
   }
 }
 
-export const proxyOwner = memoize(proxyOwnerRaw, address => address)
-export const hasProxy = memoize(hasProxyRaw, address => address)
-export const predictedProxy = memoize(predictedProxyRaw, address => address)
+export const proxyOwner =
+  process.env.DISABLE_CACHE === 'true'
+    ? proxyOwnerRaw
+    : memoize(proxyOwnerRaw, address => address)
+export const hasProxy =
+  process.env.DISABLE_CACHE === 'true'
+    ? hasProxyRaw
+    : memoize(hasProxyRaw, address => address)
+export const predictedProxy =
+  process.env.DISABLE_CACHE === 'true'
+    ? predictedProxyRaw
+    : memoize(predictedProxyRaw, address => address)
 export const resetProxyCache = () => {
   isContract.cache.clear()
   hasProxy.cache.clear()


### PR DESCRIPTION
### Description:

When `DISABLE_CACHE` is set to `true`, don't memoize proxy functions.

closes #3337 
CC @nick 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
