### PR TITLE
Fixes relayer getting stuck in lookup state

### DIFF
--- a/infra/relayer/src/purse.js
+++ b/infra/relayer/src/purse.js
@@ -282,7 +282,9 @@ class Purse {
      * Need this function because if we throw in setTimeout it won't bubble up
      * properly and can't be handled.
      */
+    const that = this
     const timeout = () => {
+      that.accountLookupInProgress = false
       throw new Error('Account acquisition timeout!')
     }
 


### PR DESCRIPTION
### Description:

If a timeout occurs, don't continue thinking an account lookup is still in progress.  

Ref #3429

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
