### PR TITLE
Reward should come from campaigns.json

### DIFF
--- a/dapps/marketplace/src/constants/config.js
+++ b/dapps/marketplace/src/constants/config.js
@@ -1,1 +1,2 @@
 export const DEFAULT_GOOGLE_MAPS_API_KEY = ``
+export const PARNTER_REFERRAL_CONFIG_URL = `https://www.originprotocol.com/static/partnerconf/campaigns.json`

--- a/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
+++ b/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
@@ -23,7 +23,7 @@ function withPartnerCampaignConfig(WrappedComponent) {
       if (cachedCampaigns && Object.keys(cachedCampaigns).length) {
         return
       } else {
-        setTimeout(async () => {
+        timeout = setTimeout(async () => {
           setPartnerConfig(await fetchConfig())
         }, 3000)
       }
@@ -31,7 +31,7 @@ function withPartnerCampaignConfig(WrappedComponent) {
       return () => {
         clearTimeout(timeout)
       }
-    })
+    }, [])
 
     return (
       <WrappedComponent

--- a/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
+++ b/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
@@ -2,7 +2,17 @@ import React, { useState, useEffect } from 'react'
 
 import { PARNTER_REFERRAL_CONFIG_URL } from 'constants/config'
 
-let cachedCampaigns
+let cachedCampaigns = {}
+
+async function fetchConfig() {
+  const resp = await fetch(PARNTER_REFERRAL_CONFIG_URL)
+  if (resp.status !== 200) {
+    console.error('Failed to fetch campaign config')
+    return
+  }
+  cachedCampaigns = await resp.json()
+  return cachedCampaigns
+}
 
 function withPartnerCampaignConfig(WrappedComponent) {
   const WithPartnerCampaignConfig = props => {
@@ -10,17 +20,11 @@ function withPartnerCampaignConfig(WrappedComponent) {
 
     useEffect(() => {
       let timeout
-      if (cachedCampaigns) {
+      if (cachedCampaigns && Object.keys(cachedCampaigns).length) {
         return
       } else {
         setTimeout(async () => {
-          const resp = await fetch(PARNTER_REFERRAL_CONFIG_URL)
-          if (resp.status !== 200) {
-            console.error('Failed to fetch campaign config')
-            return
-          }
-          const jason = await resp.json()
-          setPartnerConfig(jason)
+          setPartnerConfig(await fetchConfig())
         }, 3000)
       }
 

--- a/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
+++ b/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
@@ -19,8 +19,8 @@ function withPartnerCampaignConfig(WrappedComponent) {
             console.error('Failed to fetch campaign config')
             return
           }
-          cachedCampaigns = await resp.json()
-          setPartnerConfig(cachedCampaigns)
+          const jason = await resp.json()
+          setPartnerConfig(jason)
         }, 3000)
       }
 

--- a/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
+++ b/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
@@ -15,7 +15,7 @@ function withPartnerCampaignConfig(WrappedComponent) {
       } else {
         setTimeout(async () => {
           const resp = await fetch(PARNTER_REFERRAL_CONFIG_URL)
-          if (resp !== 200) {
+          if (resp.status !== 200) {
             console.error('Failed to fetch campaign config')
             return
           }

--- a/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
+++ b/dapps/marketplace/src/hoc/withPartnerCampaignConfig.js
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react'
+
+import { PARNTER_REFERRAL_CONFIG_URL } from 'constants/config'
+
+let cachedCampaigns
+
+function withPartnerCampaignConfig(WrappedComponent) {
+  const WithPartnerCampaignConfig = props => {
+    const [partnerConfig, setPartnerConfig] = useState(cachedCampaigns)
+
+    useEffect(() => {
+      let timeout
+      if (cachedCampaigns) {
+        return
+      } else {
+        setTimeout(async () => {
+          const resp = await fetch(PARNTER_REFERRAL_CONFIG_URL)
+          if (resp !== 200) {
+            console.error('Failed to fetch campaign config')
+            return
+          }
+          cachedCampaigns = await resp.json()
+          setPartnerConfig(cachedCampaigns)
+        }, 3000)
+      }
+
+      return () => {
+        clearTimeout(timeout)
+      }
+    })
+
+    return (
+      <WrappedComponent
+        {...props}
+        partnerCampaignConfig={partnerConfig || {}}
+      />
+    )
+  }
+  return WithPartnerCampaignConfig
+}
+
+export default withPartnerCampaignConfig

--- a/dapps/marketplace/src/pages/onboard/Finished.js
+++ b/dapps/marketplace/src/pages/onboard/Finished.js
@@ -3,17 +3,18 @@ import React, { useState } from 'react'
 import Redirect from 'components/Redirect'
 import UserProfileCreated from 'components/_UserProfileCreated'
 
+import withEnrolmentStatus from 'hoc/withEnrolmentStatus'
 import withActiveGrowthCampaign from 'hoc/withActiveGrowthCampaign'
+import withPartnerCampaignConfig from 'hoc/withPartnerCampaignConfig'
 
 import { formatTokens, getReferralReward } from 'utils/growthTools'
-
-import withEnrolmentStatus from 'hoc/withEnrolmentStatus'
 
 const Finished = ({
   linkPrefix,
   redirectto,
   activeGrowthCampaign,
-  growthEnrollmentStatus
+  growthEnrollmentStatus,
+  partnerCampaignConfig
 }) => {
   const continueTo = redirectto ? redirectto : `${linkPrefix}/onboard/back`
 
@@ -24,8 +25,7 @@ const Finished = ({
   }
 
   const enrolled = growthEnrollmentStatus === 'Enrolled'
-
-  const reward = getReferralReward(activeGrowthCampaign)
+  const reward = getReferralReward(activeGrowthCampaign, partnerCampaignConfig)
 
   const formattedReward = !reward ? null : `${formatTokens(reward)} OGN`
 
@@ -41,7 +41,9 @@ const Finished = ({
   )
 }
 
-export default withEnrolmentStatus(withActiveGrowthCampaign(Finished))
+export default withEnrolmentStatus(
+  withActiveGrowthCampaign(withPartnerCampaignConfig(Finished))
+)
 
 require('react-styl')(`
   .onboard .finished

--- a/dapps/marketplace/src/pages/onboard/RewardsSignUp.js
+++ b/dapps/marketplace/src/pages/onboard/RewardsSignUp.js
@@ -1,26 +1,27 @@
 import React, { Component } from 'react'
+import { fbt } from 'fbt-runtime'
+
+import MobileModal from 'components/MobileModal'
+import Redirect from 'components/Redirect'
+import HelpOriginWallet from 'components/DownloadApp'
+import LoadingSpinner from 'components/LoadingSpinner'
+
+import WithEnrolmentModal from 'pages/growth/WithEnrolmentModal'
 
 import withIsMobile from 'hoc/withIsMobile'
 import withWallet from 'hoc/withWallet'
-import MobileModal from 'components/MobileModal'
-import WithEnrolmentModal from 'pages/growth/WithEnrolmentModal'
-import Redirect from 'components/Redirect'
-import { fbt } from 'fbt-runtime'
-import HelpOriginWallet from 'components/DownloadApp'
-import ListingPreview from './_ListingPreview'
-import HelpProfile from './_HelpProfile'
-
-import LoadingSpinner from 'components/LoadingSpinner'
-
-import Store from 'utils/store'
-
 import withActiveGrowthCampaign from 'hoc/withActiveGrowthCampaign'
+import withPartnerCampaignConfig from 'hoc/withPartnerCampaignConfig'
 
 import {
   formatTokens,
   hasReferralCode,
   getReferralReward
 } from 'utils/growthTools'
+import Store from 'utils/store'
+
+import ListingPreview from './_ListingPreview'
+import HelpProfile from './_HelpProfile'
 
 const localStore = Store('localStorage')
 
@@ -38,7 +39,10 @@ class OnboardRewardsSignUp extends Component {
   }
 
   getReferralReward() {
-    const reward = getReferralReward(this.props.activeGrowthCampaign)
+    const reward = getReferralReward(
+      this.props.activeGrowthCampaign,
+      this.props.partnerCampaignConfig
+    )
 
     if (!reward) {
       return null
@@ -241,7 +245,7 @@ class OnboardRewardsSignUp extends Component {
 }
 
 export default withActiveGrowthCampaign(
-  withIsMobile(withWallet(OnboardRewardsSignUp))
+  withPartnerCampaignConfig(withIsMobile(withWallet(OnboardRewardsSignUp)))
 )
 
 require('react-styl')(`

--- a/infra/growth/src/resources/authentication.js
+++ b/infra/growth/src/resources/authentication.js
@@ -178,7 +178,7 @@ async function getUserAuthStatusAndToken(address) {
 
   return {
     authStatus,
-    authToken: growthParticipant.authStatus
+    authToken: growthParticipant.authToken
   }
 }
 


### PR DESCRIPTION
### Description:

Pull reward amount from `campaigns.json` for partner funnel dapp pages as the current method from PR #4115 will always return 0.

This is untested and depends on https://github.com/OriginProtocol/origin-website/pull/458

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
