### PR TITLE
Dshop GCP VM image builder

### DIFF
--- a/dapps/shop/backend/scripts/gcp/marketplace/README.md
+++ b/dapps/shop/backend/scripts/gcp/marketplace/README.md
@@ -1,0 +1,65 @@
+# Dshop compute image builder
+
+<img width="346" alt="dshops" src="https://user-images.githubusercontent.com/837/80967164-ea868b00-8de3-11ea-85e8-cc863afbdc09.png">
+
+## Quickstart
+
+You will need [packer](https://www.packer.io/downloads/) installed, and
+[`gcloud`](https://cloud.google.com/sdk/gcloud/) installed and configured.
+
+    ./build.sh
+
+## Building Google VM Images 
+
+In theory, building a VM image for Google compute instances is as simple as:
+
+- Starting an instance
+- SSHing in and setting things up the way you want it
+- Stopping the instance
+- Making a snapshot image of that boot drive
+
+Except, that simple way leaves junk on the drive, so there's a painful multi step cleanup dance afterwords. To make this better, "Packer" can be used to automate the entire process. You specify what kind of instance should be started, and a script to be run after that template instance is started. Packer can also be used to create VM images for AWS, Azure, Digital Ocean, etc. https://www.packer.io/docs/builders/googlecompute.html
+
+## Doing a VM Build
+
+To build the VM you will need Packer (https://www.packer.io) which installs easily over brew, and gcloud, which you probably already have.
+
+Packer takes a packer.json config file that controls how it works. In the sample packer file, you will need to update the Google project id and the image name before building.
+
+You will also need an account to build this from. While it's possible there's a way to have packer just use your gcloud credentials, I've never got that working. Instead, I use an accounts.json file, tied to a build identity/user on GCP . This new user needs three permisions set:
+
+- Compute Instance Admin (v1)
+- Service Account User
+- Storage Admin
+
+The documenation says that only the first two permissions are needed, but I wasn't able to get it to work without it. After you create the user, you need to download a json formatted key file, and call it accounts.json.
+
+To build, just run:
+    
+    packer build packer.json
+
+Which takes me about 8 eight minutes.
+
+Packer itself is running all commands remotely, either against the GCP API or on the server over SSH. It isn't building a VM on your computer.
+
+## The Build Script
+
+Everything you want do to make your image needs to kick off from a single bash build script. You get no feedback on your local console while this script is running, and the VM image build continues regardless of if your script works or explodes.
+
+For development purposes, it's way easier to spin up your own VM and test your script on it. Only once everything is nailed down, then worry about doing a new build through packer. I've made the current build script basicly write itself to file, then run it, teeing the script output to a file. This lets you run the same script against a test VM when you are working quickly, and from packer. When you run a new packer VM, you can look at /root/setup_log.log to what happend during the build process.
+
+## Why a VM Image
+
+I tested three different approaches: Kubernetes cluster, docker image hosted via Compute Engine instance with Google's Container OS, and a tradtional VM image for Compute Engine.
+
+The Kubernetes cluser was, well, Kubernetes. I don't think 99.9% of our customers would need this, and it would massivly increase the cost (by requiring multiple instances) and the complexity.
+
+Building a docker container running that container in Container OS on a compute instance was surprisingly easy. The only real work was configuring your local docker setup to send to Google's container repository.  Unfortinutly, containers don't get nearly as nice google marketplace pages, and it's an extra layer of virtualization. Otherwise, it worked beautifly and simply, and is a trick I'll keep in my bag for the future.
+
+Buulding the VM side was a bit of a pain to get going. I don't think I ran accross a single tutorial that worked end to end. Packer gives straight up misleading error messages that can have nothing at all to do with the actual problem. As already mentioned, getting packer setup has been quite a pain, but now that it's working, it seems to work well and the process and config is easy to understand. Most importantly the user experince for creating a VM is very good, and it keeps the cost low and clear to the user. 
+
+## From here:
+
+The current build is not optimized for production - it's basicly a proof of concept. SSL is not enabled, and it's an open question how we handle that.
+
+Once we have a production ready VM, we will need to follow the steps here: https://cloud.google.com/marketplace/docs/partners/vm/build-vm-image

--- a/dapps/shop/backend/scripts/gcp/marketplace/build.sh
+++ b/dapps/shop/backend/scripts/gcp/marketplace/build.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+################################################################################
+##
+## This script will use Packer to build a VM, then create an iamge of said VM 
+## for later use in the marketplace.
+##
+## It builds using the dedicated dshop repo at:
+##   https://github.com/OriginProtocol/dshop
+##
+## startup_script.sh is executed on VM launch to do the system build.
+##
+## The final image will be named origin-dshop-YYYYMMDDHHmmSS
+##
+## Requirements: gcloud, packer
+##
+################################################################################
+
+echo "Writing packer.json..."
+
+BUILD_ID=$(date +%Y%m%d%H%M%S)
+SOURCE_IMAGE="debian-10-buster-v20200413"
+IMAGE_FAMILY="origin-dshop"
+IMAGE_NAME="$IMAGE_FAMILY-$BUILD_ID"
+PACKER_ZONE="us-west2-b"
+PACKER_USERNAME="packer"
+TMP_DIR="/tmp/dshop-build-$BUILD_ID"
+
+mkdir -p $TMP_DIR
+
+########################
+# Get the GCP project ID
+########################
+
+PROJECT_ID="$GCP_PROJECT_ID"
+
+if [[ -z "$PROJECT_ID" ]]; then
+    PROJECT_ID=$(gcloud projects list | grep -v PROJECT_ID | head -n1 | awk '{ print $1 }')
+fi
+
+if [[ -z "$PROJECT_ID" ]]; then
+    echo "Unable to determine GCP project automagically. Set GCP_PROJECT_ID"
+    exit 1
+fi
+
+echo "Project ID: $PROJECT_ID"
+
+######################
+# Create packer config
+######################
+
+PACKER_JSON="$TMP_DIR/packer.json"
+
+cat > $PACKER_JSON <<EOF
+{
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "$PROJECT_ID",
+      "source_image": "$SOURCE_IMAGE",
+      "ssh_username": "$PACKER_USERNAME",
+      "image_name": "$IMAGE_NAME",
+      "image_family": "$IMAGE_FAMILY",
+      "zone": "$PACKER_ZONE",
+      "startup_script_file":"startup_script.sh"
+    }
+  ]
+}
+EOF
+
+echo "Created $PACKER_JSON"
+
+##################
+# Run packer build
+##################
+
+echo "Running packer build..."
+
+packer build $PACKER_JSON
+
+echo "Packer image build complete. Image name: $IMAGE_NAME"

--- a/dapps/shop/backend/scripts/gcp/marketplace/startup_script.sh
+++ b/dapps/shop/backend/scripts/gcp/marketplace/startup_script.sh
@@ -1,0 +1,173 @@
+echo "DSHOP setup beginning!"
+
+cat > ~/setup_script.sh << 'FULL_SCRIPT_DELIMITER'
+set -e
+set -x
+
+CODENAME=`grep -Po 'VERSION="[0-9]+ \(\K[^)]+' /etc/os-release`
+
+#################
+# Server packages
+#################
+curl -sL https://deb.nodesource.com/setup_10.x | bash -
+apt update
+apt upgrade -y
+apt-get install -y nodejs build-essential git wget gnupg ca-certificates
+npm install -g yarn pm2
+
+###################
+# Openresty install
+###################
+wget -O - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
+echo "deb http://openresty.org/package/debian $CODENAME openresty" \
+    | sudo tee /etc/apt/sources.list.d/openresty.list
+apt-get update
+apt-get -y install openresty luarocks
+luarocks install lua-resty-auto-ssl
+mkdir /etc/resty-auto-ssl
+chown www-data:www-data /etc/resty-auto-ssl
+openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 \
+    -subj '/CN=sni-support-required-for-valid-ssl' \
+    -keyout /etc/ssl/resty-auto-ssl-fallback.key \
+    -out /etc/ssl/resty-auto-ssl-fallback.crt
+
+###############
+# Install dshop
+###############
+useradd dshop
+mkdir /home/dshop
+chown dshop:dshop /home/dshop
+mkdir /app
+cd /app
+git clone https://github.com/OriginProtocol/dshop.git
+cd /app/dshop/
+echo ENCRYPTION_KEY="\"`openssl rand -base64 48`\"" > .env
+yarn install
+npm run migrate
+chown -R dshop:dshop .
+
+##########################
+# PM2 to run dshop process
+##########################
+sudo -u dshop pm2 start app.js 
+sudo -u dshop pm2 save
+sudo env PATH="$PATH:/usr/bin" pm2 startup systemd -u dshop --hp /home/dshop
+
+####################################
+# Openresty config to proxy to dshop
+####################################
+cat > /etc/openresty/nginx.conf << 'EOM'
+worker_processes  1;
+user www-data www-data;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include         mime.types;
+    default_type    application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # lua-resty-auto-ssl Settings
+    # Ref: https://github.com/auto-ssl/lua-resty-auto-ssl
+    lua_shared_dict auto_ssl 1m;
+    lua_shared_dict auto_ssl_settings 64k;
+    resolver 8.8.8.8;
+
+    init_by_lua_block {
+        auto_ssl = (require "resty.auto-ssl").new()
+
+        -- Define a function to determine which SNI domains to automatically handle
+        -- and register new certificates for. Defaults to not allowing any domains,
+        -- so this must be configured.
+        auto_ssl:set("allow_domain", function(domain)
+          return true
+        end)
+
+        auto_ssl:init()
+    }
+
+    init_worker_by_lua_block {
+        auto_ssl:init_worker()
+    }
+
+    # HTTPS server
+    server {
+        listen 443 ssl;
+        root /var/www/html;
+        index index.html;
+        server_name _;
+
+        # Dynamic handler for issuing or returning certs for SNI domains.
+        ssl_certificate_by_lua_block {
+            auto_ssl:ssl_certificate()
+        }
+
+        ssl_certificate /etc/ssl/resty-auto-ssl-fallback.crt;
+        ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+
+        location / {
+            proxy_pass http://localhost:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_connect_timeout       300;
+            proxy_send_timeout          300;
+            proxy_read_timeout          300;
+            send_timeout                300;
+        }
+    }
+
+    # HTTP server
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        root /var/www/html;
+        index index.html;
+        server_name _;
+
+        # Handle Let's Encrypt challenges (or auto-ssl)
+        location /.well-known/acme-challenge/ {
+            content_by_lua_block {
+                auto_ssl:challenge_server()
+            }
+        }
+
+        location / {
+            proxy_pass http://localhost:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_connect_timeout       300;
+            proxy_send_timeout          300;
+            proxy_read_timeout          300;
+            send_timeout                300;
+        }
+    }
+
+    # Internal server running on port 8999 for handling certificate tasks.
+    server {
+        listen 127.0.0.1:8999;
+        client_body_buffer_size 128k;
+        client_max_body_size 128k;
+
+        location / {
+            content_by_lua_block {
+                auto_ssl:hook_server()
+            }
+        }
+    }
+
+}
+EOM
+sudo /etc/init.d/nginx restart
+FULL_SCRIPT_DELIMITER
+
+# Run as root and store log
+sudo bash ~/setup_script.sh 2>&1 | tee ~/setup_log.log


### PR DESCRIPTION
### Description:

This is pretty much @DanielVF's work from [this gist](https://gist.github.com/DanielVF/3d5f9a0b47d93269cfda452cbe5c19a7) with the addition of a build script to make life easier, switches to [Openresty](http://openresty.org/en/getting-started.html) instead of nginx, and adds [lua-resty-auto-ssl](https://github.com/auto-ssl/lua-resty-auto-ssl) for automagic TLS support.

### Usage

Basically, all you should have to do is have gcloud configured, install packer, and run:

    ./deploy.sh

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
