### PR TITLE
make sure campaigns redirect is injected if referralCode injected at all

### DIFF
--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -54,7 +54,8 @@ class MarketplaceScreen extends PureComponent {
     this.state = {
       enablePullToRefresh: true,
       panResponder: this.getSwipeHandler(),
-      webViewRef: React.createRef()
+      webViewRef: React.createRef(),
+      injectedGetStartedRedirect: false
     }
 
     this.subscriptions = [
@@ -78,8 +79,12 @@ class MarketplaceScreen extends PureComponent {
       this.injectLanguage()
     }
     // Send the user to the campaign page if given a referral code
-    if (prevProps.settings.referralCode !== this.props.settings.referralCode) {
+    if (
+      this.props.settings.referralCode &&
+      !this.state.injectedGetStartedRedirect
+    ) {
       this.injectGetStartedRedirect('/campaigns')
+      this.setState({ injectedGetStartedRedirect: true })
     }
     if (prevProps.settings.currency !== this.props.settings.currency) {
       // Currency has changed


### PR DESCRIPTION
### Description:

The redirect to `/campaigns` wasn't being injected because the conditional check would always eval false.  This fixes it to make sure it injects at least once if there's a referral code.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
