### PR TITLE
Dshop IPFS configuration

### DIFF
--- a/devops/kubernetes/charts/origin/templates/ipfs.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.ingress.yaml
@@ -34,6 +34,9 @@ spec:
     - secretName: gateway.originprotocol.com
       hosts:
         - gateway.originprotocol.com
+    - secretName: ipfs.ogn.app
+      hosts:
+        - ipfs.ogn.app
     {{- end }}
   rules:
     - host: {{ template "ipfs.host" . }}
@@ -50,4 +53,21 @@ spec:
     {{- if eq .Release.Namespace "prod" }}
     - host: gateway.originprotocol.com
       http: *http_rules
+    - host: ipfs.ogn.app
+      http:
+        paths:
+          - path: /api/v0/add
+            backend: &api_service
+              serviceName: {{ template "ipfs.fullname" . }}
+              servicePort: 5001
+          - path: /api/v0/object/links
+            backend: *api_service
+          - path: /api/v0/object/patch/add-link
+            backend: *api_service
+          - path: /api/v0/object/patch/rm-link
+            backend: *api_service
+          - path: /ipns
+            backend:
+              serviceName: {{ template "ipfs.fullname" . }}
+              servicePort: 8080
     {{- end }}

--- a/devops/kubernetes/charts/origin/templates/ipfs.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.ingress.yaml
@@ -66,6 +66,10 @@ spec:
             backend: *api_service
           - path: /api/v0/object/patch/rm-link
             backend: *api_service
+          - path: /ipfs
+            backend:
+              serviceName: {{ template "ipfs.fullname" . }}
+              servicePort: 8080
           - path: /ipns
             backend:
               serviceName: {{ template "ipfs.fullname" . }}


### PR DESCRIPTION
Add a separate domain (`ipfs.ogn.app`) to IPFS ingress that bypasses `ipfs-proxy` and can access the add and link IPFS HTTP API methods.