### PR TITLE
fix 2 bugs that cause payment button to be in loading state

### DIFF
--- a/dapps/marketplace/src/pages/listing/PaymentMethods.js
+++ b/dapps/marketplace/src/pages/listing/PaymentMethods.js
@@ -135,6 +135,8 @@ const PaymentMethods = ({
 
   const title = <fbt desc="PaymentMethod.title">Payment Method</fbt>
 
+  const storedPaymentMethodAvailable = acceptedTokens.includes(paymentMethod)
+
   return (
     <div className="container payment-methods-page">
       <DocumentTitle>
@@ -151,11 +153,11 @@ const PaymentMethods = ({
         <div className="my-4">
           <fbt desc="PaymentMethod.acceptedCurrencies">This seller accepts</fbt>
         </div>
-        {acceptedTokens.map(token => (
+        {acceptedTokens.map((token, index) => (
           <AcceptedTokenListItem
             key={token}
             token={token}
-            selected={paymentMethod === token}
+            selected={storedPaymentMethodAvailable ? paymentMethod === token : index === 0}
             onSelect={setTokenCallback}
             hideTooltip={true}
           />

--- a/dapps/marketplace/src/pages/listing/_ConfirmPurchaseButton.js
+++ b/dapps/marketplace/src/pages/listing/_ConfirmPurchaseButton.js
@@ -34,7 +34,8 @@ const ConfirmPurchaseButton = ({
     messagingStatusLoading ||
     identityLoading ||
     walletLoading ||
-    messagingKeysLoading
+    // wallet should be available for messaging keys to possibly be in loading state
+    (wallet && messagingKeysLoading)
   ) {
     return (
       <button


### PR DESCRIPTION
### Description:
Fixes 2 issues that caused purchase button to stays disabled:
- User is on desktop and not logged in to Metamask
- User has on a previous listing selected a purchase method (let say OGN) and then opens another listing that doesn't offer that purchase method.

Fixes issue: https://github.com/OriginProtocol/origin/issues/4039
### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
