### PR TITLE
[Listener] Fix race condition in identity

### DIFF
--- a/infra/identity/src/utils.js
+++ b/infra/identity/src/utils.js
@@ -374,12 +374,12 @@ async function recordGrowthAttestationEvents(
   date,
   growthEvent
 ) {
-  // Note: this could be optimized by inserting events in parallel rather than serially.
-  // Though one caveat is that the identity data structure may contain more
-  // than one attestation of the same type. For example if a user verifies
-  // their email more than once at different point in time. This could then
-  // cause a race condition within the growthEvent.insert() method and more than one
-  // row for a given attestation type could get inserted in the growth_event table.
+  // Note: this could be optimized by inserting events in parallel rather
+  // than serially. A caveat is that the identity data structure may contain
+  // multiple attestations of the same type. For example if a user verifies
+  // their email more than once. This could then cause a race condition within
+  // the growthEvent.insert() method where the checks for ensuring there is
+  // one growth-event row per attestation type can fail.
   for (const attestation of attestations) {
     const attestationService = _getAttestationService(attestation)
     const eventType =

--- a/infra/identity/src/utils.js
+++ b/infra/identity/src/utils.js
@@ -389,15 +389,7 @@ async function recordGrowthAttestationEvents(
       continue
     }
 
-    await growthEvent.insert(
-      logger,
-      1,
-      ethAddress,
-      eventType,
-      null,
-      null,
-      date
-    )
+    await growthEvent.insert(logger, 1, ethAddress, eventType, null, null, date)
   }
 }
 


### PR DESCRIPTION
### Description:

Fixing a race condition in the identity code that was causing more than a single row per attestation type to get inserted in the growth_event table.

This is less performant but not worth optimizing prematurely.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
