### PR TITLE
[Growth] Add a new status 'Closed' to the growth_participant table

### DIFF
--- a/infra/growth/migrations/20190917214102-add-growth-participant-status-closed.js
+++ b/infra/growth/migrations/20190917214102-add-growth-participant-status-closed.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.query(`
+      ALTER TYPE enum_growth_participant_status ADD VALUE IF NOT EXISTS 'Closed';
+    `)
+  },
+
+  down: () => {
+    return Promise.resolve()
+  }
+}

--- a/infra/growth/src/apollo/resolvers.js
+++ b/infra/growth/src/apollo/resolvers.js
@@ -112,7 +112,7 @@ const resolvers = {
       return eligibility
     },
     async enrollmentStatus(_, args, context) {
-      // if identity overriden with admin_secret always show as enrolled
+      // if identity is overridden with admin_secret always show as enrolled
       if (context.identityOverriden) {
         return enums.GrowthParticipantAuthenticationStatus.Enrolled
       } else {

--- a/infra/growth/src/enums.js
+++ b/infra/growth/src/enums.js
@@ -48,12 +48,16 @@ const GrowthActionType = new Enum(
   'TelegramFollow'
 )
 
-const GrowthParticipantStatuses = new Enum('Active', 'Banned')
+// Active: account is active.
+// Banned: account was banned by our fraud scripts.
+// Closed: account was closed per the user request (and in most cases user opened a new account).
+const GrowthParticipantStatuses = new Enum('Active', 'Banned', 'Closed')
 
 const GrowthParticipantAuthenticationStatus = new Enum(
   'Enrolled',
   'Banned',
-  'NotEnrolled'
+  'NotEnrolled',
+  'Closed'
 )
 
 // DEPRECATED. Do not use.

--- a/infra/growth/src/resources/authentication.js
+++ b/infra/growth/src/resources/authentication.js
@@ -132,12 +132,17 @@ async function getUserAuthenticationStatus(token, accountId) {
 
   if (growthParticipant === null) {
     return enums.GrowthParticipantAuthenticationStatus.NotEnrolled
-  } else if (
-    growthParticipant.status === enums.GrowthParticipantStatuses.Banned
-  ) {
-    return enums.GrowthParticipantAuthenticationStatus.Banned
-  } else {
-    return enums.GrowthParticipantAuthenticationStatus.Enrolled
+  }
+
+  switch (growthParticipant.status) {
+    case enums.GrowthParticipantStatuses.Enrolled:
+      return enums.GrowthParticipantAuthenticationStatus.Enrolled
+    case enums.GrowthParticipantStatuses.Banned:
+      return enums.GrowthParticipantAuthenticationStatus.Banned
+    case enums.GrowthParticipantStatuses.Closed:
+      return enums.GrowthParticipantAuthenticationStatus.Closed
+    default:
+      throw new Error(`Unexpected GrowthParticipant status ${growthParticipant.status}`)
   }
 }
 

--- a/infra/growth/src/resources/authentication.js
+++ b/infra/growth/src/resources/authentication.js
@@ -142,7 +142,9 @@ async function getUserAuthenticationStatus(token, accountId) {
     case enums.GrowthParticipantStatuses.Closed:
       return enums.GrowthParticipantAuthenticationStatus.Closed
     default:
-      throw new Error(`Unexpected GrowthParticipant status ${growthParticipant.status}`)
+      throw new Error(
+        `Unexpected GrowthParticipant status ${growthParticipant.status}`
+      )
   }
 }
 

--- a/packages/graphql/src/typeDefs/Growth.js
+++ b/packages/graphql/src/typeDefs/Growth.js
@@ -69,6 +69,7 @@ module.exports = `
     Enrolled
     NotEnrolled
     Banned
+    Closed
   }
 
   # TODO: use Common.Price


### PR DESCRIPTION

### Description:

This PR adds the 'Closed' status to the already existing statuses 'Active', 'Banned' on the growth_participant table.

It will be used to mark an account as terminated per request from the user. For example if the user gets confused and created duplicate accounts on mobile and desktop, then contacts us to keep a single account and close the others.

Note: this PR only handles the back-end. Front-end changes to properly display closed account will be handled separately (not a high priority since very few cases).

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
