### PR TITLE
Tomlinton/same day multi vest fix

### DIFF
--- a/infra/token-transfer-client/src/components/BonusCard.js
+++ b/infra/token-transfer-client/src/components/BonusCard.js
@@ -45,7 +45,7 @@ const BonusCard = ({ onDisplayBonusModal }) => {
           <div className="mt-3 mb-2">
             <div>Earned</div>
             <strong style={{ fontSize: '24px' }}>
-              {Number(data.totals.allEarnings.toLocaleString())}
+              {Number(data.totals.allEarnings).toLocaleString()}
             </strong>{' '}
             <span className="ml-1 ogn">OGN</span>
           </div>


### PR DESCRIPTION
- Sum vests happening on the same day for the purposes of early lockups, allowing users to lockup the total sum of both vests.
- Removed some dupe tests.
- Fix for number formatting in earned value of bonus card