### PR TITLE
Update Dshop's upload request size limit

### DIFF
--- a/devops/kubernetes/charts/origin-experimental/templates/dshop-backend-mainnet.ingress.yaml
+++ b/devops/kubernetes/charts/origin-experimental/templates/dshop-backend-mainnet.ingress.yaml
@@ -19,6 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "10"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error invalid_header"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
 spec:
   tls:
     - secretName: "{{ .Values.dshopBackendMainnetHost }}"

--- a/devops/kubernetes/charts/origin-experimental/templates/dshop-backend-mainnet.ingress.yaml
+++ b/devops/kubernetes/charts/origin-experimental/templates/dshop-backend-mainnet.ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "10"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error invalid_header"
-    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
 spec:
   tls:
     - secretName: "{{ .Values.dshopBackendMainnetHost }}"


### PR DESCRIPTION
GCP has a [default request limit of 1MB](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#configuration-options). This should increase that to 50MB.