### PR TITLE
Correct address for relay validation

### DIFF
--- a/infra/relayer/src/relayer.js
+++ b/infra/relayer/src/relayer.js
@@ -343,7 +343,10 @@ class Relayer {
     // have the whitelist too tight. We'll check the logs after a while
     // and see if there is anything we should add.
     try {
-      this.validator.validate(PROXY_HARDCODE, txData)
+      // Is the user is calling a method directly on their own proxy
+      const isCallingOwnProxy =
+        normalizeAddress(to) === normalizeAddress(predictedAddress)
+      this.validator.validate(isCallingOwnProxy ? PROXY_HARDCODE : to, txData)
     } catch (e) {
       logger.error('Error in transaction validator', e)
     }

--- a/infra/relayer/src/validator.js
+++ b/infra/relayer/src/validator.js
@@ -5,6 +5,8 @@ const web3 = new Web3()
 
 const IdentityProxyBuild = require('@origin/contracts/build/contracts/IdentityProxy_solc.json')
 const Proxy = new web3.eth.Contract(IdentityProxyBuild.abi)
+const ProxyFactoryBuild = require('@origin/contracts/build/contracts/ProxyFactory_solc.json')
+const ProxyFactory = new web3.eth.Contract(ProxyFactoryBuild.abi)
 const IdentityEventsBuild = require('@origin/contracts/build/contracts/IdentityEvents.json')
 const IdentityEvents = new web3.eth.Contract(IdentityEventsBuild.abi)
 const V00MarketplaceBuild = require('@origin/contracts/build/contracts/V00_Marketplace.json')
@@ -54,6 +56,11 @@ class Validator {
         'UniswapExchange',
         addresses.UniswapDaiExchange,
         UniswapDaiExchange._jsonInterface
+      ),
+      new ProxyFactoryValidator(
+        'ProxyFactory',
+        addresses.ProxyFactory,
+        ProxyFactory._jsonInterface
       )
     ]
     // A way to look up the correct validator for an address being called.
@@ -230,6 +237,20 @@ class UniswapValidator extends ContractCallVailidator {
     } else {
       logger.info(
         `Validation failed. ${method.name} is not an allowed to be called on an exchange contract`
+      )
+      return false
+    }
+  }
+}
+
+class ProxyFactoryValidator extends ContractCallVailidator {
+  // eslint-disable-next-line no-unused-vars
+  validateMethod(method, txdata, params) {
+    if (method.name == 'createProxyWithSenderNonce') {
+      return []
+    } else {
+      logger.info(
+        `Validation failed. ${method.name} is not an allowed to be called on an proxy factory contract`
       )
       return false
     }

--- a/infra/relayer/test/validator.test.js
+++ b/infra/relayer/test/validator.test.js
@@ -8,6 +8,8 @@ const web3 = new Web3(TEST_PROVIDER_URL)
 
 const IdentityProxyBuild = require('@origin/contracts/build/contracts/IdentityProxy_solc.json')
 const Proxy = new web3.eth.Contract(IdentityProxyBuild.abi)
+const ProxyFactoryBuild = require('@origin/contracts/build/contracts/ProxyFactory_solc.json')
+const ProxyFactory = new web3.eth.Contract(ProxyFactoryBuild.abi)
 const IdentityEventsBuild = require('@origin/contracts/build/contracts/IdentityEvents.json')
 const IdentityEvents = new web3.eth.Contract(IdentityEventsBuild.abi)
 const V00MarketplaceBuild = require('@origin/contracts/build/contracts/V00_Marketplace.json')
@@ -56,7 +58,7 @@ describe('relayer whitelist', async () => {
     })
   })
 
-  describe('whitelist marketplace 000 methods', async () => {
+  describe('whitelist marketplace methods', async () => {
     describe('createListing', async () => {
       it('should succeed', async () => {
         const txdata = V00Marketplace.methods
@@ -345,6 +347,27 @@ describe('relayer whitelist', async () => {
         const res = whitelist.validate(PROXY_HARDCODE, txdata)
         assert(!res)
       })
+    })
+  })
+
+  describe('whitelist proxy factory', () => {
+    it('will create new proxy', () => {
+      const txData = IdentityEvents.methods
+        .emitIdentityUpdated(JUNK_HASH)
+        .encodeABI()
+      const Proxy = new web3.eth.Contract(IdentityProxyBuild.abi)
+      const proxyTxData = Proxy.methods
+        .changeOwnerAndExecute(Alice, addresses.IdentityEvents, '0', txData)
+        .encodeABI()
+      const createCallTxData = ProxyFactory.methods
+        .createProxyWithSenderNonce(
+          addresses.IdentityProxyImplementation,
+          proxyTxData,
+          Alice,
+          '0'
+        )
+        .encodeABI()
+      assert(whitelist.validate(addresses.ProxyFactory, createCallTxData))
     })
   })
 })


### PR DESCRIPTION
Correctly sends the contract address being called to relay validation. This should stop relay validation from logging a failure 99% of the time.

Secondly, updates relay validator to allow calls to the proxy factory to create a new proxy. This is used in the relayer tests.