### PR TITLE
Fixes environment context for Sentry in the dapp

### DIFF
--- a/dapps/marketplace/src/utils/sentry.js
+++ b/dapps/marketplace/src/utils/sentry.js
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/browser'
 
 const NET_TO_ENV = {
-  1: 'prod',
-  4: 'staging'
+  '1': 'prod',
+  '4': 'staging'
 }
 
 function getEnvName() {


### PR DESCRIPTION
### Description:

Env vars aren't naturally numbers

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
