### PR TITLE
console.warning is not a thing

### DIFF
--- a/packages/event-cache/src/utils.js
+++ b/packages/event-cache/src/utils.js
@@ -56,11 +56,11 @@ function validateParams(contract, params) {
   if (params.event) {
     if (params.event instanceof Array) {
       if (!params.event.every(ev => availableEvents.includes(ev))) {
-        console.warning('At least one event does not exist in contract')
+        console.warn('At least one event does not exist in contract')
         return false
       }
     } else if (!availableEvents.includes(params.event)) {
-      console.warning(`event does not exist in contract`)
+      console.warn(`event does not exist in contract`)
       debug(`expected ${params.event}`)
       return false
     }


### PR DESCRIPTION
### Description:

Couple calls to `console.warning` in `event-cache/src/utils.js`

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
