### PR TITLE
Use node-fetch rather than fetch in graphql identity code

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -57,6 +57,7 @@
     "json-stable-stringify": "^1.0.1",
     "lodash-es": "^4.17.11",
     "mocha": "^6.1.4",
+    "node-fetch": "^2.6.0",
     "prettier": "^1.18.2",
     "rlp": "^2.2.3",
     "subscriptions-transport-ws": "^0.9.16",

--- a/packages/graphql/src/resolvers/IdentityEvents.js
+++ b/packages/graphql/src/resolvers/IdentityEvents.js
@@ -4,6 +4,7 @@ import IpfsHash from 'ipfs-only-hash'
 import createDebug from 'debug'
 import get from 'lodash/get'
 import pick from 'lodash/pick'
+import fetch from 'node-fetch'
 
 import contracts from '../contracts'
 import {


### PR DESCRIPTION
### Description:

Fix for #3940 

The listener process imports and runs the graphql package.
Some of the queries issues by the listener to get the details about an offer involve getting data about a the buyer and seller. This was triggering the execution of the graphql identity resolver which makes a call to fetch() for getting the identity from the bridge server.
fetch() is not a supported call in Node.js which was causing an error.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
