### PR TITLE
Partner referral fixes

### DIFF
--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -77,6 +77,12 @@ class MarketplaceScreen extends PureComponent {
       // Language has changed
       this.injectLanguage()
     }
+    // Send the user to the campaign page if given a referral code
+    if (
+      prevProps.props.settings.referralCode !== this.props.settings.referralCode
+    ) {
+      this.injectGetStartedRedirect('/campaigns')
+    }
     if (prevProps.settings.currency !== this.props.settings.currency) {
       // Currency has changed
       this.injectCurrency()
@@ -160,6 +166,21 @@ class MarketplaceScreen extends PureComponent {
       // Clear clipboard
       Clipboard.setString('')
     }
+  }
+
+  injectGetStartedRedirect = path => {
+    console.log(`injectGetStartedRedirect(${path})`)
+    return this.injectJavaScript(
+      `
+      let uiState = typeof window.sessionStorage.uiState === 'undefined'
+        ? {}
+          : JSON.parse(window.sessionStorage.uiState)
+      console.log('setting getStartedRedirect to ${path}')
+      uiState.getStartedRedirect = { pathname: '${path}', search: '' }
+      window.sessionStorage.uiState = JSON.stringify(uiState)
+    `,
+      'getStartedRedirect'
+    )
   }
 
   /**

--- a/mobile/src/screens/partnerWelcome.js
+++ b/mobile/src/screens/partnerWelcome.js
@@ -21,7 +21,10 @@ class PartnerWelcomeScreen extends Component {
       config: null
     }
 
-    if (!this.props.settings.referralCode) this.next()
+    if (!this.props.settings.referralCode) {
+      console.log('skipping partner welcome...')
+      this.next()
+    }
     this.getConfig()
   }
 
@@ -42,29 +45,37 @@ class PartnerWelcomeScreen extends Component {
     const {
       settings: { referralCode }
     } = this.props
-    const url = `${COFNIG_BASE_URL}/campaigns.json`
 
-    const resp = await fetch(url)
+    if (referralCode && referralCode.startsWith('op:')) {
+      const partnerCode = referralCode.split(':')[1]
+      const url = `${COFNIG_BASE_URL}/campaigns.json`
 
-    if (resp.status !== 200) {
-      return this.next()
+      console.log(`fetching config from ${url}`)
+      const resp = await fetch(url)
+
+      if (resp.status !== 200) {
+        console.warn('originprotocol.com did not return 200')
+        return this.next()
+      }
+
+      const jason = await resp.json()
+
+      if (!Object.prototype.hasOwnProperty.call(jason, partnerCode)) {
+        console.log('Did not find referral code in config')
+        return this.next()
+      }
+
+      this.setState({
+        config: jason[partnerCode]
+      })
     }
-
-    const jason = await resp.json()
-
-    if (!Object.prototype.hasOwnProperty.call(jason, referralCode)) {
-      return this.next()
-    }
-
-    this.setState({
-      config: jason[referralCode]
-    })
   }
 
   render() {
     const { config } = this.state
 
     if (!config) {
+      console.debug('no config, not rendering')
       return null
     }
 


### PR DESCRIPTION
### Description:

Couple of referral fixes to mobile:

- Fixes the display of the partner splash and forced onboarding (addition of multiple prefixes conflicted)
- Sets the final onboarding redirect to `/campaigns` if the mobile app sees a referral code

Ref: #3948 
CC: @micahalcorn 

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
