### PR TITLE
Reduce telegram reply rate limit

### DIFF
--- a/infra/bridge/src/hooks/telegram.js
+++ b/infra/bridge/src/hooks/telegram.js
@@ -119,7 +119,7 @@ async function poller() {
   const pollInterval = process.env.TELEGRAM_POLL_INTERVAL || 2000
 
   // Telegram has a rate limit of 30 requests per second fot bots
-  const reqBottleneck = new Bottleneck({ minTime: 3330 })
+  const reqBottleneck = new Bottleneck({ minTime: 34 })
 
   // eslint-disable-next-line no-constant-condition
   while (true) {


### PR DESCRIPTION
I had increased the rate limiting time to 3s while testing locally and missed to revert it before pushing :/

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
