### PR TITLE
Fix rewards landing page

### DIFF
--- a/dapps/marketplace/src/pages/App.js
+++ b/dapps/marketplace/src/pages/App.js
@@ -35,10 +35,12 @@ import GrowthWelcome from './growth/Welcome'
 import AboutToken from './about/AboutTokens'
 import AboutPayments from './about/AboutPayments'
 import AboutCrypto from './about/AboutCrypto'
+
+import ReferralRedirect from './ReferralRedirect'
+
 import { applyConfiguration } from 'utils/marketplaceCreator'
 import Sentry from 'utils/sentry'
 import CurrencyContext from 'constants/CurrencyContext'
-
 import { setReferralCode } from 'utils/growthTools'
 
 class App extends Component {
@@ -178,6 +180,9 @@ class App extends Component {
             />
             <Route exact path="/rewards/banned" component={GrowthBanned} />
             <Route path="/welcome/:inviteCode?" component={GrowthWelcome} />
+
+            <Route path="/referral/:inviteCode" component={ReferralRedirect} />
+
             <Route path="/search" component={Listings} />
             <Route component={Listings} />
           </Switch>

--- a/dapps/marketplace/src/pages/ReferralRedirect.js
+++ b/dapps/marketplace/src/pages/ReferralRedirect.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react'
+import get from 'lodash/get'
+
+import { withRouter } from 'react-router-dom'
+
+import UserActivationLink from 'components/UserActivationLink'
+
+const localStorageKey = 'growth_invite_code'
+
+const ReferralRedirect = ({ match }) => {
+  const inviteCode = get(match, 'params.inviteCode')
+  const [redirect, setRedirect] = useState(false)
+
+  useEffect(() => {
+    if (inviteCode && inviteCode.length === 11) {
+      localStorage.setItem(localStorageKey, inviteCode)
+    } else {
+      console.warn('Skipping invalid invite code')
+    }
+    setRedirect(true)
+  }, [inviteCode])
+
+  if (redirect) {
+    return (
+      <UserActivationLink forceRedirect location={{ pathname: '/campaigns' }} />
+    )
+  }
+
+  return null
+}
+
+export default withRouter(ReferralRedirect)

--- a/dapps/marketplace/src/pages/ReferralRedirect.js
+++ b/dapps/marketplace/src/pages/ReferralRedirect.js
@@ -12,7 +12,7 @@ const ReferralRedirect = ({ match }) => {
   const [redirect, setRedirect] = useState(false)
 
   useEffect(() => {
-    if (inviteCode && inviteCode.length === 11) {
+    if (inviteCode && (inviteCode.length < 7 || inviteCode.length > 11)) {
       localStorage.setItem(localStorageKey, inviteCode)
     } else {
       console.warn('Skipping invalid invite code')

--- a/dapps/marketplace/src/pages/growth/Welcome.js
+++ b/dapps/marketplace/src/pages/growth/Welcome.js
@@ -4,13 +4,16 @@ import get from 'lodash/get'
 import { Query } from 'react-apollo'
 import { fbt } from 'fbt-runtime'
 
-import { rewardsOnMobileEnabled } from 'constants/SystemInfo'
 import withEnrolmentModal from 'pages/growth/WithEnrolmentModal'
-import withIsMobile from 'hoc/withIsMobile'
-import inviteInfoQuery from 'queries/InviteInfo'
-import DocumentTitle from 'components/DocumentTitle'
 import Onboard from 'pages/onboard/Onboard'
+
+import DocumentTitle from 'components/DocumentTitle'
 import Link from 'components/Link'
+
+import withIsMobile from 'hoc/withIsMobile'
+
+import { rewardsOnMobileEnabled } from 'constants/SystemInfo'
+import inviteInfoQuery from 'queries/InviteInfo'
 
 class GrowthWelcome extends Component {
   constructor(props) {

--- a/dapps/marketplace/src/pages/growth/WithEnrolmentModal.js
+++ b/dapps/marketplace/src/pages/growth/WithEnrolmentModal.js
@@ -2,21 +2,29 @@ import React, { Component, Fragment } from 'react'
 import { Query } from 'react-apollo'
 import { withRouter } from 'react-router-dom'
 import { fbt } from 'fbt-runtime'
-
 import omit from 'lodash/omit'
 
-import { rewardsOnMobileEnabled } from 'constants/SystemInfo'
 import growthEligibilityQuery from 'queries/GrowthEligibility'
 import enrollmentStatusQuery from 'queries/EnrollmentStatus'
 import allCampaignsQuery from 'queries/AllGrowthCampaigns'
 import profileQuery from 'queries/Profile'
+
+import Enroll from 'pages/growth/mutations/Enroll'
+
 import QueryError from 'components/QueryError'
 import Modal from 'components/Modal'
 import MobileModal from 'components/MobileModal'
-import Enroll from 'pages/growth/mutations/Enroll'
-import { mobileDevice } from 'utils/mobile'
-import withIsMobile from 'hoc/withIsMobile'
 import LoadingSpinner from 'components/LoadingSpinner'
+
+import withIsMobile from 'hoc/withIsMobile'
+import withAuthStatus from 'hoc/withAuthStatus'
+import withWallet from 'hoc/withWallet'
+
+import { rewardsOnMobileEnabled } from 'constants/SystemInfo'
+import { mobileDevice } from 'utils/mobile'
+
+import store from 'utils/store'
+const sessionStore = store('sessionStorage')
 
 const GrowthEnum = require('Growth$FbtEnum')
 
@@ -94,15 +102,19 @@ function withEnrolmentModal(WrappedComponent) {
       this.props.history.push(href)
     }
 
-    handleClick(e, enrollmentStatus, walletPresent) {
+    handleClick(e, enrollmentStatus) {
       e.preventDefault()
+
+      const { isLoggedIn } = this.props
 
       if (mobileDevice() !== null && !rewardsOnMobileEnabled) {
         this.setState({
           open: true,
           stage: 'NotSupportedOnMobile'
         })
-      } else if (!walletPresent) {
+      } else if (!isLoggedIn) {
+        const { pathname, search } = this.props.location
+        sessionStore.set('getStartedRedirect', { pathname, search })
         this.historyNavigate(this.props.urlforonboarding)
       } else if (enrollmentStatus === 'Enrolled') {
         this.historyNavigate('/campaigns')
@@ -634,14 +646,21 @@ function withEnrolmentModal(WrappedComponent) {
                           'isMobile',
                           'isMobileApp',
                           'onAccountBlocked',
-                          'goToWelcomeWhenNotEnrolled'
+                          'goToWelcomeWhenNotEnrolled',
+                          'isLoggedIn',
+                          'isAuthTokenValid',
+                          'hasAuthTokenExpired',
+                          'willAuthTokenExpire',
+                          'authStatusRefetch',
+                          'authStatusLoading',
+                          'walletType',
+                          'walletLoading',
+                          'walletProxy',
+                          'walletPredictedProxy',
+                          'location'
                         ])}
                         onClick={e =>
-                          this.handleClick(
-                            e,
-                            data.enrollmentStatus,
-                            walletAddress
-                          )
+                          this.handleClick(e, data.enrollmentStatus)
                         }
                       />
                       {open && (
@@ -671,12 +690,16 @@ function withEnrolmentModal(WrappedComponent) {
     }
   }
 
-  return withIsMobile(
-    // do not pass staticContext prop to component to prevent react errors in browser console
-    // eslint-disable-next-line no-unused-vars
-    withRouter(({ staticContext, location, match, ...props }) => (
-      <WithEnrolmentModal {...props} />
-    ))
+  return withWallet(
+    withAuthStatus(
+      withIsMobile(
+        // do not pass staticContext prop to component to prevent react errors in browser console
+        // eslint-disable-next-line no-unused-vars
+        withRouter(({ staticContext, match, ...props }) => (
+          <WithEnrolmentModal {...props} />
+        ))
+      )
+    )
   )
 }
 


### PR DESCRIPTION
Should fix #4131 

When users click on "Sign Up" in the rewards landing page, they are redirected to `/onboard` only if they are not signed in.

After the sign in and do email and profile attestations, they are taken back to `/welcome` landing page.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
