### PR TITLE
Fix messaging status subscriptions

### DIFF
--- a/dapps/marketplace/src/components/EnableMessagingModal.js
+++ b/dapps/marketplace/src/components/EnableMessagingModal.js
@@ -149,6 +149,7 @@ const EnableMessagingModal = () => {
   const [waitForSignature, setWaitForSign] = useState(false)
 
   const { data, error, networkStatus, refetch } = useQuery(query, {
+    fetchPolicy: 'network-only',
     notifyOnNetworkStatusChange: true
   })
 

--- a/dapps/marketplace/src/hoc/withMessagingStatus.js
+++ b/dapps/marketplace/src/hoc/withMessagingStatus.js
@@ -1,13 +1,22 @@
 import React from 'react'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery, useSubscription } from '@apollo/react-hooks'
 
 import query from 'queries/WalletStatus'
 
 import get from 'lodash/get'
 
+import MessagingStatusChangeSubscription from 'queries/MessagingStatusChangeSubscription'
+
 function withMessagingStatus(WrappedComponent, { excludeData } = {}) {
   const WithMessagingStatus = props => {
-    const { data, loading, error, networkStatus, refetch } = useQuery(query)
+    const { data, loading, error, networkStatus, refetch } = useQuery(query, {
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true
+    })
+
+    useSubscription(MessagingStatusChangeSubscription, {
+      onSubscriptionData: () => refetch()
+    })
 
     if (error) console.error('error executing WalletStatusQuery', error)
 

--- a/packages/messaging-client/src/Messaging.js
+++ b/packages/messaging-client/src/Messaging.js
@@ -119,10 +119,6 @@ class Messaging {
 
   async publishStatus(newStatus) {
     debug('messaging status change', this._keyStatus, 'to', newStatus)
-    if (newStatus === this._keyStatus) {
-      // Nothing to publish
-      return
-    }
 
     // Set state
     this._keyStatus = newStatus


### PR DESCRIPTION
Suppressing the event (when it is already in the same state) caused some unexpected behaviour on mobile randomly.

https://github.com/OriginProtocol/origin/compare/shahthepro/messaging-sub-fix?expand=1#diff-64fc362de5e424bf915ace27f6898007L122-L125

Also, `withMessagingStatus` HOC was not subscribed to MessagingStatusChange.