### PR TITLE
[Identity back-end] Fix attestation metadata loading

### DIFF
--- a/infra/bridge/src/controllers/identity.js
+++ b/infra/bridge/src/controllers/identity.js
@@ -107,15 +107,15 @@ router.post('/', identityWriteVerify, async (req, res) => {
       .send({ errors: [`Failed parsing identity data: ${err}`] })
   }
 
+  // In case the input address was a proxy, load the owner address.
+  const owner = await getOwnerAddress(ethAddress)
+
   // Load attestation data from the DB.
-  const addresses = await loadIdentityAddresses(ethAddress)
+  const addresses = await loadIdentityAddresses(owner)
   const metadata = await loadAttestationMetadata(
     addresses,
     ipfsData.attestations
   )
-
-  // In case the input address was a proxy, load the owner address.
-  const owner = await getOwnerAddress(ethAddress)
 
   // Save the identity in the DB.
   const identity = await saveIdentity(owner, ipfsHash, ipfsData, metadata)


### PR DESCRIPTION
### Description:

Fix bug where owner's address should be used to load proxy address(es).
No impact on user but that bug was causing some column to not get populated in the identity table.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
