### PR TITLE
Use enums for T3 revised schedule states

### DIFF
--- a/infra/token-transfer-client/src/utils/index.js
+++ b/infra/token-transfer-client/src/utils/index.js
@@ -7,14 +7,8 @@ export const getNextOnboardingPage = user => {
     return null
   } else if (!user.termsAgreedAt) {
     return '/terms'
-  } else if (
-    // Already agreed, don't display revised schedule
-    !user.revisedScheduleAgreedAt &&
-    // If rejected, don't display revised schedule
-    !user.revisedScheduleRejected &&
-    // If abstained, don't display revised schedule
-    !user.revisedScheduleAbstained
-  ) {
+  } else if (user.revisedScheduleStatus === null) {
+    // Revised schedule status unknown, display revised schedule terms
     return '/revised_schedule'
   } else if (!user.phone) {
     return '/phone'

--- a/infra/token-transfer-server/migrations/20191114224700-revised-schedule-column-update.js
+++ b/infra/token-transfer-server/migrations/20191114224700-revised-schedule-column-update.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { RevisedScheduleStatus } = require('../src/enums')
+
+const tableName = 't3_user'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.removeColumn(tableName, 'revised_schedule_abstained'),
+      queryInterface.removeColumn(tableName, 'revised_schedule_rejected'),
+      queryInterface.addColumn(
+        tableName,
+        'revised_schedule_status',
+        Sequelize.ENUM(RevisedScheduleStatus)
+      )
+    ])
+  },
+  down: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn(
+        tableName,
+        'revised_schedule_abstained',
+        Sequelize.BOOLEAN
+      ),
+      queryInterface.removeColumn(tableName, 'revised_schedule_status'),
+      queryInterface.addColumn(
+        tableName,
+        'revised_schedule_rejected',
+        Sequelize.BOOLEAN
+      )
+    ])
+  }
+}

--- a/infra/token-transfer-server/src/controllers/user.js
+++ b/infra/token-transfer-server/src/controllers/user.js
@@ -59,6 +59,8 @@ router.post(
     // Terms agreement fields are immutable once set
     if (req.body.revisedScheduleAgreedAt && !req.user.revisedScheduleAgreedAt) {
       toUpdate.revisedScheduleAgreedAt = req.body.revisedScheduleAgreedAt
+      // Mark the status as accepted
+      toUpdate.revisedScheduleStatus = 'Accepted'
     }
     if (req.body.termsAgreedAt && !req.user.termsAgreedAt) {
       toUpdate.termsAgreedAt = req.body.termsAgreedAt

--- a/infra/token-transfer-server/src/enums.js
+++ b/infra/token-transfer-server/src/enums.js
@@ -34,7 +34,10 @@ const TransferStatuses = new Enum(
 
 const InvestorTypes = new Enum('Advisor', 'Strategic', 'CoinList')
 
+const RevisedScheduleStatus = new Enum('Accepted', 'Rejected', 'Abstained')
+
 module.exports = {
   InvestorTypes,
+  RevisedScheduleStatus,
   TransferStatuses
 }

--- a/infra/token-transfer-server/src/models/user.js
+++ b/infra/token-transfer-server/src/models/user.js
@@ -16,8 +16,7 @@ module.exports = (sequelize, DataTypes) => {
       otpVerified: DataTypes.BOOLEAN,
       employee: DataTypes.BOOLEAN,
       revisedScheduleAgreedAt: DataTypes.DATE,
-      revisedScheduleRejected: DataTypes.BOOLEAN,
-      revisedScheduleAbstained: DataTypes.BOOLEAN,
+      revisedScheduleStatus: DataTypes.ENUM(enums.RevisedScheduleStatus),
       termsAgreedAt: DataTypes.DATE,
       investorType: DataTypes.ENUM(enums.InvestorTypes)
     },


### PR DESCRIPTION
Should have not done it the lazy way @franckc sorry! When I get the data to be imported here I realised we don't have the dates some of the amendments were signed so I needed a different way to represent accepted without a date. I could have just set it to some random date but that seemed ugly. It's good to have a record of who accepted via the onboarding flow and who didn't.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~~[ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~~
- ~~[ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~~
- ~~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~~
