### PR TITLE
BottomScrollListener component update

### DIFF
--- a/dapps/marketplace/src/components/BottomScrollListener.js
+++ b/dapps/marketplace/src/components/BottomScrollListener.js
@@ -76,9 +76,7 @@ const BottomScrollListener = ({
       canFetchMore = true
     }
 
-    const hasMoreSpace =
-      elementRef.current.clientHeight <=
-      elementRef.current.parentElement.clientHeight
+    const hasMoreSpace = elementRef.current.clientHeight < window.innerHeight
 
     if (bindOnContainer && hasMoreSpace) {
       canFetchMore = true


### PR DESCRIPTION
elementRef is document, and document.parentElement.clientHeight is giving null error.
Changed to window.innerHeight

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
