### PR TITLE
Fix onMessagingStatusChange subscription

### DIFF
--- a/dapps/marketplace/src/queries/MessagingStatusChangeSubscription.js
+++ b/dapps/marketplace/src/queries/MessagingStatusChangeSubscription.js
@@ -3,9 +3,7 @@ import gql from 'graphql-tag'
 export default gql`
   subscription onMessagingStatusChange {
     messagingStatusChange {
-      hasGeneratedWallet
-      hasSignedWalletAddress
-      messagingEnabled
+      newStatus
     }
   }
 `

--- a/packages/graphql/src/resolvers/Subscription.js
+++ b/packages/graphql/src/resolvers/Subscription.js
@@ -32,15 +32,13 @@ export default {
     subscribe: () => pubsub.asyncIterator('MESSAGE_ADDED')
   },
   markedAsRead: {
-    resolve: ({ markedAsRead }) => {
-      return markedAsRead
-    },
+    resolve: ({ markedAsRead }) => markedAsRead,
     subscribe: () => pubsub.asyncIterator('MARKED_AS_READ')
   },
   messagingStatusChange: {
-    resolve: ({ messagingStatusChange }) => {
-      return messagingStatusChange
-    },
+    resolve: ({ messagingStatusChange }) => ({
+      newStatus: messagingStatusChange
+    }),
     subscribe: () => pubsub.asyncIterator('MESSAGING_STATUS_CHANGE')
   }
 }

--- a/packages/graphql/src/typeDefs/Messaging.js
+++ b/packages/graphql/src/typeDefs/Messaging.js
@@ -2,7 +2,7 @@ module.exports = `
   extend type Subscription {
     messageAdded: NewMessageResult
     markedAsRead: MarkedAsReadResult
-    messagingStatusChange: MessagingStatusResult
+    messagingStatusChange: MessagingStatusChangeResult
   }
 
   type NewMessageResult {
@@ -17,10 +17,8 @@ module.exports = `
     messagesRead: Int
   }
 
-  type MessagingStatusResult {
-    hasGeneratedWallet: Boolean
-    hasSignedWalletAddress: Boolean
-    enabled: Boolean
+  type MessagingStatusChangeResult {
+    newStatus: String
   }
 
   extend type Query {

--- a/packages/messaging-client/src/Messaging.js
+++ b/packages/messaging-client/src/Messaging.js
@@ -188,6 +188,11 @@ class Messaging {
 
     this.account_key = key
     this.account = undefined
+
+    await this.pubsub.publish('MESSAGING_STATUS_CHANGE', {
+      messagingStatusChange: 'disabled'
+    })
+
     this.events.emit('new', this.account_key)
     // just start it up here
     if (await this.initRemote()) {
@@ -259,9 +264,7 @@ class Messaging {
     this.ready = true
     this.events.emit('ready', this.account_key)
     this.pubsub.publish('MESSAGING_STATUS_CHANGE', {
-      hasGeneratedWallet: true,
-      hasSignedWalletAddress: true,
-      messagingEnabled: true
+      messagingStatusChange: 'ready'
     })
   }
 
@@ -313,6 +316,11 @@ class Messaging {
     //set phrase in the cookie
     const scopedMessagingPhraseName = `${MESSAGING_PHRASE}:${this.account_key}`
     this.setKeyItem(scopedMessagingPhraseName, phraseStr)
+
+    await this.pubsub.publish('MESSAGING_STATUS_CHANGE', {
+      messagingStatusChange: 'sign1'
+    })
+
     await this.initMessaging()
   }
 
@@ -330,9 +338,6 @@ class Messaging {
     const signature = await signer.sign(sigPhrase, this.account_key)
     debug('signedSig', signature)
     this.events.emit('signedSig')
-    this.pubsub.publish('MESSAGING_STATUS_CHANGE', {
-      hasGeneratedWallet: true
-    })
 
     // 32 bytes in hex + 0x
     const sigKey = signature.substring(0, 66)
@@ -347,9 +352,8 @@ class Messaging {
     this.pub_msg = PROMPT_PUB_KEY + this.account.address
     const signer = this.personalSign ? this.web3.eth.personal : this.web3.eth
     this.pub_sig = await signer.sign(this.pub_msg, this.account_key)
-    this.pubsub.publish('MESSAGING_STATUS_CHANGE', {
-      hasGeneratedWallet: true,
-      hasSignedWalletAddress: true
+    await this.pubsub.publish('MESSAGING_STATUS_CHANGE', {
+      messagingStatusChange: 'sign2'
     })
     const scopedPubSigKeyName = `${PUB_MESSAGING_SIG}:${this.account_key}`
     this.setKeyItem(scopedPubSigKeyName, this.pub_sig)


### PR DESCRIPTION
A minor fix. `onMessagingStatusChange` event was published before the account was set. Related to issue #3625 