### PR TITLE
Full syncmode for test network

### DIFF
--- a/devops/kubernetes/charts/ethereum-network/templates/geth-miner.statefulset.yaml
+++ b/devops/kubernetes/charts/ethereum-network/templates/geth-miner.statefulset.yaml
@@ -32,6 +32,7 @@ spec:
         args:
         - "-c"
         - "geth
+          --syncmode "full"
           --bootnodes=`cat /root/.ethereum/bootnodes`
           --mine
           --miner.threads 2

--- a/devops/kubernetes/charts/ethereum-network/templates/geth-tx.statefulset.yaml
+++ b/devops/kubernetes/charts/ethereum-network/templates/geth-tx.statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         args:
           - "-c"
           - "geth
+            --syncmode "full"
             --ws
             --wsaddr 0.0.0.0
             --wsport 8546


### PR DESCRIPTION
### Description:

Think we're running into pruning issues on the test net.  Probably shouldn't use `fast` syncmode(default) on a network with 2 nodes.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
