### PR TITLE
Defer enroll mutation until fingerprint data is available

### DIFF
--- a/dapps/marketplace/src/hoc/withFingerprint.js
+++ b/dapps/marketplace/src/hoc/withFingerprint.js
@@ -66,9 +66,16 @@ const getFingerprint = memoize(getFingerprintFn)
 
 function withFingerprint(WrappedComponent) {
   const WithFingerprint = props => {
-    const [fingerprintData, setFingerprintData] = useState(
+    const [fingerprintData, _setFingerprintData] = useState(
       cachedFingerprintData
     )
+
+    const [loading, setLoading] = useState(fingerprintData ? false : true)
+
+    const setFingerprintData = data => {
+      _setFingerprintData(data)
+      setLoading(false)
+    }
 
     useEffect(() => {
       let timeout, idleCallback
@@ -92,7 +99,13 @@ function withFingerprint(WrappedComponent) {
       }
     })
 
-    return <WrappedComponent {...props} fingerprintData={fingerprintData} />
+    return (
+      <WrappedComponent
+        {...props}
+        fingerprintData={fingerprintData}
+        fingerprintLoading={loading}
+      />
+    )
   }
   return withWallet(WithFingerprint)
 }

--- a/dapps/marketplace/src/pages/growth/mutations/Enroll.js
+++ b/dapps/marketplace/src/pages/growth/mutations/Enroll.js
@@ -22,11 +22,20 @@ const Error = props => (
  */
 const ENROLL_MESSAGE = 'I accept the terms of growth campaign version: 1.0'
 
-const Enroll = ({ fingerprintData, onAccountBlocked, onSuccess }) => {
+const Enroll = ({
+  fingerprintData,
+  fingerprintLoading,
+  onAccountBlocked,
+  onSuccess
+}) => {
   const [enroll] = useMutation(GrowthEnroll)
   const [error, setError] = useState(null)
 
   useEffect(() => {
+    if (fingerprintLoading) {
+      return
+    }
+
     enroll({
       variables: {
         agreementMessage: ENROLL_MESSAGE,
@@ -51,7 +60,7 @@ const Enroll = ({ fingerprintData, onAccountBlocked, onSuccess }) => {
           )
         )
       })
-  }, [])
+  }, [fingerprintData, fingerprintLoading])
 
   if (error) {
     return <Error error={error} />

--- a/packages/graphql/test/availability-calculator.js
+++ b/packages/graphql/test/availability-calculator.js
@@ -4,7 +4,14 @@ import dayjs from 'dayjs'
 import AvailabilityCalculator from '../src/utils/AvailabilityCalculator'
 
 describe('Availability Calculator', function() {
-  const year = dayjs().year() + 1
+  let year = dayjs().year()
+
+  const currentMonth = dayjs().month()
+
+  if (currentMonth >= 2) {
+    year = year + 1
+  }
+
   let instance
 
   beforeEach(() => {


### PR DESCRIPTION
Previously, the user has to click on a button to sign a message and trigger the enroll mutation. Since the signing requirement was removed in favor of auth token, We no longer needed that extra modal. 

So, I had made that enroll mutation to auto run when `pages/growth/mutations/Enroll` component is rendered. The problem was that the fingerprint data took a couple of seconds to load. So when the component was rendered, fingerprintData was always `null`.

This PR will defer the enroll mutation until the finger data is loaded and cached. 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
