### PR TITLE
imToken websocket kludge

### DIFF
--- a/packages/graphql/src/contracts.js
+++ b/packages/graphql/src/contracts.js
@@ -740,6 +740,16 @@ export function shutdown() {
 
 if (isBrowser) {
   if (window.ethereum) {
+    /**
+     * imToken kludge to deal with a misbehaving provider wanting eth_subscribe
+     * but imToken doesn't actually support is.  web3.js detect websocket
+     * support by checking for provider.on.   This could change after
+     * web3.beta.34
+     */
+    if (window.ethereum.isImToken) {
+      window.ethereum.on = undefined
+    }
+
     metaMask = applyWeb3Hack(new Web3(window.ethereum))
     metaMaskEnabled = window.localStorage.metaMaskEnabled ? true : false
   } else if (window.web3) {


### PR DESCRIPTION
### Description:

imToken will throw an error trying to use `eth_subscribe` because of how web3.js detects websocket support.  This undefines `provider.on` to try and get around that detection.

There's a chance of unexpected behavior after this so we should keep an eye out.

Would like @micahalcorn to test out the test URL first: https://shoporigin.com/index.test.html

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
