### PR TITLE
Increase listener polling interval from 5 to 30sec

### DIFF
--- a/infra/discovery/src/listener/listener.js
+++ b/infra/discovery/src/listener/listener.js
@@ -29,6 +29,9 @@ const { blockGauge, errorCounter, metricsServer } = require('./metrics')
 const { handleEvent } = require('./handler')
 const { getLastBlock, setLastBlock, withRetrys } = require('./utils')
 
+// Poll for new events every 30 seconds.
+const pollIntervalSec = 30
+
 /**
  * Helper class passed to logic methods containing config and shared resources.
  */
@@ -141,16 +144,14 @@ async function main() {
     logger.warn(`Backfill mode: concurrency=${context.config.concurrency}`)
   }
 
-  // Helper function to wait at most tickIntervalSeconds.
-  const tickIntervalSeconds = 5
-  let start
-
+  // Helper function to wait at most pollIntervalSec.
   async function nextTick() {
     const elapsed = new Date() - start
-    const delay = Math.max(tickIntervalSeconds * 1000 - elapsed, 1)
+    const delay = Math.max(pollIntervalSec * 1000 - elapsed, 1)
     return new Promise(resolve => setTimeout(() => resolve(true), delay))
   }
 
+  let start
   do {
     start = new Date()
 


### PR DESCRIPTION
### Description:

Decrease polling interval in order to reduce number of calls to Alchemy.
The impact is that there will be a longer delay for indexing listings.
But we have so few listings creation/edit that this should not be a concern.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
