### PR TITLE
Adds fetch timeout for EthGasStationProvider

### DIFF
--- a/packages/web3-provider/src/subproviders/EthGasStationProvider.js
+++ b/packages/web3-provider/src/subproviders/EthGasStationProvider.js
@@ -14,9 +14,7 @@ const GAS_PRICE_KEY = process.env.GAS_PRICE_KEY || 'average' // 'safeLow'
  */
 function timeoutFetch(url, ms = 10000) {
   return Promise.race([
-    fetch(url).then(res => {
-      return res
-    }),
+    fetch(url),
     new Promise((resolve, reject) => {
       setTimeout(() => reject(new Error('timeout')), ms)
     })

--- a/packages/web3-provider/src/subproviders/EthGasStationProvider.js
+++ b/packages/web3-provider/src/subproviders/EthGasStationProvider.js
@@ -5,6 +5,24 @@ const CACHE_TIME = 15000
 const GAS_STATION_URL = 'https://ethgasstation.info/json/ethgasAPI.json'
 const GAS_PRICE_KEY = process.env.GAS_PRICE_KEY || 'average' // 'safeLow'
 
+/**
+ * Wraps a fetch with a timeout
+ *
+ * @param url {string} URL to fetch
+ * @param ms {number} timeout in milliseconds
+ * @returns {object} fetch response object
+ */
+function timeoutFetch(url, ms = 10000) {
+  return Promise.race([
+    fetch(url).then(res => {
+      return res
+    }),
+    new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error('timeout')), ms)
+    })
+  ])
+}
+
 class EthGasStationProvider extends SubProvider {
   constructor() {
     super()
@@ -16,7 +34,7 @@ class EthGasStationProvider extends SubProvider {
   }
 
   async fetchData() {
-    const res = await fetch(GAS_STATION_URL)
+    const res = await timeoutFetch(GAS_STATION_URL)
     if (res.status !== 200) {
       throw new Error(`Fetch returned code ${res.status}`)
     }


### PR DESCRIPTION
### Description:

This might solve .:. #3512.  Doesn't appear that cross-fetch will timeout if the HTTP server doesn't timeout.  I suspect ethgasstation might not and this is blocking for longer than it should.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
