### PR TITLE
Fix casing of address lookups for validator.

### DIFF
--- a/infra/relayer/src/validator.js
+++ b/infra/relayer/src/validator.js
@@ -86,7 +86,7 @@ class Validator {
 
     for (let i = 1; i <= 20; i++) {
       const [_address, _txdata] = toCheck.pop()
-      const validator = this.validatorsByAddress[_address]
+      const validator = this.validatorsByAddress[_address.toLowerCase()]
       logger.info(`${i}. Checking call to ${_address} data ${_txdata}`)
       if (!validator) {
         logger.info(
@@ -119,7 +119,7 @@ class ContractCallVailidator {
   constructor(name, address, jsonInterface, opts) {
     opts = opts || {}
     this.name = name
-    this.address = address
+    this.address = address.toLowerCase()
     this.methods = this._methodsBySignature(jsonInterface)
     this.addresses = opts.addresses || {}
     const { whitelistMethods } = opts || {}

--- a/infra/relayer/test/validator.test.js
+++ b/infra/relayer/test/validator.test.js
@@ -68,6 +68,18 @@ describe('relayer whitelist', async () => {
         assert(res)
       })
     })
+    describe('createListing', async () => {
+      it('should succeed with different address casing', async () => {
+        const txdata = V00Marketplace.methods
+          .createListing(JUNK_HASH, 0, Bob)
+          .encodeABI()
+        const res = whitelist.validate(
+          addresses.Marketplace.toLowerCase(),
+          txdata
+        )
+        assert(res)
+      })
+    })
     describe('updateListing', async () => {
       it('should succeed', async () => {
         const txdata = V00Marketplace.methods


### PR DESCRIPTION
LowerCase all the addresses for looking up validators.

Validator tests were always working fine in tests, since all the contract addresses used in transactions came from the same file that the addresses used by the validator came from.

Add test for this.