### PR TITLE
Get time for login from auth server

### DIFF
--- a/infra/auth-server/src/controllers/index.js
+++ b/infra/auth-server/src/controllers/index.js
@@ -5,4 +5,11 @@ const router = express.Router()
 
 router.use('/api/tokens', require('./tokens'))
 
+// Returns the current timestamp of the server
+router.get('/api/now', (req, res) => {
+  res.status(200).send({
+    timestamp: Date.now()
+  })
+})
+
 module.exports = router

--- a/mobile/src/PushNotifications.js
+++ b/mobile/src/PushNotifications.js
@@ -313,10 +313,16 @@ class PushNotifications extends Component {
       return
     }
 
+    const authClient = new AuthClient({
+      authServer:
+        this.props.config.authServer || 'https://auth.originprotocol.com',
+      disablePersistence: true
+    })
+
     const message = AUTH_MESSAGE
     const payload = {
       message,
-      timestamp: Date.now()
+      timestamp: await authClient.getServerTime()
     }
 
     let signature
@@ -336,12 +342,6 @@ class PushNotifications extends Component {
 
       signature = await ethersWallet.signMessage(stringify(payload))
     }
-
-    const authClient = new AuthClient({
-      authServer:
-        this.props.config.authServer || 'https://auth.originprotocol.com',
-      disablePersistence: true
-    })
 
     try {
       const tokenData = await authClient.getTokenWithSignature(

--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -29,6 +29,8 @@ import stringify from 'json-stable-stringify'
 import DeviceInfo from 'react-native-device-info'
 import { NativeModules } from 'react-native'
 
+import AuthClient from '@origin/auth-client/src/auth-client'
+
 import OriginButton from 'components/origin-button'
 import OriginWeb3View from 'components/origin-web3view'
 
@@ -44,6 +46,11 @@ import { PROMPT_MESSAGE, PROMPT_PUB_KEY, AUTH_MESSAGE } from '../constants'
 import CommonStyles from 'styles/common'
 import CardStyles from 'styles/card'
 import UpdatePrompt from 'components/update-prompt'
+
+const authClient = new AuthClient({
+  authServer: this.props.config.authServer || 'https://auth.originprotocol.com',
+  disablePersistence: true
+})
 
 class MarketplaceScreen extends PureComponent {
   static navigationOptions = () => {
@@ -274,7 +281,7 @@ class MarketplaceScreen extends PureComponent {
 
     const payload = {
       message: AUTH_MESSAGE,
-      timestamp: Date.now()
+      timestamp: await authClient.getServerTime()
     }
 
     // Sign the message

--- a/mobile/src/screens/marketplace.js
+++ b/mobile/src/screens/marketplace.js
@@ -47,10 +47,7 @@ import CommonStyles from 'styles/common'
 import CardStyles from 'styles/card'
 import UpdatePrompt from 'components/update-prompt'
 
-const authClient = new AuthClient({
-  authServer: this.props.config.authServer || 'https://auth.originprotocol.com',
-  disablePersistence: true
-})
+import withConfig from 'hoc/withConfig'
 
 class MarketplaceScreen extends PureComponent {
   static navigationOptions = () => {
@@ -278,6 +275,12 @@ class MarketplaceScreen extends PureComponent {
    */
   injectAuthSign = async () => {
     const { wallet } = this.props
+
+    const authClient = new AuthClient({
+      authServer:
+        this.props.config.authServer || 'https://auth.originprotocol.com',
+      disablePersistence: true
+    })
 
     const payload = {
       message: AUTH_MESSAGE,
@@ -898,8 +901,10 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setMarketplaceWebViewError(error))
 })
 
-export default withOriginGraphql(
-  connect(mapStateToProps, mapDispatchToProps)(MarketplaceScreen)
+export default withConfig(
+  withOriginGraphql(
+    connect(mapStateToProps, mapDispatchToProps)(MarketplaceScreen)
+  )
 )
 
 const styles = StyleSheet.create({

--- a/packages/auth-client/src/auth-client.js
+++ b/packages/auth-client/src/auth-client.js
@@ -97,7 +97,7 @@ class AuthClient {
 
     const payload = {
       message: message || 'I intend to sign in to Origin Marketplace',
-      timestamp: Date.now()
+      timestamp: await this.getServerTime()
     }
 
     let signature
@@ -379,6 +379,28 @@ class AuthClient {
    */
   _removeCache(wallet) {
     window.localStorage.removeItem(`auth:${wallet}`)
+  }
+
+  /**
+   * Get server time
+   */
+  async getServerTime() {
+    try {
+      let url = new URL(this.authServer)
+      url.pathname = '/api/now'
+      url = url.toString()
+
+      const rawResponse = await fetch(url)
+
+      const response = await rawResponse.json()
+
+      return response.body.timestamp || Date.now()
+    } catch (err) {
+      console.error('Failed to get timestamp from server')
+    }
+
+    // Fallback
+    return Date.now()
   }
 }
 

--- a/packages/auth-client/src/auth-client.js
+++ b/packages/auth-client/src/auth-client.js
@@ -394,9 +394,13 @@ class AuthClient {
 
       const response = await rawResponse.json()
 
-      return response.body.timestamp || Date.now()
+      if (!response.body.timestamp) {
+        throw new Error('Timestamp missing from response')
+      }
+
+      return response.body.timestamp
     } catch (err) {
-      console.error('Failed to get timestamp from server')
+      console.error('Failed to get timestamp from server', err)
     }
 
     // Fallback

--- a/packages/auth-client/src/auth-client.js
+++ b/packages/auth-client/src/auth-client.js
@@ -394,11 +394,11 @@ class AuthClient {
 
       const response = await rawResponse.json()
 
-      if (!response.body.timestamp) {
+      if (!response.timestamp) {
         throw new Error('Timestamp missing from response')
       }
 
-      return response.body.timestamp
+      return response.timestamp
     } catch (err) {
       console.error('Failed to get timestamp from server', err)
     }


### PR DESCRIPTION
User are not able to login if they have incorrect date/time on their machine. This PR adds an endpoint to auth server that will return the current timestamp of auth server.

It shouldn't be a problem security wise either, we already trust the client to send the timestamp. Also, we don't generate auth token if the time is in future or older than a few minutes.

This requires a mobile app update.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
