### PR TITLE
Env var cleanup and admin fix

### DIFF
--- a/dapps/admin/webpack.config.js
+++ b/dapps/admin/webpack.config.js
@@ -74,7 +74,10 @@ const config = {
   mode: isProduction ? 'production' : 'development',
   plugins: [
     new HtmlWebpackPlugin({ template: 'public/template.html', inject: false }),
-    new webpack.EnvironmentPlugin({ HOST: 'localhost' })
+    new webpack.EnvironmentPlugin({
+      HOST: 'localhost',
+      WEBPACK_BUILD: true // Used by EventCache
+    })
   ],
 
   optimization: {

--- a/dapps/marketplace/webpack.config.js
+++ b/dapps/marketplace/webpack.config.js
@@ -152,11 +152,8 @@ const config = {
       NAMESPACE: process.env.NAMESPACE || 'dev',
       ETH_NETWORK_ID: process.env.ETH_NETWORK_ID || null,
       TELEGRAM_BOT_USERNAME: TELEGRAM_BOT_USERNAME,
-      NODE_ENV: process.env.NODE_ENV || 'development'
-    }),
-    // This is used for event-cache to conditionally leave out Postgres backend
-    new webpack.EnvironmentPlugin({
-      WEBPACK_BUILD: true
+      NODE_ENV: process.env.NODE_ENV || 'development',
+      WEBPACK_BUILD: true // Used by EventCache
     })
   ],
 


### PR DESCRIPTION
### Description:

Makes sure `WEBPACK_BUILD` is set for admin dapp build and cleans up the marketplace plugin definition a bit.

This env var was introduced for PR #3155 to deal with conditional imports of sequelize junk the dapp doesn't need.  Reduces the bundle by ~1MB.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
