### PR TITLE
[T3 server] Send country code rather than country struct when calling insight

### DIFF
--- a/infra/token-transfer-server/src/controllers/account.js
+++ b/infra/token-transfer-server/src/controllers/account.js
@@ -70,8 +70,10 @@ router.post(
         if (geo) {
           countryCode = geo.countryCode
         }
-      } catch(e) {
-        logger.warn(`Failed resolving IP ${ip} to a country for sending to Insight`)
+      } catch (e) {
+        logger.warn(
+          `Failed resolving IP ${ip} to a country for sending to Insight`
+        )
       }
       request
         .post('https://www.originprotocol.com/mailing-list/join')

--- a/infra/token-transfer-server/src/controllers/account.js
+++ b/infra/token-transfer-server/src/controllers/account.js
@@ -64,7 +64,15 @@ router.post(
       // Add account address to Wallet Insights. Only logs a warning on failure,
       // doesn't block the account add action.
       const ip = req.headers['x-real-ip'] || req.headers['x-forwarded-for']
-      const countryCode = await ip2geo(ip)
+      let countryCode = ''
+      try {
+        const geo = await ip2geo(ip)
+        if (geo) {
+          countryCode = geo.countryCode
+        }
+      } catch(e) {
+        logger.warn(`Failed resolving IP ${ip} to a country for sending to Insight`)
+      }
       request
         .post('https://www.originprotocol.com/mailing-list/join')
         .send(`email=${encodeURIComponent(req.user.email)}`)


### PR DESCRIPTION
### Description:

Same as title.
Sorry, my bad for breaking this.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
