### PR TITLE
[Identity] Fix bug where identity table was not populated correctly

### DIFF
--- a/infra/identity/src/utils.js
+++ b/infra/identity/src/utils.js
@@ -140,16 +140,15 @@ async function _countryLookup(addresses) {
 }
 
 /**
- * Loads proxy address associated with an owner address.
- * Returns addresses (or only the owner if not proxy found) in a list.
+ * Loads proxy address(es) (if any) associated with an owner address.
  *
  * @param ownerAddress
- * @returns {Promise<Array<string>>}
+ * @returns {Promise<Array<string>>} Lower cased addresses, incuding owner and proxy(ies).
  */
 async function loadIdentityAddresses(ownerAddress) {
   // Attestation rows in the DB may have been written under the
   // proxy eth address. Load proxy addresses.
-  const addresses = [ownerAddress]
+  const addresses = [ownerAddress.toLowerCase()]
   const proxies = await db.Proxy.findAll({ where: { ownerAddress } })
   for (const proxy of proxies) {
     addresses.push(proxy.address)

--- a/infra/identity/src/utils.js
+++ b/infra/identity/src/utils.js
@@ -148,7 +148,8 @@ async function _countryLookup(addresses) {
 async function loadIdentityAddresses(ownerAddress) {
   // Attestation rows in the DB may have been written under the
   // proxy eth address. Load proxy addresses.
-  const addresses = [ownerAddress.toLowerCase()]
+  ownerAddress = ownerAddress.toLowerCase()
+  const addresses = [ownerAddress]
   const proxies = await db.Proxy.findAll({ where: { ownerAddress } })
   for (const proxy of proxies) {
     addresses.push(proxy.address)


### PR DESCRIPTION
### Description:

Case mismatch on the address was causing the logic to fail loading attestation data.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
