### PR TITLE
Don't include username in attestation body if empty

### DIFF
--- a/infra/bridge/src/utils/attestation.js
+++ b/infra/bridge/src/utils/attestation.js
@@ -119,21 +119,29 @@ const createTelegramAttestation = async ({ message, identity }) => {
     ? `https://t.me/${userProfileData.username}`
     : null
 
+  const userProps = {
+    userId: {
+      raw: String(userProfileData.id)
+    }
+  }
+
+  if (userProfileData.username) {
+    userProps.username = {
+      raw: userProfileData.username
+    }
+
+    userProps.profileUrl = {
+      raw: profileUrl
+    }
+  }
+
   const attestationBody = {
     verificationMethod: {
       oAuth: true
     },
     site: {
       siteName: 'telegram.com',
-      userId: {
-        raw: String(userProfileData.id)
-      },
-      username: {
-        raw: userProfileData.username
-      },
-      profileUrl: {
-        raw: profileUrl
-      }
+      ...userProps
     }
   }
 


### PR DESCRIPTION
In Telegram the username is optional. So when an user without an username tries to do the attestation, the attestation body contains `{ username: { raw: null } }` which is invalid as per the attestation_v1.0.0.json schema. It has to be string value or not exist at all.

This fixes #4217 

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
