### PR TITLE
Add CORS_WHITELIST for setting CORS in @origin/token-transfer-server

### DIFF
--- a/infra/token-transfer-server/README.md
+++ b/infra/token-transfer-server/README.md
@@ -9,9 +9,10 @@ export SENDGRID_FROM_EMAIL="Origin Protocol <support@shoporigin.com>"
 export SENDGRID_API_KEY="<SendGrid key>"
 export CLIENT_URL"=http://localhost:3000/#"
 export DATABASE_URL="postgres://origin:origin@localhost/origin"
+export CORS_WHITELIST="https://investor.originprotocol.com,https://team.originprotocol.com"
 ```
 
-Setup 
+Setup
 
 ```
 nvm install 10.15.3
@@ -19,12 +20,13 @@ yarn install
 ```
 
 Run migration
+
 ```
 yarn run migrate
 ```
 
 ##### Start the server
+
 ```
 yarn run start
 ```
-

--- a/infra/token-transfer-server/src/app.js
+++ b/infra/token-transfer-server/src/app.js
@@ -63,10 +63,7 @@ if (app.get('env') === 'production') {
 // Configure CORS in Heroku, outside of Heroku this is handled by Kubernetes nginx ingress
 if (process.env.HEROKU) {
   // Whitelisted domains
-  const corsWhitelist = [
-    'https://investor.originprotocol.com',
-    'https://team.originprotocol.com'
-  ]
+  const corsWhitelist = process.env.CORS_WHITELIST.split(/,\s*/)
 
   app.use(
     cors({


### PR DESCRIPTION
### Description:

The whitelist of host names for CORS is hard-coded when deploying to the Heroku. So, I need to have another environment variable to set this whitelist without changing anything in the codebase.

### Checklist:

- [x] Test your work and double-check to confirm that you didn't break anything
- [ ] ~[Wrap any new text/strings with `fbt`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#wrapping-text) for translation~
- [ ] ~If there are any new/changed strings to translate, [`npm run translate`](https://github.com/OriginProtocol/origin/tree/master/dapps/marketplace/translation#integrating-translations)~
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/origin/tree/master/docs)
