### PR TITLE
Don't do a makeOffer requiring a proxy without a proxy

### DIFF
--- a/packages/graphql/src/mutations/marketplace/makeOffer.js
+++ b/packages/graphql/src/mutations/marketplace/makeOffer.js
@@ -6,7 +6,12 @@ import contracts from '../../contracts'
 import cost from '../_gasCost'
 import parseId from '../../utils/parseId'
 import currencies from '../../utils/currencies'
-import { proxyOwner, predictedProxy, resetProxyCache } from '../../utils/proxy'
+import {
+  isContract,
+  proxyOwner,
+  predictedProxy,
+  resetProxyCache
+} from '../../utils/proxy'
 import { swapToTokenTx } from '../uniswap/swapToToken'
 import createDebug from 'debug'
 import { checkForMessagingOverride } from '../../resolvers/messaging/Messaging'
@@ -115,6 +120,10 @@ async function makeOffer(_, data) {
       if (!owner) {
         owner = buyer
         proxy = await predictedProxy(buyer)
+        // This shouldn't happen at this point, a proxy should already exist
+        if (!isContract(proxy)) {
+          throw new Error('Proxy does not exist')
+        }
       }
       const Proxy = new contracts.web3Exec.eth.Contract(
         IdentityProxy.abi,


### PR DESCRIPTION
### Description:

**I don't think this is right, DO NOT MERGE**

This adds a check to makeOffer mutation to make sure a proxy exists before trying to use it.

Ref #3312
CC @nick 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
