### PR TITLE
Fixes relayer fallback and withdrawOffer

### DIFF
--- a/dapps/marketplace/src/pages/transaction/mutations/WithdrawOffer.js
+++ b/dapps/marketplace/src/pages/transaction/mutations/WithdrawOffer.js
@@ -94,7 +94,7 @@ class WithdrawOffer extends Component {
     withdrawOffer({
       variables: {
         offerID: this.props.offer.id,
-        from: this.props.from
+        from: this.props.offer.buyer.id
       }
     })
   }

--- a/packages/graphql/src/mutations/_txHelper.js
+++ b/packages/graphql/src/mutations/_txHelper.js
@@ -706,7 +706,7 @@ export default function txHelper({
     if (shouldUseRelayer && shouldUseProxy) {
       const address = get(toSend, '_parent._address')
       try {
-        await sendViaRelayer({
+        return await sendViaRelayer({
           web3,
           tx: toSend,
           proxy,

--- a/packages/graphql/src/mutations/_txHelper.js
+++ b/packages/graphql/src/mutations/_txHelper.js
@@ -721,31 +721,34 @@ export default function txHelper({
         if (String(err).match(/denied message signature/)) {
           return reject(err)
         } else {
-          // Re-throw in a timeout so we can catch the error in tests
+          /**
+           * Re-throw in a timeout so we can catch the error in tests, but it
+           * should not cause the whole process to burn, so we can fallback to
+           * the traditional wallet sendTransaction
+           */
           setTimeout(() => {
             throw err
           }, 1)
         }
       }
-    } else {
-      // Send using the availble or given web3 instance
-      // TODO: holy argument hell, batman!  Why isn't half of this part of the tx?
-      debug(`Sending via web3`)
-      await sendViaWeb3({
-        web3,
-        tx: toSend,
-        to,
-        sourceAccount: from,
-        value,
-        gas,
-        gasPrice,
-        hashCallbacks,
-        receiptCallbacks,
-        confirmCallbacks,
-        mutation
-      })
-      debug(`Sent via web3`)
     }
+
+    // Send using the availble or given web3 instance
+    debug(`Sending via web3`)
+    await sendViaWeb3({
+      web3,
+      tx: toSend,
+      to,
+      sourceAccount: from,
+      value,
+      gas,
+      gasPrice,
+      hashCallbacks,
+      receiptCallbacks,
+      confirmCallbacks,
+      mutation
+    })
+    debug(`Sent via web3`)
   }).catch(err => {
     console.error(err)
     throw err


### PR DESCRIPTION
### Description:

- `from` was not being properly set for withdrawOffer transactions
- relayer fallback to web3 was mistakenly disabled

Ref #3283

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
