### PR TITLE
[Growth] Serve graphql at / vs /graphql

### DIFF
--- a/devops/kubernetes/charts/origin/templates/growth.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/growth.ingress.yaml
@@ -20,7 +20,6 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,authentication,X-Growth-Secret,X-Growth-Wallet"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    nginx.ingress.kubernetes.io/rewrite-target: /graphql
     nginx.ingress.kubernetes.io/limit-rps: "100"
 spec:
   tls:

--- a/infra/bridge/src/utils/webhook-helpers.js
+++ b/infra/bridge/src/utils/webhook-helpers.js
@@ -47,7 +47,7 @@ module.exports.populateValidContents = async () => {
 
   try {
     const response = await request
-      .post(process.env.GROWTH_SERVER_URL + '/graphql')
+      .post(process.env.GROWTH_SERVER_URL)
       .send({
         query
       })

--- a/infra/growth/src/apollo/app.js
+++ b/infra/growth/src/apollo/app.js
@@ -41,6 +41,9 @@ const bundle = promBundle({
 })
 app.use(bundle)
 
+// Non-graphQL routes first.
+app.post('/log_event', logEvent)
+
 // Start ApolloServer by passing type definitions and the resolvers
 // responsible for fetching the data for those types.
 const server = new ApolloServer({
@@ -108,10 +111,7 @@ const server = new ApolloServer({
     }
   }
 })
-server.applyMiddleware({ app })
-
-// Non-graphQL routes.
-app.post('/log_event', logEvent)
+server.applyMiddleware({ app, path: '/' })
 
 const port = process.env.PORT || 4008
 


### PR DESCRIPTION
### Description:

Get rid of the ingress rewrite so that we can have non-graphql routes on the growth server.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
