### PR TITLE
Fixes bad props reference in mobile app

### DIFF
--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -78,9 +78,7 @@ class MarketplaceScreen extends PureComponent {
       this.injectLanguage()
     }
     // Send the user to the campaign page if given a referral code
-    if (
-      prevProps.settings.referralCode !== this.props.settings.referralCode
-    ) {
+    if (prevProps.settings.referralCode !== this.props.settings.referralCode) {
       this.injectGetStartedRedirect('/campaigns')
     }
     if (prevProps.settings.currency !== this.props.settings.currency) {

--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -79,7 +79,7 @@ class MarketplaceScreen extends PureComponent {
     }
     // Send the user to the campaign page if given a referral code
     if (
-      prevProps.props.settings.referralCode !== this.props.settings.referralCode
+      prevProps.settings.referralCode !== this.props.settings.referralCode
     ) {
       this.injectGetStartedRedirect('/campaigns')
     }


### PR DESCRIPTION
### Description:

`prevProps.props` is not a thing.

Ref: #4101

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
