### PR TITLE
DShop admin config: only use local marketplace address when on network id 999

### DIFF
--- a/dapps/shop/src/utils/listing.js
+++ b/dapps/shop/src/utils/listing.js
@@ -133,7 +133,6 @@ export async function createListing({ title, network }) {
  * @returns {Promise<void>}
  */
 export async function updateListing({ config, shopIpfsHash }) {
-  console.log('updateListing CONFIG=', config)
   if (!shopIpfsHash) {
     console.error('shop IPFS hash not provided')
     return

--- a/dapps/shop/src/utils/useConfig.js
+++ b/dapps/shop/src/utils/useConfig.js
@@ -19,7 +19,7 @@ function useConfig() {
       setLoading(true)
       try {
         const net = localStorage.ognNetwork || process.env.NETWORK
-        const NetID = net === 'mainnet' ? '1' : net === 'rinkeby' ? '4' : '999'
+        const netId = net === 'mainnet' ? '1' : net === 'rinkeby' ? '4' : '999'
         const url = `${dataUrl()}config.json`
         console.debug(`Loading config from ${url}...`)
         const raw = await fetch(url)
@@ -34,11 +34,12 @@ function useConfig() {
           }
 
           config.supportEmailPlain = supportEmailPlain
-          const netConfig = config.networks[NetID] || {}
-          if (process.env.MARKETPLACE_CONTRACT) {
+          const netConfig = config.networks[netId] || {}
+          if (netId === '999' && process.env.MARKETPLACE_CONTRACT) {
+            // Use the address of the marketplace contract deployed on the local test network.
             netConfig.marketplaceContract = process.env.MARKETPLACE_CONTRACT
           }
-          config = { ...config, ...netConfig, netId: NetID }
+          config = { ...config, ...netConfig, netId }
         } else {
           console.error(`Loading of config failed from ${url}`)
         }


### PR DESCRIPTION
### Description:

Fix bug in admin config where the local marketplace address was used on any network. This caused a fun bug for the update listing button on Mainnet :) 

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] [Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation
- [ ] If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)
- [ ] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
