### PR TITLE
T3 separate employee API URL

### DIFF
--- a/devops/dockerfiles/origin-token-transfer-client
+++ b/devops/dockerfiles/origin-token-transfer-client
@@ -23,7 +23,6 @@ COPY ./packages/contracts ./packages/contracts
 COPY ./packages/ip2geo ./packages/ip2geo
 COPY ./packages/token ./packages/token
 
-
 RUN yarn install
 
 ENV NODE_ENV=production

--- a/devops/kubernetes/charts/origin/templates/_helpers.tpl
+++ b/devops/kubernetes/charts/origin/templates/_helpers.tpl
@@ -216,11 +216,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{- printf "%s-%s" .Release.Name "t3" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "t3.host" -}}
+{{- define "t3-investor.host" -}}
 {{- if eq .Release.Namespace "prod" -}}
 {{- printf "investor.originprotocol.com" }}
 {{- else -}}
 {{- printf "investor.%s.originprotocol.com" .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "t3-employee.host" -}}
+{{- if eq .Release.Namespace "prod" -}}
+{{- printf "employee.originprotocol.com" }}
+{{- else -}}
+{{- printf "employee.%s.originprotocol.com" .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
 

--- a/devops/kubernetes/charts/origin/templates/t3.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/t3.ingress.yaml
@@ -19,11 +19,11 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: "50"
 spec:
   tls:
-    - secretName: {{ template "t3.host" . }}
+    - secretName: {{ template "t3-investor.host" . }}
       hosts:
-        - {{ template "t3.host" . }}
+        - {{ template "t3-investor.host" . }}
   rules:
-  - host: {{ template "t3.host" . }}
+  - host: {{ template "t3-investor.host" . }}
     http:
       paths:
         - path: /
@@ -34,3 +34,10 @@ spec:
           backend:
             serviceName: {{ template "t3.fullname" . }}
             servicePort: 5000
+  - host: {{ template "t3-employee.host" . }}
+    http:
+      paths:
+        - path: /
+          backend:
+            serviceName: {{ template "t3.fullname" . }}
+            servicePort: 80

--- a/devops/kubernetes/charts/origin/templates/t3.service.yaml
+++ b/devops/kubernetes/charts/origin/templates/t3.service.yaml
@@ -20,4 +20,3 @@ spec:
     port: 80
   - name: express
     port: 5000
-

--- a/infra/token-transfer-client/src/components/pages/Dashboard.js
+++ b/infra/token-transfer-client/src/components/pages/Dashboard.js
@@ -26,7 +26,7 @@ import {
   getIsLoading as getTransferIsLoading,
   getWithdrawnAmount
 } from '@/reducers/transfer'
-import { getUnlockDate } from '@/utils'
+import { unlockDate } from '@/constants'
 import BalanceCard from '@/components/BalanceCard'
 import NewsHeadlinesCard from '@/components/NewsHeadlinesCard'
 import VestingCard from '@/components/VestingCard'
@@ -60,7 +60,6 @@ const Dashboard = props => {
   const balanceAvailable = vestedTotal
     .minus(props.withdrawnAmount)
     .minus(props.lockupTotals.locked)
-  const unlockDate = getUnlockDate(props.user)
   const isLocked = !unlockDate || moment.utc() < unlockDate
 
   return (

--- a/infra/token-transfer-client/src/components/pages/Lockup.js
+++ b/infra/token-transfer-client/src/components/pages/Lockup.js
@@ -21,7 +21,7 @@ import {
   getIsLoading as getTransferIsLoading,
   getWithdrawnAmount
 } from '@/reducers/transfer'
-import { getUnlockDate } from '@/utils'
+import { unlockDate } from '@/constants'
 import LockupCard from '@/components/LockupCard'
 import BonusModal from '@/components/BonusModal'
 
@@ -44,7 +44,6 @@ const Lockup = props => {
     )
   }
 
-  const unlockDate = getUnlockDate(props.user)
   const isLocked = !unlockDate || moment.utc() < unlockDate
   const { vestedTotal } = props.grantTotals
   const balanceAvailable = vestedTotal

--- a/infra/token-transfer-client/src/components/pages/WithdrawalHistory.js
+++ b/infra/token-transfer-client/src/components/pages/WithdrawalHistory.js
@@ -23,7 +23,7 @@ import {
   getIsLoading as getTransferIsLoading,
   getWithdrawnAmount
 } from '@/reducers/transfer'
-import { getUnlockDate } from '@/utils'
+import { unlockDate } from '@/constants'
 import WithdrawalHistoryCard from '@/components/WithdrawalHistoryCard'
 import EthAddress from '@/components/EthAddress'
 
@@ -44,7 +44,6 @@ const WithdrawalHistory = props => {
     )
   }
 
-  const unlockDate = getUnlockDate(props.user)
   const isLocked = !unlockDate || moment.utc() < unlockDate
 
   const accountNicknameMap = {}

--- a/infra/token-transfer-client/src/constants/index.js
+++ b/infra/token-transfer-client/src/constants/index.js
@@ -1,16 +1,18 @@
 import {
   earnOgnEnabled,
-  employeeUnlockDate,
-  investorUnlockDate,
-  lockupBonusRate
+  lockupBonusRate,
+  unlockDate
 } from '@origin/token-transfer-server/src/shared'
 
-const apiUrl = process.env.API_URL || 'http://localhost:5000'
-
-export {
-  apiUrl,
-  earnOgnEnabled,
-  employeeUnlockDate,
-  investorUnlockDate,
-  lockupBonusRate
+let apiUrl
+if (process.env.NODE_ENV === 'production') {
+  if (window.location.hostname.includes('employee')) {
+    apiUrl = process.env.EMPLOYEE_API_URL
+  } else {
+    apiUrl = window.location.origin
+  }
+} else {
+  apiUrl = 'http://localhost:5000'
 }
+
+export { apiUrl, earnOgnEnabled, unlockDate, lockupBonusRate }

--- a/infra/token-transfer-client/src/utils/index.js
+++ b/infra/token-transfer-client/src/utils/index.js
@@ -1,5 +1,3 @@
-import { employeeUnlockDate, investorUnlockDate } from '@/constants'
-
 export const getNextOnboardingPage = user => {
   if (user.otpVerified) {
     // Verified OTP can no longer perform any onboarding as OTP would be required
@@ -16,9 +14,4 @@ export const getNextOnboardingPage = user => {
     // Only remaining step is OTP setup
     return '/otp/explain'
   }
-}
-
-export const getUnlockDate = user => {
-  if (!user) return
-  return user.employee ? employeeUnlockDate : investorUnlockDate
 }

--- a/infra/token-transfer-server/src/shared.js
+++ b/infra/token-transfer-server/src/shared.js
@@ -134,20 +134,10 @@ function lockupHasExpired(lockup) {
   )
 }
 
-// Unlock dates, if undefined assume tokens are locked with an unknown unlock
+// Unlock date, if undefined assume tokens are locked with an unknown unlock
 // date
-const employeeUnlockDate = moment(
-  process.env.EMPLOYEE_UNLOCK_DATE,
-  'YYYY-MM-DD'
-).isValid()
-  ? moment.utc(process.env.EMPLOYEE_UNLOCK_DATE)
-  : undefined
-
-const investorUnlockDate = moment(
-  process.env.INVESTOR_UNLOCK_DATE,
-  'YYYY-MM-DD'
-).isValid()
-  ? moment.utc(process.env.INVESTOR_UNLOCK_DATE)
+const unlockDate = moment(process.env.UNLOCK_DATE, 'YYYY-MM-DD').isValid()
+  ? moment.utc(process.env.UNLOCK_DATE)
   : undefined
 
 // Lockup bonus rate as a percentage
@@ -174,8 +164,7 @@ module.exports = {
   toMoment,
   momentizeLockup,
   momentizeGrant,
-  employeeUnlockDate,
-  investorUnlockDate,
+  unlockDate,
   lockupHasExpired,
   lockupBonusRate,
   lockupDuration,


### PR DESCRIPTION
- Kubernetes configuration for a separate client with an employee hostname.
- Use only one unlock date env var, no need for two because employees and investors run on a separate server.
- Allow setting an employee specific API URL via an env var that is used when the employee hostname is in use.