### PR TITLE
iOS LaunchScreen update

### DIFF
--- a/mobile/ios/OriginMarketplace.xcodeproj/project.pbxproj
+++ b/mobile/ios/OriginMarketplace.xcodeproj/project.pbxproj
@@ -448,10 +448,9 @@
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "OriginMarketplace" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/mobile/ios/OriginMarketplace/Base.lproj/LaunchScreen.xib
+++ b/mobile/ios/OriginMarketplace/Base.lproj/LaunchScreen.xib
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_9" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="origin-logo-light" translatesAutoresizingMaskIntoConstraints="NO" id="R4q-n7-BXl">
                     <rect key="frame" x="147" y="56" width="81" height="19"/>
                 </imageView>
             </subviews>
-            <color key="backgroundColor" red="0.16078431372549021" green="0.22352941176470589" blue="0.29411764705882354" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" red="0.30890191770677811" green="0.437069611678088" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
             <constraints>
                 <constraint firstItem="R4q-n7-BXl" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="56" id="AZj-FX-LGu"/>
                 <constraint firstItem="R4q-n7-BXl" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Z2Q-le-rcl"/>

--- a/mobile/src/AppContainer.js
+++ b/mobile/src/AppContainer.js
@@ -19,7 +19,6 @@ import AuthenticationGuard from 'components/authentication-guard'
 import UpdatePrompt from 'components/update-prompt'
 import BackupPrompt from 'components/backup-prompt'
 import SamsungBKS from 'components/samsung-bks'
-import Loading from 'components/loading'
 
 class MarketplaceApp extends React.Component {
   static router = Navigation.router
@@ -126,9 +125,7 @@ class MarketplaceApp extends React.Component {
       <>
         {this.props.samsungBKS.enabled && <SamsungBKS />}
         {!this.props.samsungBKS.error &&
-          (samsungBKSInitializing ? (
-            <Loading />
-          ) : (
+          (samsungBKSInitializing ? null : (
             <>
               <StatusBar />
               <AuthenticationGuard />


### PR DESCRIPTION
- Change iOS launch screen to clear blue
- Remove other loading indicator that isn't really necessary as it is very quick (and it makes it look like a flicker)
- Migrated an iOS localisation thing

Closes #3421.