### PR TITLE
Disable KeyboardAvoidingView on iOS

### DIFF
--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -556,9 +556,9 @@ class MarketplaceScreen extends Component {
         <SafeAreaView style={{ flex: 1 }}>
           <KeyboardAvoidingView
             behavior="padding"
-            keyboardVerticalOffset={Platform.select({ ios: 0, android: 20 })}
+            keyboardVerticalOffset={20}
             style={{ flex: 1 }}
-            enabled
+            enabled={Platform.os === 'android'}
           >
             <ScrollView
               contentContainerStyle={{ flex: 1 }}


### PR DESCRIPTION
The KeyboardAvoidingView was introduced to fix an issue on Android where the keyboard would overlay the bottom of mobile modals. This was never an issue on iOS and the KeyboardAvoidingView caused a padding issue there (#3376). We can just disable the KeyboardAvoidingView on iOS to solve that.

Closes #3376.