### PR TITLE
T3 minimum lockup size

### DIFF
--- a/infra/token-transfer-client/src/components/BonusModal.js
+++ b/infra/token-transfer-client/src/components/BonusModal.js
@@ -142,7 +142,7 @@ class BonusModal extends Component {
             </div>
           </div>
 
-          {this.state.amount ? (
+          {this.state.amount && this.state.amount >= 10 ? (
             <div className="text-left">
               <div className="row">
                 <div className="col">
@@ -173,8 +173,8 @@ class BonusModal extends Component {
           ) : (
             <>
               <div className="p-5 mx-4 text-muted text-center">
-                Please enter a number of tokens to lock up for one year. Bonus
-                tokens will be calculated based on that amount.
+                Please enter a number of tokens to lock up for one year (minimum
+                10 OGN). Bonus tokens will be calculated based on that amount.
               </div>
               <hr />
             </>
@@ -183,7 +183,11 @@ class BonusModal extends Component {
           <button
             type="submit"
             className="btn btn-primary btn-lg mt-5"
-            disabled={!this.state.amount || this.props.lockupIsAdding}
+            disabled={
+              !this.state.amount ||
+              this.state.amount <= 10 ||
+              this.props.lockupIsAdding
+            }
           >
             {this.props.lockupIsAdding ? (
               <>

--- a/infra/token-transfer-server/src/controllers/lockup.js
+++ b/infra/token-transfer-server/src/controllers/lockup.js
@@ -45,7 +45,7 @@ router.post(
     check('amount')
       .isNumeric()
       .toInt()
-      .isInt({ min: 0 })
+      .isInt({ min: 10 })
       .withMessage('Amount must be greater than 0'),
     check('code').custom(isValidTotp),
     ensureLoggedIn

--- a/infra/token-transfer-server/test/api/lockup.test.js
+++ b/infra/token-transfer-server/test/api/lockup.test.js
@@ -166,7 +166,7 @@ describe('Lockup HTTP API', () => {
     await request(this.mockApp)
       .post('/api/lockups')
       .send({
-        amount: 1,
+        amount: 10,
         code: totp.gen(this.otpKey)
       })
       .expect(404)
@@ -181,7 +181,7 @@ describe('Lockup HTTP API', () => {
     const response = await request(this.mockApp)
       .post('/api/lockups')
       .send({
-        amount: 1,
+        amount: 10,
         code: totp.gen(this.otpKey)
       })
       .expect(422)
@@ -207,7 +207,7 @@ describe('Lockup HTTP API', () => {
     const response = await request(this.mockApp)
       .post('/api/lockups')
       .send({
-        amount: 1,
+        amount: 10,
         code: totp.gen(this.otpKey)
       })
       .expect(422)
@@ -355,7 +355,7 @@ describe('Lockup HTTP API', () => {
       request(this.mockApp)
         .post('/api/lockups')
         .send({
-          amount: 1,
+          amount: 10,
           code: totp.gen(this.otpKey)
         })
     ])
@@ -390,7 +390,7 @@ describe('Lockup HTTP API', () => {
       request(this.mockApp)
         .post('/api/lockups')
         .send({
-          amount: 1,
+          amount: 10,
           code: totp.gen(this.otpKey)
         })
     ])
@@ -402,7 +402,7 @@ describe('Lockup HTTP API', () => {
     sendStub.restore()
   })
 
-  it('should not add lockups with below 0 amount', async () => {
+  it('should not add lockups with below 10 amount', async () => {
     const response = await request(this.mockApp)
       .post('/api/lockups')
       .send({


### PR DESCRIPTION
Implements minimum lockup of 10 to prevent 0 sized lockups and also users taking advantage of lockup rewards being rounded up, e.g. lockup 1 OGN for 1 OGN.