### PR TITLE
proxy-buffers-number for ipfs ingress

### DIFF
--- a/devops/kubernetes/charts/origin/templates/ipfs.ingress.yaml
+++ b/devops/kubernetes/charts/origin/templates/ipfs.ingress.yaml
@@ -23,6 +23,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "120"
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "16"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "64k"
 spec:
   tls:


### PR DESCRIPTION
Was seeing a bunch of this in the logs for IPFS requests:

    [...] an upstream response is buffered to a temporary file [...]

The files generally weren't that large, either.  Adding this in hopes to reduce that a bit.