### PR TITLE
Notify users to go through Telegram Attestation on DApp

### DIFF
--- a/infra/bridge/src/controllers/hooks/telegram.js
+++ b/infra/bridge/src/controllers/hooks/telegram.js
@@ -91,7 +91,7 @@ router.post('/', telegramIPWhitelistMiddleware, async (req, res) => {
       replyWithMessage(
         res,
         message.chat.id,
-        "Sorry, we couldn't verify your account. Please go through the Telegram Attestation from Origin Marketplace again."
+        'Please return to the Origin Marketplace app and retry your Telegram verification.'
       )
     } else {
       // Log unexpected private chat messages to DB

--- a/infra/bridge/src/controllers/hooks/telegram.js
+++ b/infra/bridge/src/controllers/hooks/telegram.js
@@ -85,6 +85,14 @@ router.post('/', telegramIPWhitelistMiddleware, async (req, res) => {
         message.chat.id,
         'Great, now go back to the Origin Marketplace app to continue'
       )
+    } else if (message.text.startsWith('/start')) {
+      // User tried to send /start directly
+      logger.debug('Ignoring invalid attestation request')
+      replyWithMessage(
+        res,
+        message.chat.id,
+        "Sorry, we couldn't verify your account. Please go through the Telegram Attestation from Origin Marketplace again."
+      )
     } else {
       // Log unexpected private chat messages to DB
       logger.debug('Logging chat')


### PR DESCRIPTION
When an user sends `/start` directly to the bot, reply to them with a message to go through the flow on the DApp again.
