### PR TITLE
Catch clicks exactly on icon in dropdowns

### DIFF
--- a/dapps/marketplace/src/pages/_Footer.js
+++ b/dapps/marketplace/src/pages/_Footer.js
@@ -322,6 +322,7 @@ require('react-styl')(`
               bottom: 0
               right: 12px
               transform: rotateZ(90deg)
+              pointer-events: none
           .footer-dropdown
             cursor: pointer
             margin-left: 12px


### PR DESCRIPTION
The ::after pseudo-element with carrot icon for dropdowns (in footer at least) was capturing mouse events. Meaning that if you clicked *exactly* on the carrot, the dropdown would not open. Adding `pointer-events: none` prevents this capturing of mouse events.

Image showing region of un-clickable pseudo-element in dapp footer dropdown:

![image](https://user-images.githubusercontent.com/673455/73397763-0cc6b500-4299-11ea-90ca-b6dec61565a4.png)
