### PR TITLE
Fix Modals on Modals

### DIFF
--- a/dapps/marketplace/src/pages/transaction/mutations/FinalizeOffer.js
+++ b/dapps/marketplace/src/pages/transaction/mutations/FinalizeOffer.js
@@ -50,7 +50,7 @@ class FinalizeOffer extends Component {
       return
     }
 
-    this.setState({ waitFor: 'pending' })
+    this.setState({ waitFor: 'pending', confirmationModal: false })
 
     const { offer, rating, review, from } = this.props
     finalizeOffer({


### PR DESCRIPTION
# Closes: #3182 
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/guides/getting_started/contributing.html)

### Description:

Please explain the changes you made here:

- When a buyer would release funds you would have modals stacked on top of each other.
- I added `confirmationModal: false` to the onClick function to fire off when a user click yes release funds

![mobile_modal](https://user-images.githubusercontent.com/15057964/74900524-eefae600-5354-11ea-9f57-d2f3a5bad6b0.gif)

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
