### PR TITLE
[IPFS outage] Stop writing identity data to IPFS

### DIFF
--- a/packages/graphql/src/mutations/identity/deployIdentity.js
+++ b/packages/graphql/src/mutations/identity/deployIdentity.js
@@ -146,7 +146,9 @@ async function deployIdentity(
   const ipfsData = await _buildIdentity(owner, proxy, profile, attestations)
 
   // Write the identity data to IPFS.
-  const ipfsHash = await post(contracts.ipfsRPC, ipfsData)
+  // FRANCK 1/9/2020 Temporarily disabling writing identity to IPFS due to outage.
+  // const ipfsHash = await post(contracts.ipfsRPC, ipfsData)
+  const ipfsHash = 'NOT_UPLOADED'
 
   if (contracts.config.centralizedIdentityEnabled) {
     // Write the identity data to centralized storage via the identity server.


### PR DESCRIPTION
### Description:

This change will have the following effect:
- The DApp won't store the identity blob to IPFS before it makes a request to the bridge server to save an identity. It means that the identity blob will only be saved in the DB and no longer both in IPFS and DB
 - Note that we'll also lose identity history since previously we were relying on storing the history of identity IPFS hashes. I think that's tolerable given the situation we are in

Once this change is deployed and the client refresh to pick up the code, user should be able again to save their identity (e.g. set/update profile, add attestations).

Once we have fixed our IPFS cluster, we can if backfill the data in IPFS by reading it from the DB.

This change will NOT fix:
- profile pic uploads
- listing creation
- offer creation

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
