### PR TITLE
Remove T3 tokens from welcome emails

### DIFF
--- a/infra/token-transfer-server/src/templates/welcome.mjml
+++ b/infra/token-transfer-server/src/templates/welcome.mjml
@@ -22,7 +22,7 @@
             <mj-section background-color="white">
                 <mj-column>
                     <mj-text font-size="18px" line-height="1.67">
-                        The following link will provide you access to the Origin Investor Portal. It will expire in 24 hours. You can reply directly to this email with any questions.
+                        Please open the link below to get started with the Origin Investor Portal. You can reply directly to this email with any questions.
                     </mj-text>
                 </mj-column>
             </mj-section>

--- a/infra/token-transfer-server/src/templates/welcome.txt
+++ b/infra/token-transfer-server/src/templates/welcome.txt
@@ -1,5 +1,3 @@
 The following link will provide you access to the Origin Investor Portal.
 
 <%= url %>
-
-It will expire in 24 hours. You can reply directly to this email with any questions.


### PR DESCRIPTION
Remove pregenerated login tokens from welcome emails. Users can just jump to the T3 page and enter their email and get their own token. Avoids peoples initial tokens expiring and then them having to ask us.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- ~~[ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~~
- ~~[ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~~
- ~~[ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)~~
