### PR TITLE
Fix group type

### DIFF
--- a/infra/bridge/src/controllers/hooks/telegram.js
+++ b/infra/bridge/src/controllers/hooks/telegram.js
@@ -111,7 +111,7 @@ router.post('/', async (req, res) => {
    * Bots can be added to any group by anyone. So check the group id
    * before rewarding the user on production
    */
-  const isGroup = message.chat && message.chat.type === 'group'
+  const isGroup = message.chat && message.chat.type !== 'private'
   const isValidGroup =
     process.env.NODE_ENV !== 'production' ||
     (isGroup &&


### PR DESCRIPTION
Seems like the group type of Korean Telegram group is "supergroup" instead of "group". This makes the events from that group to be dropped