### PR TITLE
Pass phone, country and IP to the email webhook

### DIFF
--- a/infra/bridge/src/controllers/identity.js
+++ b/infra/bridge/src/controllers/identity.js
@@ -146,7 +146,7 @@ router.post('/', authMiddleware, identityWriteVerify, async (req, res) => {
   await pinIdentityToIpfs(identity)
 
   // Call webhook to record the user's email in the insight tool.
-  await postToEmailWebhook(identity)
+  await postToEmailWebhook(identity, metadata.ip)
 
   return res.status(200).send({ ethAddress: owner })
 })

--- a/infra/bridge/src/utils/identity.js
+++ b/infra/bridge/src/utils/identity.js
@@ -113,9 +113,10 @@ async function _postToWebhook(
  * and server would check it.
  *
  * @param {{ethAddress:string, email:string, firstName: string, lastName: string}} identity
+ * @param {string} ip
  * @returns {Promise<void>}
  */
-async function postToEmailWebhook(identity) {
+async function postToEmailWebhook(identity, ip) {
   if (process.env.NODE_ENV !== 'production') {
     logger.info('Test environment. Skipping email webhook.')
     return
@@ -139,7 +140,9 @@ async function postToEmailWebhook(identity) {
     identity.firstName || ''
   )}&last_name=${encodeURIComponent(
     identity.lastName || ''
-  )}&phone=${encodeURIComponent(identity.phone || '')}&dapp_user=1`
+  )}&phone=${encodeURIComponent(identity.phone || '')}&ip=${encodeURIComponent(
+    ip || ''
+  )}&country_code=${encodeURIComponent(identity.country || '')}&dapp_user=1`
   await _postToWebhook(url, emailData, 'application/x-www-form-urlencoded')
 }
 

--- a/infra/bridge/src/utils/identity.js
+++ b/infra/bridge/src/utils/identity.js
@@ -113,7 +113,7 @@ async function _postToWebhook(
  * and server would check it.
  *
  * @param {{ethAddress:string, email:string, firstName: string, lastName: string}} identity
- * @param {string} ip
+ * @param {string} ip: IP address the identity update originated from.
  * @returns {Promise<void>}
  */
 async function postToEmailWebhook(identity, ip) {

--- a/infra/identity/src/utils.js
+++ b/infra/identity/src/utils.js
@@ -118,10 +118,10 @@ async function _loadValueFromAttestation(addresses, method) {
 }
 
 /**
- * Returns the country of the identity based on IP from the most recent attestation.
+ * Returns the country code of the identity based on IP from the most recent attestation.
  *
  * @param {Array<string>} addresses
- * @returns {Promise<string> || null} 2 letters country code or null if lookup failed.
+ * @returns {Promise<{country: string, ip: string}> || null} 2 letters country code or null if lookup failed.
  * @private
  */
 async function _countryLookup(addresses) {
@@ -132,11 +132,12 @@ async function _countryLookup(addresses) {
   }
 
   // Do the IP to geo lookup.
-  const geo = await ip2geo(attestation.remoteIpAddress)
+  const ip = attestation.remoteIpAddress
+  const geo = await ip2geo(ip)
   if (!geo) {
     return null
   }
-  return geo.countryCode
+  return { country: geo.countryCode, ip }
 }
 
 /**
@@ -248,7 +249,9 @@ async function loadAttestationMetadata(addresses, attestations) {
   )
 
   // Add country of origin based on IP.
-  metadata.country = await _countryLookup(addresses)
+  const data = await _countryLookup(addresses)
+  metadata.country = data ? data.country : null
+  metadata.ip = data ? data.ip : null
 
   return metadata
 }


### PR DESCRIPTION
### Description:

Send phone,IP and country code as arguments when calling the website email webhook from the bridge when an identity gets updated.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
