### PR TITLE
Fix Admin Dapp

### DIFF
--- a/dapps/admin/src/pages/_NodeInfo.js
+++ b/dapps/admin/src/pages/_NodeInfo.js
@@ -52,7 +52,11 @@ const Subs = () => {
     client.reFetchObservableQueries()
   }
 
-  const net = data.config
+  if (!data) {
+    return null
+  }
+
+  const net = get(data, 'config')
   const config = pick(
     get(data, 'configObj', {}),
     'relayerEnabled',


### PR DESCRIPTION
The `data` object was being accessed even before the query loaded. This caused the admin tool to crash. This PR should fix it.