### PR TITLE
Store twitter and telegram profile in identity

### DIFF
--- a/infra/discovery/src/listener/handler_proxy.js
+++ b/infra/discovery/src/listener/handler_proxy.js
@@ -7,8 +7,8 @@ const logger = require('./logger')
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
 
 class ProxyEventHandler {
-  constructor(config) {
-    this.config = config
+  constructor(context) {
+    this.config = context.config
   }
 
   /**

--- a/infra/discovery/src/listener/listener.js
+++ b/infra/discovery/src/listener/listener.js
@@ -119,12 +119,15 @@ async function main() {
   )
 
   // List of contracts the listener watches events from.
+  // Note: The identity and listing handlers have a dependency on the data extracted
+  // by the proxy handler. Therefore it is important to process the proxy contract
+  // events first.
   const contracts = {}
-  if (config.identity) {
-    contracts['IdentityEvents'] = contractsContext.identityEvents
-  }
   if (config.proxy) {
     contracts['ProxyFactory'] = contractsContext.ProxyFactory
+  }
+  if (config.identity) {
+    contracts['IdentityEvents'] = contractsContext.identityEvents
   }
   if (config.marketplace) {
     // Listen to all versions of marketplace
@@ -156,6 +159,7 @@ async function main() {
       return context.web3.eth.getBlockNumber()
     })
 
+    // Note: Object.keys() returns keys in the same order they were inserted.
     for (const contractKey of Object.keys(contracts)) {
       let processedToBlock = await getLastBlock(
         context.config,

--- a/infra/discovery/test/listener-handler.test.js
+++ b/infra/discovery/test/listener-handler.test.js
@@ -344,10 +344,7 @@ describe('Listener Handlers', () => {
   })
 
   it(`Proxy`, async () => {
-    const handler = new ProxyEventHandler(
-      this.config,
-      this.context.graphqlClient
-    )
+    const handler = new ProxyEventHandler({ config: this.config })
 
     const proxyAddress = '0xAB123'
     const ownerAddress = '0xCD456'

--- a/infra/identity/src/utils.js
+++ b/infra/identity/src/utils.js
@@ -281,13 +281,10 @@ function validateIdentityIpfsData(ipfsData) {
  */
 async function saveIdentity(owner, ipfsHash, ipfsData, attestationMetadata) {
   // Create an object representing the updated identity.
-  // Notes:
-  //  - By convention, the identity is stored under the owner's address in the DB.
-  //  - We omit a few fields coming from the attestation metadata such as
-  //    twitterProfile and telegramProfilesince. Those are large JSON objects
-  //    that would clutter the identity and they can be retrieved if needed
-  //    from the attestation table.
-  const blacklistedFields = ['twitterProfile', 'telegramProfile']
+  // Note: by convention, the identity is stored under the owner's address in the DB.
+  // TODO(franck): consider backlisting twitterProfile and telegramProfile to
+  //               reduce the amount of data stored in the data column.
+  const blacklistedFields = []
   const identity = {
     ethAddress: owner.toLowerCase(),
     firstName: get(ipfsData, 'profile.firstName'),


### PR DESCRIPTION
### Description:

This PR fixes a couple of issues caused by PR #3773:
 1. I disabled storing the full twitter and telegram profile in the identity data column.
This caused the twitter share reward calculation to break and always return zero (see [this code](https://github.com/OriginProtocol/origin/blob/master/infra/growth/src/resources/rules/socialShareRule.js#L174)). In the future I may change this code to lookup that data from the attestation table, but for the short-term this PR restores storing that data in the identity table. Once deployed, I'll run a backfill in prod.
2. There was a change in the argument to the proxy_handler (passing a context rather than a config object). This caused the proxy handler to get disabled.


### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
