### PR TITLE
Add authorization header to bridge identity write requests

### DIFF
--- a/packages/graphql/src/mutations/identity/deployIdentity.js
+++ b/packages/graphql/src/mutations/identity/deployIdentity.js
@@ -157,9 +157,13 @@ async function deployIdentity(
     }
     const url = `${identityServer}/api/identity?ethAddress=${from}`
 
+    const authToken = contracts.authClient.getAccessToken(owner)
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        authorization: 'Bearer ' + authToken,
+        'content-type': 'application/json'
+      },
       credentials: 'include',
       body: JSON.stringify({ ipfsData, ipfsHash })
     })

--- a/packages/graphql/src/mutations/identity/deployIdentity.js
+++ b/packages/graphql/src/mutations/identity/deployIdentity.js
@@ -158,6 +158,10 @@ async function deployIdentity(
     const url = `${identityServer}/api/identity?ethAddress=${from}`
 
     const authToken = contracts.authClient.getAccessToken(owner)
+    if (!authToken) {
+      throw new Error('Identity write failure. Auth token missing.')
+    }
+
     const response = await fetch(url, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
### Description:

Now that the bridge identity write endpoint is enforcing auth, the request needs to include an authorization token.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
