### PR TITLE
Change back arrow colour

### DIFF
--- a/mobile/src/components/back-arrow.js
+++ b/mobile/src/components/back-arrow.js
@@ -6,7 +6,7 @@ import { Text, TouchableOpacity } from 'react-native'
 const BackArrow = ({ onClick, style }) => {
   return (
     <TouchableOpacity onPress={() => onClick()} style={style}>
-      <Text style={{ fontSize: 40, color: '#e7e6f1' }}>&lsaquo;</Text>
+      <Text style={{ fontSize: 40, color: '#94a7b5' }}>&lsaquo;</Text>
     </TouchableOpacity>
   )
 }


### PR DESCRIPTION
Make the back arrow in mobile onboarding match Zeplin colour. Closes #3938.