### PR TITLE
Fix Webpack config due to renamed option

### DIFF
--- a/infra/token-transfer-client/config/webpack.config.js
+++ b/infra/token-transfer-client/config/webpack.config.js
@@ -572,7 +572,7 @@ module.exports = function(webpackEnv) {
           exclude: [/\.map$/, /asset-manifest\.json$/],
           importWorkboxFrom: 'cdn',
           navigateFallback: publicUrl + '/index.html',
-          navigateFallbackBlacklist: [
+          navigateFallbackDenylist: [
             // Exclude URLs starting with /_, as they're likely an API call
             new RegExp('^/_'),
             // Exclude URLs containing a dot, as they're likely a resource in


### PR DESCRIPTION
#4316 included a change that renamed an option in the T3 webpack config and broke the build. This fixes it.