### PR TITLE
Fix name of origin-auth in docker test builds

### DIFF
--- a/.circleci/docker_test_builds.sh
+++ b/.circleci/docker_test_builds.sh
@@ -76,7 +76,7 @@ do_build origin-relayer infra/relayer/package.json
 results="$results
 $retval"
 
-do_build origin-auth-server infra/auth-server/package.json
+do_build origin-auth infra/auth-server/package.json
 results="$results
 $retval"
 


### PR DESCRIPTION
This got renamed by @shahthepro.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
