### PR TITLE
Add additional header to T3 server for originating IP address for Heroku

### DIFF
--- a/infra/token-transfer-server/src/utils.js
+++ b/infra/token-transfer-server/src/utils.js
@@ -35,7 +35,9 @@ const getFingerprintData = async req => {
       version: device.version,
       os: device.os
     },
-    location: await ip2geo(req.headers['x-real-ip'])
+    location: await ip2geo(
+      req.headers['x-real-ip'] || req.headers['x-forwarded-for']
+    )
   }
 }
 


### PR DESCRIPTION
Per title. Required for ip2geo to function.