### PR TITLE
fix version resolution in getId functions.  closes #3387

### DIFF
--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -538,7 +538,8 @@ export function setMarketplace(address, epoch, version = '000') {
     contract,
     contractExec: contract
   }
-  context.marketplaceVersionByAddress = context.marketplaceVersionByAddress || {}
+  context.marketplaceVersionByAddress =
+    context.marketplaceVersionByAddress || {}
   context.marketplaceVersionByAddress[address] = version
 
   if (metaMask) {

--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -193,6 +193,7 @@ export function setNetwork(net, customConfig) {
   context.graphql = config.graphql
 
   delete context.marketplace
+  delete context.marketplaceVersionByAddress
   delete context.marketplaceExec
   delete context.ogn
   delete context.ognExec
@@ -537,6 +538,8 @@ export function setMarketplace(address, epoch, version = '000') {
     contract,
     contractExec: contract
   }
+  context.marketplaceVersionByAddress = context.marketplaceVersionByAddress || {}
+  context.marketplaceVersionByAddress[address] = version
 
   if (metaMask) {
     const contractMM = new metaMask.eth.Contract(

--- a/packages/graphql/src/utils/getId.js
+++ b/packages/graphql/src/utils/getId.js
@@ -1,9 +1,14 @@
+import context from '../contracts'
+
 export function getOriginListingId(networkId, event) {
-  return `${networkId}-000-${event.returnValues.listingID}-${event.blockNumber}`
+  // config addresses are all lowercase
+  const version = context.marketplaceVersionByAddress[event.address.toLowerCase()] || '000'
+  return `${networkId}-${version}-${event.returnValues.listingID}-${event.blockNumber}`
 }
 
 export function getOriginOfferId(networkId, event) {
-  return `${networkId}-000-${event.returnValues.listingID}-${event.returnValues.offerID}`
+  const version = context.marketplaceVersionByAddress[event.address] || '000'
+  return `${networkId}-${version}-${event.returnValues.listingID}-${event.returnValues.offerID}`
 }
 
 export function getListingId(networkId, version, listingId) {

--- a/packages/graphql/src/utils/getId.js
+++ b/packages/graphql/src/utils/getId.js
@@ -2,7 +2,8 @@ import context from '../contracts'
 
 export function getOriginListingId(networkId, event) {
   // config addresses are all lowercase
-  const version = context.marketplaceVersionByAddress[event.address.toLowerCase()] || '000'
+  const version =
+    context.marketplaceVersionByAddress[event.address.toLowerCase()] || '000'
   return `${networkId}-${version}-${event.returnValues.listingID}-${event.blockNumber}`
 }
 


### PR DESCRIPTION
### Description:

Fixes version resolution in `@origin/graphql/src/utils/getId`.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
