### PR TITLE
[WIP] Deal with create2 failures in ProxyFactory

### DIFF
--- a/packages/contracts/contracts/proxy/ProxyFactory.s
+++ b/packages/contracts/contracts/proxy/ProxyFactory.s
@@ -49,6 +49,12 @@ contract ProxyFactory {
         assembly {
             proxy := create2(0x0, add(0x20, deploymentData), mload(deploymentData), salt)
         }
+
+        // create2 failed
+        if (proxy == address(0)) {
+            revert("proxy-deploy-failed");
+        }
+
         if (initializer.length > 0)
             // solium-disable-next-line security/no-inline-assembly
             assembly {
@@ -73,6 +79,12 @@ contract ProxyFactory {
         assembly {
             proxy := create2(0x0, add(0x20, deploymentData), mload(deploymentData), salt)
         }
+
+        // create2 failed
+        if (proxy == address(0)) {
+            revert("proxy-deploy-failed");
+        }
+
         if (initializer.length > 0) {
             uint256 value = msg.value;
             // solium-disable-next-line security/no-inline-assembly


### PR DESCRIPTION
### Description:

`revert` on `create2` failure in ProxyFactory proxy creation methods.

Ref #3392

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
