### PR TITLE
EventCache should die without an address

### DIFF
--- a/devops/kubernetes/values/origin/values-dev.yaml
+++ b/devops/kubernetes/values/origin/values-dev.yaml
@@ -59,7 +59,7 @@ adminImageTag: '671a9b0'
 
 # origin-relayer
 relayerImage: origin-relayer
-relayerImageTag: '52a541a'
+relayerImageTag: 'c454ae0'
 
 # origin-graphql
 graphqlImage: origin-graphql

--- a/packages/event-cache/src/EventCache.js
+++ b/packages/event-cache/src/EventCache.js
@@ -118,6 +118,14 @@ class EventCache {
   constructor(contract, originBlock = 0, config) {
     this._processConfig(config)
 
+    if (
+      !(contract._address || (contract.options && contract.options.address))
+    ) {
+      throw new Error(
+        'Contract missing address!  Can not initialize EventCache'
+      )
+    }
+
     this.contract = contract
     this.originBlock = Number(originBlock)
     this.web3 = new Web3(contract.currentProvider)

--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -498,19 +498,26 @@ export function toggleMetaMask(enabled) {
 export function setMarketplace(address, epoch, version = '000') {
   if (!address) return
   const contract = new web3.eth.Contract(MarketplaceContract.abi, address)
-  patchWeb3Contract(contract, epoch, {
-    ...context.config,
-    useLatestFromChain: false,
-    ipfsEventCache:
-      context.config[`V${version.slice(1)}_Marketplace_EventCache`],
-    cacheMaxBlock:
-      context.config[`V${version.slice(1)}_Marketplace_EventCacheMaxBlock`],
-    prefix:
-      typeof address === 'undefined'
-        ? 'Marketplace_'
-        : `${address.slice(2, 8)}_`,
-    platform: typeof window === 'undefined' ? 'memory' : 'browser'
-  })
+
+  try {
+    patchWeb3Contract(contract, epoch, {
+      ...context.config,
+      useLatestFromChain: false,
+      ipfsEventCache:
+        context.config[`V${version.slice(1)}_Marketplace_EventCache`],
+      cacheMaxBlock:
+        context.config[`V${version.slice(1)}_Marketplace_EventCacheMaxBlock`],
+      prefix:
+        typeof address === 'undefined'
+          ? 'Marketplace_'
+          : `${address.slice(2, 8)}_`,
+      platform: typeof window === 'undefined' ? 'memory' : 'browser'
+    })
+  } catch (err) {
+    console.error('Unable to initialize EventCache for Marketplace')
+    throw err
+  }
+
   context.marketplace = contract
 
   const eventSource = new EventSource({
@@ -550,18 +557,25 @@ export function setIdentityEvents(address, epoch) {
     IdentityEventsContract.abi,
     address
   )
-  patchWeb3Contract(context.identityEvents, epoch, {
-    ...context.config,
-    ipfsEventCache: context.config.IdentityEvents_EventCache,
-    cacheMaxBlock: context.config.IdentityEvents_EventCacheMaxBlock,
-    useLatestFromChain: false,
-    prefix:
-      typeof address === 'undefined'
-        ? 'IdentityEvents_'
-        : `${address.slice(2, 8)}_`,
-    platform: typeof window === 'undefined' ? 'memory' : 'browser',
-    batchSize: 2500
-  })
+
+  try {
+    patchWeb3Contract(context.identityEvents, epoch, {
+      ...context.config,
+      ipfsEventCache: context.config.IdentityEvents_EventCache,
+      cacheMaxBlock: context.config.IdentityEvents_EventCacheMaxBlock,
+      useLatestFromChain: false,
+      prefix:
+        typeof address === 'undefined'
+          ? 'IdentityEvents_'
+          : `${address.slice(2, 8)}_`,
+      platform: typeof window === 'undefined' ? 'memory' : 'browser',
+      batchSize: 2500
+    })
+  } catch (err) {
+    console.error('Unable to initialize EventCache for IdentityEvents')
+    throw err
+  }
+
   context.identityEventsExec = context.identityEvents
 
   if (metaMask) {
@@ -586,18 +600,23 @@ export function setProxyContracts(config) {
     config.IdentityProxyImplementation
   )
   // Add an event cache to ProxyFactory.
-  patchWeb3Contract(context.ProxyFactory, config.ProxyFactory_Epoch, {
-    ...context.config,
-    ipfsEventCache: null, // TODO add IPFS cache after Meta-txn launch, once we have a non trivial number of events.
-    cacheMaxBlock: null,
-    useLatestFromChain: false,
-    prefix:
-      typeof config.ProxyFactory === 'undefined'
-        ? 'ProxyFactory_'
-        : `${config.ProxyFactory.slice(2, 8)}_`,
-    platform: typeof window === 'undefined' ? 'memory' : 'browser',
-    batchSize: 2500
-  })
+  try {
+    patchWeb3Contract(context.ProxyFactory, config.ProxyFactory_Epoch, {
+      ...context.config,
+      ipfsEventCache: null, // TODO add IPFS cache after Meta-txn launch, once we have a non trivial number of events.
+      cacheMaxBlock: null,
+      useLatestFromChain: false,
+      prefix:
+        typeof config.ProxyFactory === 'undefined'
+          ? 'ProxyFactory_'
+          : `${config.ProxyFactory.slice(2, 8)}_`,
+      platform: typeof window === 'undefined' ? 'memory' : 'browser',
+      batchSize: 2500
+    })
+  } catch (err) {
+    console.error('Unable to initialize EventCache for ProxyFactory')
+    throw err
+  }
 }
 
 export function shutdown() {


### PR DESCRIPTION
### Description:

EventCache is useless without an address.  It should raise a storm without one.  Might help troubleshoot #2944.  Will not stop errors when this happens.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
