### PR TITLE
Add tests for Shipping Address and Fractional Listings

### DIFF
--- a/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
+++ b/dapps/marketplace/src/pages/create-listing/ChooseListingType.js
@@ -135,6 +135,8 @@ require('react-styl')(`
 
   @media (max-width: 767.98px)
     .create-listing
+      h1
+        font-size: 1.5rem
       .choose-category
         border: unset
         padding: unset

--- a/dapps/marketplace/src/pages/create-listing/_RequireShipping.js
+++ b/dapps/marketplace/src/pages/create-listing/_RequireShipping.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 
 import { fbt } from 'fbt-runtime'
 
@@ -10,6 +10,12 @@ const RequireShipping = ({ onChange, listing }) => {
   const [requiresShipping, setRequiresShipping] = useState(
     (isForSale && newListing) || get(listing, 'requiresShipping')
   )
+
+  useEffect(() => {
+    if (newListing) {
+      onChange(requiresShipping)
+    }
+  }, [])
 
   const onChangeCallback = useCallback(
     e => {

--- a/dapps/marketplace/src/pages/listing/_BuyFractional.js
+++ b/dapps/marketplace/src/pages/listing/_BuyFractional.js
@@ -137,7 +137,7 @@ const Fractional = ({
             acceptedTokens={listing.acceptedTokens}
             listing={listing}
             value={token}
-            tookenStatus={tokenStatus}
+            tokenStatus={tokenStatus}
           >
             <ConfirmShippingAndPurchase
               listing={listing}

--- a/dapps/marketplace/src/pages/listing/_BuyFractional.js
+++ b/dapps/marketplace/src/pages/listing/_BuyFractional.js
@@ -137,8 +137,7 @@ const Fractional = ({
             acceptedTokens={listing.acceptedTokens}
             listing={listing}
             value={token}
-            hasBalance={tokenStatus.hasBalance}
-            hasEthBalance={tokenStatus.hasEthBalance}
+            tookenStatus={tokenStatus}
           >
             <ConfirmShippingAndPurchase
               listing={listing}

--- a/dapps/marketplace/src/pages/listing/_BuyFractionalHourly.js
+++ b/dapps/marketplace/src/pages/listing/_BuyFractionalHourly.js
@@ -149,8 +149,7 @@ const FractionalHourly = ({
             acceptedTokens={listing.acceptedTokens}
             listing={listing}
             value={token}
-            hasBalance={tokenStatus.hasBalance}
-            hasEthBalance={tokenStatus.hasEthBalance}
+            tokenStatus={tokenStatus}
           >
             <ConfirmShippingAndPurchase
               listing={listing}

--- a/dapps/marketplace/src/pages/listing/_BuyMultiUnit.js
+++ b/dapps/marketplace/src/pages/listing/_BuyMultiUnit.js
@@ -101,8 +101,7 @@ const MultiUnit = ({
         acceptedTokens={listing.acceptedTokens}
         listing={listing}
         value={token}
-        hasBalance={tokenStatus.hasBalance}
-        hasEthBalance={tokenStatus.hasEthBalance}
+        tokenStatus={tokenStatus}
       >
         <ConfirmShippingAndPurchase
           listing={listing}

--- a/dapps/marketplace/src/pages/listing/_BuySingleUnit.js
+++ b/dapps/marketplace/src/pages/listing/_BuySingleUnit.js
@@ -65,8 +65,7 @@ const SingleUnit = ({ listing, growthReward, prices, tokenStatus, token }) => {
         acceptedTokens={listing.acceptedTokens}
         listing={listing}
         value={token}
-        hasBalance={tokenStatus.hasBalance}
-        hasEthBalance={tokenStatus.hasEthBalance}
+        tokenStatus={tokenStatus}
       >
         <ConfirmShippingAndPurchase
           listing={listing}

--- a/dapps/marketplace/src/pages/listing/_PaymentOptions.js
+++ b/dapps/marketplace/src/pages/listing/_PaymentOptions.js
@@ -71,7 +71,7 @@ const PaymentOptions = ({
   ...props
 }) => {
   const isLoadingData =
-    get(props, 'tokenStatus.loading') ||
+    get(tokenStatus, 'loading') ||
     props.cannotTransact === 'loading' ||
     Object.keys(props).some(key => key.endsWith('Loading') && props[key])
 

--- a/dapps/marketplace/src/pages/listing/_PaymentOptions.js
+++ b/dapps/marketplace/src/pages/listing/_PaymentOptions.js
@@ -65,8 +65,7 @@ const PaymentOptions = ({
   value,
   price,
   tokens,
-  hasBalance,
-  hasEthBalance,
+  tokenStatus,
   children,
   cannotTransact,
   ...props
@@ -79,6 +78,8 @@ const PaymentOptions = ({
   if (isLoadingData) {
     return null
   }
+
+  const { hasBalance, hasEthBalance } = tokenStatus
 
   const noBalance = cannotTransact && cannotTransact !== 'no-balance'
   const noTokens = !Object.keys(tokens).length

--- a/dapps/marketplace/test/_helpers.js
+++ b/dapps/marketplace/test/_helpers.js
@@ -52,6 +52,15 @@ export const waitForText = async (page, text, path) => {
   return xpath
 }
 
+export const waitUntilTextHides = async (page, text, path) => {
+  const escapedText = escapeXpathString(text)
+  const xpath = `/html/body//${path || '*'}[contains(text(), ${escapedText})]`
+  await page.waitForXPath(xpath, {
+    hidden: true
+  })
+  return xpath
+}
+
 export const hasText = async (page, text, path) => {
   const escapedText = escapeXpathString(text)
   const xpath = `/html/body//${path || '*'}[contains(text(), ${escapedText})]`

--- a/dapps/marketplace/test/_helpers.js
+++ b/dapps/marketplace/test/_helpers.js
@@ -111,6 +111,8 @@ export const changeAccount = async (page, account, isFreshAccount = false) => {
       strength: 0
     }
 
+    delete window.localStorage.uiState
+
     if (isFreshAccount) {
       delete window.localStorage.useWeb3Identity
       delete window.localStorage.useMessagingObject
@@ -119,7 +121,14 @@ export const changeAccount = async (page, account, isFreshAccount = false) => {
       window.localStorage.useMessagingObject = JSON.stringify({
         enabled: true,
         pubKey: '0xff',
-        pubSig: '0xff'
+        pubSig: '0xff',
+        shippingOverride: {
+          name: 'Bruce Wayne',
+          address1: '123 Wayne Towers',
+          stateProvinceRegion: 'New Jersey',
+          postalCode: '123456',
+          country: 'USA'
+        }
       })
     }
   }, { account, isFreshAccount })

--- a/dapps/marketplace/test/index.js
+++ b/dapps/marketplace/test/index.js
@@ -6,7 +6,8 @@ import {
   clickBySelector,
   pic,
   createAccount,
-  giveRating
+  giveRating,
+  waitUntilTextHides
 } from './_helpers'
 import services from './_services'
 import assert from 'assert'
@@ -170,6 +171,46 @@ const purchaseMultiUnitListing = async ({ buyer, withShipping, title }) => {
   await pic(page, 'transaction-wait-for-seller')
 }
 
+const purchaseFractionalListing = async ({ buyer }) => {
+  await pic(page, 'listing-detail')
+  await changeAccount(page, buyer)
+
+  await clickByText(page, 'Availability', 'button')
+
+  const startDay = await page.$('.calendar:not(:first-child) .days .day:nth-child(9)')
+  const endDay = await page.$('.calendar:not(:first-child) .days .day:nth-child(15)')
+  await startDay.click()
+  await endDay.click()
+
+  await clickByText(page, 'Save', 'button')
+
+  await waitUntilTextHides(page, 'Save', 'button')
+
+  await waitForText(page, 'Total Price')
+
+  await clickByText(page, 'Book')
+
+  // Purchase confirmation
+  await waitForText(page, 'Please confirm your purchase', 'h1')
+  await pic(page, 'purchase-confirmation')
+  
+  await waitForText(page, 'Total Price')
+
+  // TODO: Find a way to verify check in and check out dates in summary
+
+  await waitForText(page, 'Check In')
+  await waitForText(page, 'Check Out')
+
+  await clickByText(page, 'Book', 'button')
+
+  await waitForText(page, 'View Purchase Details', 'button')
+  await pic(page, 'purchase-listing')
+
+  await clickByText(page, 'View Purchase Details', 'button')
+  await waitForText(page, 'Transaction History')
+  await pic(page, 'transaction-wait-for-seller')
+}
+
 const acceptOffer = async ({ seller }) => {
   await changeAccount(page, seller)
   await waitForText(page, 'Accept Offer', 'button')
@@ -206,7 +247,10 @@ const confirmReleaseFundsAndRate = async ({ buyer, review }) => {
   await pic(page, 'transaction-release-funds-finalized')
 }
 
-function randomTitle() {
+function randomTitle({ isFractional }) {
+  if (isFractional) {
+    return `3BHK apartment ${Math.floor(Math.random() * 100000)}`
+  }
   return `T-Shirt ${Math.floor(Math.random() * 100000)}`
 }
 
@@ -693,6 +737,182 @@ function multiUnitTests({ autoSwap, withShipping } = {}) {
   })
 }
 
+function fractionalTests({ autoSwap } = {}) {
+  describe(`Fractional Listing for Eth`, function() {
+    let seller, buyer, title, review
+    before(async function() {
+      ({ seller, buyer } = await reset('100'))
+      title = randomTitle({ isFractional: true })
+      review = randomReview()
+    })
+
+    it('should switch to Seller account', async function() {
+      await changeAccount(page, seller)
+    })
+
+    it('should have no Purchases', async function() {
+      await clickByText(page, 'Purchases', 'a/span')
+      await waitForText(page, 'You haven’t bought anything yet.')
+    })
+
+    it('should have no Listings', async function() {
+      await clickByText(page, 'Listings', 'a/span')
+      await waitForText(page, "You don't have any listings yet.")
+    })
+
+    it('should have no Sales', async function() {
+      await clickByText(page, 'Sales', 'a/span')
+      await waitForText(page, 'You haven’t sold anything yet.')
+    })
+
+    it('should have no Notifications', async function() {
+      await clickBySelector(page, '.nav-item.notifications a')
+      await page.waitForFunction(
+        `(function() {
+          try {
+            const selector = '.notifications.dropdown .dropdown-menu .count'
+            return document.querySelector(selector).innerText.replace(/\\s/, ' ').includes("0 Notifications")
+          } catch(e) {
+            return false
+          }
+        })()`
+      )
+    })
+
+    it('should navigate to the Add Listing page', async function() {
+      await clickByText(page, 'Add Listing')
+      await pic(page, 'add-listing')
+    })
+
+    it('should select For Rent', async function() {
+      await clickByText(page, 'For Rent')
+    })
+
+    it('should select Housing', async function() {
+      await clickByText(page, 'Housing')
+      await pic(page, 'add-listing')
+    })
+
+    it('should allow title and description entry', async function() {
+      await page.type('input[name=title]', title)
+      await page.type('textarea[name=description]', 'T-Shirt in size large')
+      await clickByText(page, 'Continue')
+      await pic(page, 'add-listing')
+    })
+
+    it('should allow price entry', async function() {
+      await page.type('input[name=price]', '1')
+      await page.type('input[name=weekendPrice]', '1')
+      await clickByText(page, 'Ethereum') // Select Eth
+      await clickByText(page, 'Maker Dai') // De-select Dai
+      await clickByText(page, 'Continue')
+      await pic(page, 'add-listing')
+    })
+
+    it('should allow changing availability and custom prices', async () => {
+      await waitForText(page, 'Availability', 'h1')
+      // TODO: To be updated after #3351 is fixed
+      // const startDay = await page.$('.calendar:not(:first-child) .days .day:nth-child(9)')
+      // const endDay = await page.$('.calendar:not(:first-child) .days .day:nth-child(15)')
+      // await startDay.click()
+      // await endDay.click()
+
+      // const availabilityNo = await page.$('.availability-editor .form-group input[type=radio]')
+      // await availabilityNo.click()
+
+      // await clickByText(page, 'Save', 'button')
+
+      await clickByText(page, 'Continue', 'button')
+    })
+
+    it('should allow image entry', async function() {
+      const input = await page.$('input[type="file"]')
+      await input.uploadFile(__dirname + '/fixtures/image-1.jpg')
+      await page.waitForSelector('.image-picker .preview-row')
+      await pic(page, 'add-listing')
+    })
+
+    it('should continue to review', async function() {
+      await clickByText(page, 'Continue')
+      await pic(page, 'add-listing')
+    })
+
+    it('should create listing', async function() {
+      await clickByText(page, 'Publish', 'button')
+      await waitForText(page, 'Promote Now', 'a')
+      await pic(page, 'add-listing')
+    })
+
+    it('should continue to listing', async function() {
+      await clickByText(page, 'View My Listing', 'a')
+    })
+
+    it('should have listing under Listings tab', async function() {
+      await clickByText(page, 'Listings', 'a/span')
+      await waitForText(page, 'Listings', 'h1')
+      await waitForText(page, title, 'a')
+      await clickByText(page, title, 'a')
+    })
+
+    it('should continue to listing promotion', async function() {
+      await clickByText(page, 'Promote Now', 'a')
+    })
+
+    it('should continue to OGN entry', async function() {
+      await clickByText(page, 'Continue', 'a')
+    })
+
+    it('should wait for correct OGN balance', async function() {
+      await page.waitForFunction(
+        `document.querySelector('.promote-listing .balance').innerText.includes("OGN Balance: 100")`
+      )
+    })
+
+    it('should enter 10 OGN', async function() {
+      await page.type('input[name=commissionPerUnit]', '10')
+      await clickByText(page, 'Continue', 'a')
+    })
+
+    it('should allow promotion tx', async function() {
+      await clickByText(page, 'Promote Now', 'button')
+    })
+
+    if (autoSwap) {
+      it('should prompt the user to approve their OGN', async function() {
+        await clickByText(page, 'Promote Now', 'button')
+      })
+    }
+
+    it('should allow listing to be viewed', async function() {
+      await clickByText(page, 'View My Listing', 'a')
+    })
+
+    it('should allow a new listing to be purchased', async function() {
+      await purchaseFractionalListing({ buyer })
+    })
+
+    it('should allow a new listing to be accepted', async function() {
+      await acceptOffer({ seller })
+    })
+
+    it('should allow a new listing to be finalized', async function() {
+      await confirmReleaseFundsAndRate({ buyer, review })
+    })
+
+    it('should have review on listing', async function() {
+      await clickByText(page, 'View Listing', 'li/div/a')
+      await waitForText(page, review, 'div')
+    })
+
+    it('should have purchase in Complete Purchases tab', async function() {
+      await clickByText(page, 'Purchases', 'a/span')
+      await waitForText(page, 'Purchases', 'h1')
+      await clickByText(page, 'Complete', 'a')
+      await waitForText(page, title, 'a')
+    })
+  })
+}
+
 function listingTests({ autoSwap } = {}) {
   singleUnitTests({ autoSwap })
   singleUnitTests({ autoSwap, withShipping: true })
@@ -700,6 +920,7 @@ function listingTests({ autoSwap } = {}) {
   singleUnitDaiTests({ autoSwap, withShipping: true })
   multiUnitTests({ autoSwap })
   multiUnitTests({ autoSwap, withShipping: true })
+  fractionalTests({ autoSwap })
 }
 
 function userProfileTests() {

--- a/packages/graphql/src/mutations/marketplace/makeOffer.js
+++ b/packages/graphql/src/mutations/marketplace/makeOffer.js
@@ -9,6 +9,7 @@ import currencies from '../../utils/currencies'
 import { proxyOwner, predictedProxy, resetProxyCache } from '../../utils/proxy'
 import { swapToTokenTx } from '../uniswap/swapToToken'
 import createDebug from 'debug'
+import { checkForMessagingOverride } from '../../resolvers/messaging/Messaging'
 const debug = createDebug('origin:makeOffer:')
 
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
@@ -23,7 +24,11 @@ async function makeOffer(_, data) {
     throw new Error('No marketplace')
   }
 
-  if (data.shippingAddress && data.shippingAddress !== '') {
+  let messagingOverride
+  if (messagingOverride = checkForMessagingOverride()) {
+    // Skip encryption in test environment
+    data.shippingAddressEncrypted = JSON.stringify(messagingOverride.shippingOverride)
+  } else if (data.shippingAddress && data.shippingAddress !== '') {
     const listing = await marketplace.eventSource.getListing(listingId)
     let seller = await proxyOwner(listing.seller.id)
     seller = seller || listing.seller.id


### PR DESCRIPTION
Adds some tests to DApp for Shipping Address and Fractional Listings.

For Fractional Listing tests, Custom pricing and availability has been skipped for now. Should be added after #3351 

### Checklist:
- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~~[Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~~
- [ ] ~~If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~~
- [ ] ~~Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~~
