### PR TITLE
@origin/bridge did not return xrate for USDT

### DIFF
--- a/infra/bridge/src/utils/exchange-rate.js
+++ b/infra/bridge/src/utils/exchange-rate.js
@@ -21,7 +21,8 @@ const currencies = [
   'CNY',
   'USDC',
   'GUSD',
-  'OKB'
+  'OKB',
+  'USDT'
 ]
 
 let pollInterval


### PR DESCRIPTION
Fix for #4061 
Added missing `USDT` to currencies array. 
Because https://github.com/OriginProtocol/origin/blob/master/packages/graphql/src/utils/currencies.js#L147 was referencing this code https://github.com/OriginProtocol/origin/blob/master/infra/bridge/src/utils/exchange-rate.js#L24, where USDT is missing, and below in FALLBACK_EXCHANGE_RATES , it is present. 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
