### PR TITLE
Throw errors on invalid txhash

### DIFF
--- a/packages/graphql/src/mutations/_txHelper.js
+++ b/packages/graphql/src/mutations/_txHelper.js
@@ -439,8 +439,10 @@ async function sendViaRelayer({
   if (!resp || !resp.id) {
     throw new Error('No transaction hash from relayer!')
   }
-
   const txHash = resp.id
+  if (typeof txHash !== 'string' || ![66, 64].includes(txHash.length)) {
+    throw new Error('Invalid transaction hash returned by relayer!')
+  }
 
   if (hashCallbacks && hashCallbacks.length) {
     await handleCallbacks({
@@ -555,6 +557,10 @@ async function sendViaWeb3({
 
   tx.once('transactionHash', async hash => {
     txHash = hash
+    if (typeof txHash !== 'string' || ![66, 64].includes(txHash.length)) {
+      console.error('Invaild hash: ', txHash)
+      throw new Error('Invalid transaction hash returned by web3!')
+    }
     await handleCallbacks({ callbacks: hashCallbacks, val: hash })
   })
     .once('receipt', async receipt => {


### PR DESCRIPTION
### Description:

Throws errors on invalid transaction hash in `txHelper`.  Trying to get to the bottom of #3275.  The graphql receipt resolver already does validation.  This is the only place I found that might be doing this from the dapp.

In the case of these invalid hashes being sent to Alchemy, it would generate an error anyway, so better to head it off early.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
