### PR TITLE
Fix active campaign resolver

### DIFF
--- a/infra/growth/src/resources/campaign.js
+++ b/infra/growth/src/resources/campaign.js
@@ -42,7 +42,7 @@ class GrowthCampaign {
     const campaigns = await db.GrowthCampaign.findAll({})
     return campaigns
       .map(campaign => new CampaignRules(campaign, JSON.parse(campaign.rules)))
-      .find(campaign => campaign.status === enums.GrowthCampaignStatuses.Active)
+      .find(campaign => campaign.getStatus() === enums.GrowthCampaignStatuses.Active)
   }
 
   /**

--- a/infra/growth/src/resources/campaign.js
+++ b/infra/growth/src/resources/campaign.js
@@ -39,18 +39,10 @@ class GrowthCampaign {
    * @returns {Promise<CampaignRules>}
    */
   static async getActive() {
-    const campaign = await db.GrowthCampaign.findOne({
-      where: {
-        rewardStatus: enums.GrowthCampaignRewardStatuses.NotReady
-      },
-      order: [['createdAt', 'ASC']]
-    })
-
-    if (!campaign) {
-      return null
-    }
-
-    return new CampaignRules(campaign, JSON.parse(campaign.rules))
+    const campaigns = await db.GrowthCampaign.findAll({})
+    return campaigns
+      .map(campaign => new CampaignRules(campaign, JSON.parse(campaign.rules)))
+      .find(campaign => campaign.status === enums.GrowthCampaignStatuses.Active)
   }
 
   /**

--- a/infra/growth/src/resources/campaign.js
+++ b/infra/growth/src/resources/campaign.js
@@ -39,10 +39,23 @@ class GrowthCampaign {
    * @returns {Promise<CampaignRules>}
    */
   static async getActive() {
-    const campaigns = await db.GrowthCampaign.findAll({})
-    return campaigns
-      .map(campaign => new CampaignRules(campaign, JSON.parse(campaign.rules)))
-      .find(campaign => campaign.getStatus() === enums.GrowthCampaignStatuses.Active)
+    const now = new Date()
+    const campaign = await db.GrowthCampaign.findOne({
+      where: {
+        startDate: {
+          [Sequelize.Op.lte]: now
+        },
+        endDate: {
+          [Sequelize.Op.gt]: now
+        }
+      }
+    })
+
+    if (!campaign) {
+      return null
+    }
+
+    return new CampaignRules(campaign, JSON.parse(campaign.rules))
   }
 
   /**

--- a/infra/growth/src/resources/campaign.js
+++ b/infra/growth/src/resources/campaign.js
@@ -2,7 +2,6 @@ const Sequelize = require('sequelize')
 
 const db = require('../models')
 const { CampaignRules } = require('./rules')
-const enums = require('../enums')
 
 class GrowthCampaign {
   /**


### PR DESCRIPTION
Seems like `rewardStatus` in the GrowthCampaign model is not a reliable way to query or filter the active campaign. So changing that to use `CampaignRules.getStatus()` method
