### PR TITLE
txHelper error handler change

### DIFF
--- a/packages/graphql/src/mutations/_txHelper.js
+++ b/packages/graphql/src/mutations/_txHelper.js
@@ -575,6 +575,30 @@ async function sendViaWeb3({
 
   let txHash
 
+  function errorHandler(error) {
+    /**
+     * This seems like an internal web3.js error and not caused by our code.
+     * it should be temporary, so we're just gonna ignore it.
+     */
+    if (error && error.message && error.message.includes('Invalid params')) {
+      console.error(error.message)
+      return
+    }
+
+    if (txHash) {
+      const hashTosend = isValidHash(txHash) ? txHash : null
+      pubsub.publish('TRANSACTION_UPDATED', {
+        transactionUpdated: {
+          id: hashTosend,
+          status: 'error',
+          error,
+          mutation
+        }
+      })
+    }
+    reject(error)
+  }
+
   tx.once('transactionHash', async hash => {
     txHash = hash
     if (typeof txHash === 'object' && get(txHash, 'message')) {
@@ -597,29 +621,8 @@ async function sendViaWeb3({
         val: { confNumber, receipt }
       })
     })
-    .on('error', function(error) {
-      /**
-       * This seems like an internal web3.js error and not caused by our code.
-       * it should be temporary, so we're just gonna ignore it.
-       */
-      if (error && error.message && error.message.includes('Invalid params')) {
-        console.error(error.message)
-        return
-      }
-
-      if (txHash) {
-        const hashTosend = isValidHash(txHash) ? txHash : null
-        pubsub.publish('TRANSACTION_UPDATED', {
-          transactionUpdated: {
-            id: hashTosend,
-            status: 'error',
-            error,
-            mutation
-          }
-        })
-      }
-    })
-    .catch(reject)
+    .on('error', errorHandler)
+    .catch(errorHandler)
 }
 
 export default function txHelper({

--- a/packages/graphql/src/mutations/_txHelper.js
+++ b/packages/graphql/src/mutations/_txHelper.js
@@ -581,6 +581,7 @@ async function sendViaWeb3({
      * it should be temporary, so we're just gonna ignore it.
      */
     if (error && error.message && error.message.includes('Invalid params')) {
+      console.debug('error caught by errorHandler for web3.js transaction')
       console.error(error.message)
       return
     }


### PR DESCRIPTION
### Description:

In an effort to deal with the tx receipt param issues we've been seeing(and me thinking they're web3.js internal), I moved the error event handler to also be used in `.catch()`.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
