### PR TITLE
Missing block tracker methods

### DIFF
--- a/packages/mobile-bridge/src/index.js
+++ b/packages/mobile-bridge/src/index.js
@@ -15,10 +15,13 @@ class BlockTracker {
    */
   constructor({ pubsub }) {
     this._resetHandlers()
+    this.latest = 0
 
+    const that = this
     pubsub.ee.on('NEW_BLOCK', ({ newBlock }) => {
       if (typeof newBlock.id === 'number') {
         const blockNum = `0x${newBlock.id.toString(16)}`
+        that.latest = blockNum
         this.emit('latest', blockNum)
       } else {
         console.warn('Invalid block number in BlockTracker')
@@ -57,6 +60,23 @@ class BlockTracker {
 
   removeAllListeners() {
     return this._resetHandlers()
+  }
+
+  async getLatestBlock () {
+    // return if available
+    if (this.latest) return this.latest
+    // wait for a new latest block
+    this.latest = await new Promise(resolve => this.once('latest', resolve))
+    // return newly set current block
+    return this.latest
+  }
+
+  getCurrentBlock () {
+    return this.latest
+  }
+
+  isRunning () {
+    return true
   }
 }
 


### PR DESCRIPTION
### Description:

The replacement block tracker in PR #4357 is missing a few methods that web3-provider-engine expects causing some errors.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
