### PR TITLE
Alternative to polling for balance updates

### DIFF
--- a/mobile/src/components/origin-web3view.js
+++ b/mobile/src/components/origin-web3view.js
@@ -6,7 +6,13 @@
 
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
-import { Modal, StyleSheet, PermissionsAndroid, Platform } from 'react-native'
+import {
+  Modal,
+  StyleSheet,
+  PermissionsAndroid,
+  Platform,
+  DeviceEventEmitter
+} from 'react-native'
 import { ethers } from 'ethers'
 import { WebView } from 'react-native-webview'
 import SafeAreaView from 'react-native-safe-area-view'
@@ -245,6 +251,7 @@ const OriginWeb3View = React.forwardRef(({ onMessage, ...props }, ref) => {
           }
           console.debug('Got transaction hash', transaction.hash)
           setTransactionCardLoading(false)
+          DeviceEventEmitter.emit('transactionSent', transaction.hash)
           toggleModal(modal, transaction.hash)
         }}
         loading={transactionCardLoading}

--- a/mobile/src/screens/wallet.js
+++ b/mobile/src/screens/wallet.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   ActivityIndicator,
   Alert,
@@ -8,7 +8,8 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  View
+  View,
+  DeviceEventEmitter
 } from 'react-native'
 import { connect } from 'react-redux'
 import { fbt } from 'fbt-runtime'
@@ -22,6 +23,11 @@ import ListStyles from 'styles/list'
 import OriginButton from 'components/origin-button'
 
 const walletScreen = props => {
+  useEffect(() => {
+    // We want to update the balances if the network has been changed
+    DeviceEventEmitter.emit('updateBalance')
+  }, [props.settings.network])
+
   const handleFunding = currency => {
     const { address } = props.wallet.activeAccount
 


### PR DESCRIPTION
### Description:

This uses "strategic" events to update the balance instead of an interval to poll for balance updates.  Currently this includes sending transactions and changing networks.

Anything I'm missing?

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
