### PR TITLE
Admin: DeployMarketplace account selection fix

### DIFF
--- a/dapps/admin/src/pages/contracts/_DeployContract.js
+++ b/dapps/admin/src/pages/contracts/_DeployContract.js
@@ -20,6 +20,16 @@ class DeployContract extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.accounts != prevProps.accounts) {
+      let admin = rnd(this.props.accounts.filter(a => a.role === 'Admin'))
+      if (!admin) admin = rnd(this.props.accounts)
+      this.setState({
+        from: admin ? admin.id : ''
+      })
+    }
+  }
+
   render() {
     const input = field => ({
       value: this.state[field],

--- a/dapps/admin/src/pages/contracts/_DeployIdentityEvents.js
+++ b/dapps/admin/src/pages/contracts/_DeployIdentityEvents.js
@@ -20,6 +20,16 @@ class DeployIdentityEventsContract extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.accounts != prevProps.accounts) {
+      let admin = rnd(this.props.accounts.filter(a => a.role === 'Admin'))
+      if (!admin) admin = rnd(this.props.accounts)
+      this.setState({
+        from: admin ? admin.id : ''
+      })
+    }
+  }
+
   render() {
     const input = field => ({
       value: this.state[field],

--- a/dapps/admin/src/pages/contracts/_DeployMarketplace.js
+++ b/dapps/admin/src/pages/contracts/_DeployMarketplace.js
@@ -25,7 +25,7 @@ class DeployMarketplace extends Component {
       version: '001',
       token: token ? token.id : '',
       from: admin ? admin.id : '',
-      autoWhitelist: true
+      autoWhitelist: false
     }
   }
 

--- a/dapps/admin/src/pages/contracts/_DeployMarketplace.js
+++ b/dapps/admin/src/pages/contracts/_DeployMarketplace.js
@@ -29,6 +29,16 @@ class DeployMarketplace extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.accounts != prevProps.accounts) {
+      let admin = rnd(this.props.accounts.filter(a => a.role === 'Admin'))
+      if (!admin) admin = rnd(this.props.accounts)
+      this.setState({
+        from: admin ? admin.id : ''
+      })
+    }
+  }
+
   render() {
     const input = field => ({
       value: this.state[field],

--- a/dapps/admin/src/pages/contracts/_DeployToken.js
+++ b/dapps/admin/src/pages/contracts/_DeployToken.js
@@ -24,6 +24,16 @@ class DeployToken extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.accounts != prevProps.accounts) {
+      let admin = rnd(this.props.accounts.filter(a => a.role === 'Admin'))
+      if (!admin) admin = rnd(this.props.accounts)
+      this.setState({
+        from: admin ? admin.id : ''
+      })
+    }
+  }
+
   render() {
     const input = field => ({
       value: this.state[field],
@@ -49,7 +59,7 @@ class DeployToken extends Component {
                   </FormGroup>
                 </div>
                 <div style={{ flex: 1, marginRight: 20 }}>
-                  <FormGroup label="Owner">
+                  <FormGroup label="Type">
                     <HTMLSelect
                       {...input('type')}
                       fill={true}

--- a/packages/graphql/src/mutations/token/deployToken.js
+++ b/packages/graphql/src/mutations/token/deployToken.js
@@ -58,8 +58,7 @@ async function deployToken(_, { type, name, decimals, supply, symbol, from }) {
 
       if (type === 'OriginToken') {
         if (typeof window !== 'undefined') {
-          window.localStorage[`${symbol}Contract`] =
-            receipt.contractAddress
+          window.localStorage[`${symbol}Contract`] = receipt.contractAddress
         }
         contracts.ogn = Contract
         contracts.ognExec = Contract

--- a/packages/graphql/src/mutations/token/deployToken.js
+++ b/packages/graphql/src/mutations/token/deployToken.js
@@ -3,29 +3,29 @@ import StandardToken from '@origin/contracts/build/contracts/TestToken'
 import contracts from '../../contracts'
 import txHelper, { checkMetaMask } from '../_txHelper'
 
-async function deployToken(_, args) {
+async function deployToken(_, { type, name, decimals, supply, symbol, from }) {
   const web3 = contracts.web3Exec
-  await checkMetaMask(web3.eth.defaultAccount)
-  const supply = web3.utils.toWei(args.supply, 'ether')
+  await checkMetaMask(from)
+  const supplyWei = web3.utils.toWei(supply, 'ether')
   let tx, Contract
 
-  if (args.type === 'Standard') {
+  if (type === 'Standard') {
     Contract = new web3.eth.Contract(StandardToken.abi)
     tx = Contract.deploy({
       data: StandardToken.bytecode,
-      arguments: [args.name, args.symbol, args.decimals, supply]
+      arguments: [name, symbol, decimals, supplyWei]
     })
   } else {
     Contract = new web3.eth.Contract(OriginToken.abi)
     tx = Contract.deploy({
       data: OriginToken.bytecode,
-      arguments: [supply]
+      arguments: [supplyWei]
     })
   }
 
   return txHelper({
     tx,
-    from: args.from,
+    from: from,
     gas: 4612388,
     mutation: 'deployToken',
     onReceipt: receipt => {
@@ -36,12 +36,12 @@ async function deployToken(_, args) {
         /* Ignore */
       }
       const tokenDef = {
-        type: args.type,
+        type: type,
         id: receipt.contractAddress,
-        name: args.name,
-        symbol: args.symbol,
-        decimals: args.decimals,
-        supply
+        name: name,
+        symbol: symbol,
+        decimals: decimals,
+        supplyWei
       }
       tokens.push(tokenDef)
       if (typeof window !== 'undefined') {
@@ -56,9 +56,9 @@ async function deployToken(_, args) {
       })
       contracts[receipt.contractAddress] = Contract
 
-      if (args.type === 'OriginToken') {
+      if (type === 'OriginToken') {
         if (typeof window !== 'undefined') {
-          window.localStorage[`${args.symbol}Contract`] =
+          window.localStorage[`${symbol}Contract`] =
             receipt.contractAddress
         }
         contracts.ogn = Contract

--- a/packages/graphql/src/utils/proxy.js
+++ b/packages/graphql/src/utils/proxy.js
@@ -1,6 +1,8 @@
 import memorize from './memorize'
 import contracts from '../contracts'
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
 async function isContractRaw(address) {
   const code = await contracts.web3.eth.getCode(address)
   return code && code.length > 2
@@ -82,7 +84,8 @@ async function proxyOwnerRaw(address) {
     const Proxy = contracts.ProxyImp.clone()
     Proxy.options.address = address
     const id = await Proxy.methods.owner().call()
-    return id || null
+    if (!id || id === ZERO_ADDRESS) return null
+    return id
   } catch (e) {
     return null
   }


### PR DESCRIPTION
### Description:

The way account selection is done in the constructor prevents the state from being updated when the prop is updated.  Added handling of this case in a `componentDidUpdate` method.

This also handles some cases(geth?) where a `Proxy.owner()` call may return a zero-address.  This was specifically seen on dev and I imagine other geth JSON-RPC nodes as well.

This also sets `autoWhiltelist` to false because it's only useful in the case of the deployer account actually being the token owner, which I think is rare.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
