### PR TITLE
Revert "Fix Telegram Attestation on Mobile (#3405)"

### DIFF
--- a/dapps/marketplace/src/components/growth/Action.js
+++ b/dapps/marketplace/src/components/growth/Action.js
@@ -146,8 +146,7 @@ function Action(props) {
     title = fbt('Join us on Telegram', 'RewardActions.followOnTelegram')
     allowInteractionWhenCompleted = true
     // TODO: Move screen name to Enviroment variable
-    // externalLink = 'tg://resolve?domain=@originprotocol'
-    externalLink = 'https://t.me/originprotocol'
+    externalLink = 'tg://resolve?domain=@originprotocol'
   } else if (type === 'FacebookLike') {
     buttonLink = undefined
     foregroundImgSrc = 'images/growth/facebook-icon.svg'

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -112,14 +112,3 @@ Add the `NODE_OPTIONS` env var to your Metro builder startup command to add the 
     INSTALL_FAILED_UPDATE_INCOMPATIBLE: Package com.origincatcher signatures do not match previously installed version; ignoring!
 
 Uninstall the app from your phone and try again.
-
------------
-
-> Error: Activity class {com.origincatcher/com.origincatcher.MainActivity} does not exist.
-  Error while Launching activity
-
-Run the following command in a terminal
-
-```
-adb uninstall com.origincatcher
-```

--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -595,26 +595,22 @@ class MarketplaceScreen extends Component {
   _openDeepLinkUrlAttempt = async (
     interceptUrlPredicate,
     makeUrl,
-    timeControlVariableName,
-    skipForceRefresh
+    timeControlVariableName
   ) => {
     // non interceptable url
     if (!interceptUrlPredicate()) return
 
     const url = makeUrl()
-    if (await Linking.canOpenURL(url)) {
-      if (!skipForceRefresh) {
-        this.goBackToDapp()
-      }
+    if (Linking.canOpenURL(url)) {
+      this.goBackToDapp()
       // preventing multiple subsequent shares
       if (
         !this[timeControlVariableName] ||
         new Date() - this[timeControlVariableName] > 3000
       ) {
         this[timeControlVariableName] = new Date()
-        await Linking.openURL(url)
+        return await Linking.openURL(url)
       }
-      return true
     } else {
       // can not open deep link url
       return false
@@ -622,82 +618,53 @@ class MarketplaceScreen extends Component {
   }
 
   checkForShareNativeDialogInterception = async url => {
-    console.log('Url change: ', url.href)
     // natively tweet if possible on Android
-    if (
-      await this._openDeepLinkUrlAttempt(
-        () =>
-          url.hostname === 'twitter.com' &&
-          url.pathname === '/intent/tweet' &&
-          Platform.OS === 'android',
-        () =>
-          `twitter://post?message=${encodeURIComponent(
-            url.searchParams.get('text')
-          )}`,
-        'lastTweetAttemptTime'
-      )
-    ) {
-      return true
-    }
+    console.log('Url change: ', url.href)
+    await this._openDeepLinkUrlAttempt(
+      () =>
+        url.hostname === 'twitter.com' &&
+        url.pathname === '/intent/tweet' &&
+        Platform.OS === 'android',
+      () =>
+        `twitter://post?message=${encodeURIComponent(
+          url.searchParams.get('text')
+        )}`,
+      'lastTweetAttemptTime'
+    )
 
     //open twitter profile natively if possible on Android
-    if (
-      await this._openDeepLinkUrlAttempt(
-        () =>
-          url.hostname === 'twitter.com' &&
-          url.pathname === '/intent/follow' &&
-          Platform.OS === 'android',
-        () =>
-          `twitter://user?screen_name=${url.searchParams.get('screen_name')}`,
-        'lastOpenTwitterProfileTime'
-      )
-    ) {
-      return true
-    }
+    await this._openDeepLinkUrlAttempt(
+      () =>
+        url.hostname === 'twitter.com' &&
+        url.pathname === '/intent/follow' &&
+        Platform.OS === 'android',
+      () => `twitter://user?screen_name=${url.searchParams.get('screen_name')}`,
+      'lastOpenTwitterProfileTime'
+    )
 
     // open facebook profile natively if possible on Android
-    if (
-      await this._openDeepLinkUrlAttempt(
-        () =>
-          (url.hostname === 'www.facebook.com' ||
-            url.hostname === 'm.facebook.com') &&
-          url.pathname.toLowerCase() === '/originprotocol/' &&
-          Platform.OS === 'android',
-        //Facebook on IOS and Android has different deep-linking format
-        () => `fb://page/120151672018856`,
-        'lastOpenFacebookProfileTime'
-      )
-    ) {
-      return true
-    }
+    await this._openDeepLinkUrlAttempt(
+      () =>
+        (url.hostname === 'www.facebook.com' ||
+          url.hostname === 'm.facebook.com') &&
+        url.pathname.toLowerCase() === '/originprotocol/' &&
+        Platform.OS === 'android',
+      //Facebook on IOS and Android has different deep-linking format
+      () => `fb://page/120151672018856`,
+      'lastOpenFacebookProfileTime'
+    )
 
     // open facebook profile natively if possible and IOS
-    if (
-      await this._openDeepLinkUrlAttempt(
-        () =>
-          (url.hostname === 'www.facebook.com' ||
-            url.hostname === 'm.facebook.com') &&
-          url.pathname.toLowerCase() === '/originprotocol/' &&
-          Platform.OS === 'ios',
-        //Facebook on IOS and Android has different deep-linking format
-        () => `fb://profile/120151672018856`,
-        'lastOpenFacebookProfileTime'
-      )
-    ) {
-      return true
-    }
-
-    // Open telegram links on native web browser
-    if (
-      await this._openDeepLinkUrlAttempt(
-        () => url.hostname === 't.me',
-        () => url.toString(),
-        'lastOpenTelegramProfileTime',
-        true
-      )
-    ) {
-      return true
-    }
+    await this._openDeepLinkUrlAttempt(
+      () =>
+        (url.hostname === 'www.facebook.com' ||
+          url.hostname === 'm.facebook.com') &&
+        url.pathname.toLowerCase() === '/originprotocol/' &&
+        Platform.OS === 'ios',
+      //Facebook on IOS and Android has different deep-linking format
+      () => `fb://profile/120151672018856`,
+      'lastOpenFacebookProfileTime'
+    )
 
     if (
       url.hostname === 'www.facebook.com' ||
@@ -714,9 +681,7 @@ class MarketplaceScreen extends Component {
         }
         const canShowFbShare = await ShareDialog.canShow(shareLinkContent)
 
-        if (!canShowFbShare) {
-          return
-        }
+        if (!canShowFbShare) return
 
         this.facebookShareShowTime = new Date()
         const shareResult = await ShareDialog.show(shareLinkContent)
@@ -756,18 +721,10 @@ class MarketplaceScreen extends Component {
       }
 
       this.setState(stateUpdate)
-
-      const intercepted = await this.checkForShareNativeDialogInterception(url)
-      if (intercepted) {
-        // Stop loading if URL has been intercepted
-        this.dappWebView.stopLoading()
-        return false
-      }
+      await this.checkForShareNativeDialogInterception(url)
     } catch (error) {
       console.warn(`Browser reporting malformed url: ${state.url}`)
     }
-
-    return true
   }
 
   onWebViewLoad = async () => {
@@ -904,7 +861,6 @@ class MarketplaceScreen extends Component {
                 this.props.setMarketplaceWebViewError(nativeEvent.description)
               }}
               onNavigationStateChange={this.onWebViewNavigationStateChange}
-              onShouldStartLoadWithRequest={this.onWebViewNavigationStateChange}
               renderLoading={() => {
                 return (
                   <View style={styles.loading}>


### PR DESCRIPTION
Sorry @shahthepro I think we'll have to revert this because the current mobile code lives in `tomlinton/web3view` and this has been refactored. I think it'll be easier to redo this rather than try and merge. My fault as I've had this long running branch that hasn't been merged into master but is the basis for the current set of mobile releases.

I'll create a new PR for this.