### PR TITLE
Fix T3 client side balance calculation for expired withdrawals

### DIFF
--- a/infra/token-transfer-client/src/reducers/transfer.js
+++ b/infra/token-transfer-client/src/reducers/transfer.js
@@ -1,4 +1,4 @@
-import enums from '@origin/token-transfer-server/src/enums'
+import { calculateWithdrawn } from '@origin/token-transfer-server/src/shared'
 
 import {
   ADD_TRANSFER_PENDING,
@@ -91,19 +91,4 @@ export const getError = state => state.error
 export const getIsAdding = state => state.isAdding
 export const getIsConfirming = state => state.isConfirming
 export const getIsLoading = state => state.isLoading
-export const getWithdrawnAmount = state => {
-  const pendingOrCompleteTransfers = [
-    enums.TransferStatuses.WaitingEmailConfirm,
-    enums.TransferStatuses.Enqueued,
-    enums.TransferStatuses.Paused,
-    enums.TransferStatuses.WaitingConfirmation,
-    enums.TransferStatuses.Success
-  ]
-
-  return state.transfers.reduce((total, transfer) => {
-    if (pendingOrCompleteTransfers.includes(transfer.status)) {
-      return total + Number(transfer.amount)
-    }
-    return total
-  }, 0)
-}
+export const getWithdrawnAmount = state => calculateWithdrawn(state.transfers)


### PR DESCRIPTION
All in the title! Now uses same method for both client and server calculation, which is what I intended but somehow didn't clean up.